### PR TITLE
feat: add Settings view & badge‑toggle for blocked‑item count

### DIFF
--- a/wBlock Advanced/SafariExtensionHandler.swift
+++ b/wBlock Advanced/SafariExtensionHandler.swift
@@ -347,11 +347,20 @@ public class SafariExtensionHandler: SFSafariExtensionHandler {
         validationHandler: @escaping ((Bool, String) -> Void)
     ) {
         Task {
-            // Retrieve the total number of blocked resources on the active tab.
-            let blockedCount = await ToolbarData.shared.getBlockedOnActiveTab(in: window)
-            // Determine the badge text based on the count.
-            let badgeText = blockedCount == 0 ? "" : String(blockedCount)
-            validationHandler(true, badgeText)
+            // Check if badge counter is disabled
+            let defaults = UserDefaults(suiteName: GroupIdentifier.shared.value)
+            let isBadgeDisabled = defaults?.bool(forKey: "disableBadgeCounter") ?? false
+            
+            if isBadgeDisabled {
+                // Badge is disabled, show empty string
+                validationHandler(true, "")
+            } else {
+                // Retrieve the total number of blocked resources on the active tab.
+                let blockedCount = await ToolbarData.shared.getBlockedOnActiveTab(in: window)
+                // Determine the badge text based on the count.
+                let badgeText = blockedCount == 0 ? "" : String(blockedCount)
+                validationHandler(true, badgeText)
+            }
         }
     }
 
@@ -508,4 +517,3 @@ public class SafariExtensionHandler: SFSafariExtensionHandler {
         return Array(zapperHostnames)
     }
 }
-

--- a/wBlock/ContentView.swift
+++ b/wBlock/ContentView.swift
@@ -19,6 +19,7 @@ struct ContentView: View {
     @State private var showingUserScriptsView = false
     @State private var showOnlyEnabledLists = false
     @State private var showingWhitelistSheet = false
+    @State private var showingSettingsSheet = false
     @Environment(\.scenePhase) var scenePhase
     
     private var hasCompletedOnboarding: Bool {
@@ -93,6 +94,10 @@ struct ContentView: View {
             }
             .sheet(isPresented: $showingUserScriptsView) {
                 UserScriptManagerView(userScriptManager: userScriptManager)
+            }
+            // Add settings sheet
+            .sheet(isPresented: $showingSettingsSheet) {
+                SettingsView()
             }
             .sheet(isPresented: $filterManager.showingUpdatePopup) {
                 UpdatePopupView(filterManager: filterManager, userScriptManager: userScriptManager, isPresented: $filterManager.showingUpdatePopup)
@@ -206,6 +211,14 @@ struct ContentView: View {
                         Label("Show Enabled Only", systemImage: showOnlyEnabledLists ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
                     }
                     .help("Toggle to show only enabled filter lists")
+                    
+                    // Add settings button to macOS toolbar
+                    Button {
+                        showingSettingsSheet = true
+                    } label: {
+                        Label("Settings", systemImage: "gear")
+                    }
+                    .help("wBlock settings")
                 }
             }
             #endif
@@ -302,6 +315,11 @@ struct ContentView: View {
                 
                 Button { showingAddFilterSheet = true } label: {
                     Image(systemName: "plus")
+                }
+                
+                // Add settings button
+                Button { showingSettingsSheet = true } label: {
+                    Image(systemName: "gear")
                 }
             }
             .buttonStyle(.plain)
@@ -534,4 +552,3 @@ struct AddFilterListView: View {
         dismiss()
     }
 }
-

--- a/wBlock/SettingsView.swift
+++ b/wBlock/SettingsView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import wBlockCoreService
+
+struct SettingsView: View {
+    @AppStorage("disableBadgeCounter", store: UserDefaults(suiteName: GroupIdentifier.shared.value))
+    private var disableBadgeCounter = false
+    
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Settings")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                Spacer()
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.gray)
+                        .font(.title2)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding([.top, .horizontal])
+            
+            Form {
+                Section {
+                    Toggle("Show blocked item count in toolbar", isOn: Binding(
+                        get: { !disableBadgeCounter },
+                        set: { disableBadgeCounter = !$0 }
+                    ))
+                    .toggleStyle(.switch)
+                }
+                
+                Section {
+                    HStack {
+                        Text("wBlock Version")
+                        Spacer()
+                        Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown")
+                            .foregroundColor(.secondary)
+                    }
+                } header: {
+                    Text("About")
+                }
+                .textCase(.none)
+            }
+            .formStyle(.grouped)
+            
+            Spacer()
+        }
+        #if os(macOS)
+        .frame(minWidth: 350, minHeight: 200)
+        #endif
+    }
+}


### PR DESCRIPTION
- Introduce a new Settings screen where users can adjust their preferences.
- Add a toggle that lets users enable or disable the badge showing the number of blocked items on the Safari toolbar icon.