### PR TITLE
Update Add Filter List modal helper text

### DIFF
--- a/wBlock/ContentView.swift
+++ b/wBlock/ContentView.swift
@@ -870,7 +870,7 @@ struct AddFilterListView: View {
         Group {
             switch validationState {
             case .idle:
-                Text("We’ll download and enable the filter automatically.")
+                Text("wBlock will download and turn on the filter list automatically.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             case .invalid:


### PR DESCRIPTION
This updates the “Add Filter List” modal helper message to follow Apple Style Guide wording:
- [Avoid first-person “we”.](https://support.apple.com/guide/applestyleguide/apsg48ccd3b3/web#:~:text=One%20word.-,we,-Don’t%20use%20first)
- [Use “turn on” instead of “enable” when you mean turning a feature on.](https://support.apple.com/guide/applestyleguide/apsg076a7313/web#:~:text=enable%20(v.)%2C%20enabled%20(adj.))

No behavior changes.
