### PR TITLE
Bump SafariConverterLib to 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Supports 750,000 rules across 5 extensions with Protocol Buffer storage and LZ4 
 <td width="50%">
 
 **Dependencies & Standards**
-- SafariConverterLib v4.0.4 for AdGuard to Safari rule conversion
+- SafariConverterLib v4.1.0 for AdGuard to Safari rule conversion
 - AdGuard Scriptlets v2.2.9 for advanced blocking techniques
 - Swift 5.9+ with strict concurrency checking enabled
 - WCAG 2.1 AA compliance with full VoiceOver and Dynamic Type support

--- a/wBlock.xcodeproj/project.pbxproj
+++ b/wBlock.xcodeproj/project.pbxproj
@@ -3636,14 +3636,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		C1A41C532DE08A040056F63D /* XCRemoteSwiftPackageReference "SafariConverterLib" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/AdguardTeam/SafariConverterLib";
-			requirement = {
-				branch = master;
-				kind = branch;
+			C1A41C532DE08A040056F63D /* XCRemoteSwiftPackageReference "SafariConverterLib" */ = {
+				isa = XCRemoteSwiftPackageReference;
+				repositoryURL = "https://github.com/AdguardTeam/SafariConverterLib";
+				requirement = {
+					kind = upToNextMajorVersion;
+					minimumVersion = 4.1.0;
+				};
 			};
-		};
 		C1A41C562DE08A0E0056F63D /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/weichsel/ZIPFoundation";

--- a/wBlock.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wBlock.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AdguardTeam/SafariConverterLib",
       "state" : {
-        "branch" : "master",
-        "revision" : "17c6128ca2af185ffb245c38b4f921be891bd31a"
+        "revision" : "a3ed1682d6169248cdc8058d58813a0b3e7c5b4a",
+        "version" : "4.1.0"
       }
     },
     {


### PR DESCRIPTION
Updates `SafariConverterLib` to `v4.1.0`.

## Changes
- Bump `SafariConverterLib` requirement to `>= 4.1.0 < 5.0.0` in the Xcode project Swift Package reference.
- Update `Package.resolved` to pin `SafariConverterLib` at `4.1.0`.
- Refresh README dependency version.