### PR TITLE
Update console log prefix

### DIFF
--- a/wBlock Advanced/Resources/script.js
+++ b/wBlock Advanced/Resources/script.js
@@ -29787,7 +29787,7 @@ function _toPrimitive(t, r) {
      */
     // Initialize the logger to be used by the `@adguard/safari-extension`.
     // Change logging level to Debug if you need to see more details.
-    const log = new ConsoleLogger("[wBlock Advanced]", LoggingLevel.Info);
+    const log = new ConsoleLogger("[wBlock Advanced]", LoggingLevel.Error);
     setLogger(log);
     log.debug("Content script is starting...");
     // Initialize the delayed event dispatcher. This may intercept DOMContentLoaded

--- a/wBlock Scripts (iOS)/Resources/background.js
+++ b/wBlock Scripts (iOS)/Resources/background.js
@@ -23303,7 +23303,7 @@ function _toPrimitive(t, r) {
      */
     // Initialize the logger to be used by the `@adguard/safari-extension`.
     // Change logging level to Debug if you need to see more details.
-    const log = new ConsoleLogger("[wBlock Scripts]", LoggingLevel.Info);
+    const log = new ConsoleLogger("[wBlock Scripts]", LoggingLevel.Error);
     setLogger(log);
     /**
      * Global variable to track the engine timestamp.

--- a/wBlock Scripts (iOS)/Resources/content.js
+++ b/wBlock Scripts (iOS)/Resources/content.js
@@ -29800,7 +29800,7 @@ function _toPrimitive(t, r) {
      */
     // Initialize the logger to be used by the `@adguard/safari-extension`.
     // Change logging level to Debug if you need to see more details.
-    const log = new ConsoleLogger("[wBlock Scripts]", LoggingLevel.Info);
+    const log = new ConsoleLogger("[wBlock Scripts]", LoggingLevel.Error);
     setLogger(log);
     // Initialize the delayed event dispatcher. This may intercept DOMContentLoaded
     // and load events. The delay of 1000ms is used as a buffer to capture critical


### PR DESCRIPTION
Updates prefix to `[wBlock Advanced / Scripts]` along with changing log from an info to an error level. The console log is a little much IMO. fixes #178 