### PR TITLE
Feat: Increase iOS rule limit to 150,000.

### DIFF
--- a/wBlock/AppFilterManager.swift
+++ b/wBlock/AppFilterManager.swift
@@ -626,7 +626,7 @@ class AppFilterManager: ObservableObject {
                 }
             }
 
-            let ruleLimit = await MainActor.run { self.currentPlatform == .iOS ? 150000 : 150000 }
+            let ruleLimit = 150000
             let warningThreshold = Int(Double(ruleLimit) * 0.8) // 80% threshold
             
             // Check if this category is approaching the limit

--- a/wBlock/AppFilterManager.swift
+++ b/wBlock/AppFilterManager.swift
@@ -401,7 +401,7 @@ class AppFilterManager: ObservableObject {
     
     func showCategoryWarning(for category: FilterListCategory) {
         let ruleCount = getCategoryRuleCount(category)
-        let ruleLimit = currentPlatform == .iOS ? 150000 : 150000
+        let ruleLimit = 150000
         let warningThreshold = Int(Double(ruleLimit) * 0.8) // 80% threshold
         
         categoryWarningMessage = """

--- a/wBlock/AppFilterManager.swift
+++ b/wBlock/AppFilterManager.swift
@@ -401,7 +401,7 @@ class AppFilterManager: ObservableObject {
     
     func showCategoryWarning(for category: FilterListCategory) {
         let ruleCount = getCategoryRuleCount(category)
-        let ruleLimit = currentPlatform == .iOS ? 50000 : 150000
+        let ruleLimit = currentPlatform == .iOS ? 150000 : 150000
         let warningThreshold = Int(Double(ruleLimit) * 0.8) // 80% threshold
         
         categoryWarningMessage = """
@@ -626,8 +626,8 @@ class AppFilterManager: ObservableObject {
                 }
             }
 
-            let ruleLimit = await MainActor.run { self.currentPlatform == .iOS ? 50000 : 150000 }
-            let warningThreshold = await MainActor.run { self.currentPlatform == .iOS ? 48000 : 140000 }
+            let ruleLimit = await MainActor.run { self.currentPlatform == .iOS ? 150000 : 150000 }
+            let warningThreshold = Int(Double(ruleLimit) * 0.8) // 80% threshold
             
             // Check if this category is approaching the limit
             await MainActor.run {


### PR DESCRIPTION
Recent versions of Safari on iOS have greater rule limits that previously.  Reference: https://adguard.com/en/blog/adguard-v4-5-1-for-ios.html

Calculate 80% threshold value based on the actual limit.