### PR TITLE
Update prefix / switch error logging

### DIFF
--- a/wBlock Advanced/Resources/script.js
+++ b/wBlock Advanced/Resources/script.js
@@ -22604,7 +22604,7 @@ function _toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = 
    */
   // Initialize the logger to be used by the `@adguard/safari-extension`.
   // Change logging level to Debug if you need to see more details.
-  const log = new ConsoleLogger('[AdGuard Sample App Extension]', LoggingLevel.Info);
+  const log = new ConsoleLogger('[wBlock Advanced]', LoggingLevel.Error);
   setLogger(log);
   log.debug('Content script is starting...');
   // Initialize the delayed event dispatcher. This may intercept DOMContentLoaded

--- a/wBlock Scripts (iOS)/Resources/background.js
+++ b/wBlock Scripts (iOS)/Resources/background.js
@@ -17030,7 +17030,7 @@ function _toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = 
    */
   // Initialize the logger to be used by the `@adguard/safari-extension`.
   // Change logging level to Debug if you need to see more details.
-  const log = new ConsoleLogger('[AdGuard Sample Web Extension]', LoggingLevel.Info);
+  const log = new ConsoleLogger('[wBlock Scripts]', LoggingLevel.Error);
   setLogger(log);
   /**
    * Global variable to track the engine timestamp.

--- a/wBlock Scripts (iOS)/Resources/content.js
+++ b/wBlock Scripts (iOS)/Resources/content.js
@@ -22617,7 +22617,7 @@ function _toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = 
    */
   // Initialize the logger to be used by the `@adguard/safari-extension`.
   // Change logging level to Debug if you need to see more details.
-  const log = new ConsoleLogger('[AdGuard Sample Web Extension]', LoggingLevel.Info);
+  const log = new ConsoleLogger('[wBlock Scripts]', LoggingLevel.Error);
   setLogger(log);
   // Initialize the delayed event dispatcher. This may intercept DOMContentLoaded
   // and load events. The delay of 1000ms is used as a buffer to capture critical


### PR DESCRIPTION
Fixes #178 

- Updates references to `wBlock`
- reduces log level to error as console gets filled up pretty quickly by wBlock messages