### PR TITLE
Revert content-blocker target redistribution and restore extension display names

### DIFF
--- a/wBlock Ads (iOS)/Info.plist
+++ b/wBlock Ads (iOS)/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDisplayName</key>
-	<string>wBlock 1</string>
-	<key>CFBundleName</key>
-	<string>wBlock 1</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/wBlock Ads/Info.plist
+++ b/wBlock Ads/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDisplayName</key>
-	<string>wBlock 1</string>
-	<key>CFBundleName</key>
-	<string>wBlock 1</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/wBlock Custom (iOS)/Info.plist
+++ b/wBlock Custom (iOS)/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDisplayName</key>
-	<string>wBlock 5</string>
-	<key>CFBundleName</key>
-	<string>wBlock 5</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/wBlock Custom/Info.plist
+++ b/wBlock Custom/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDisplayName</key>
-	<string>wBlock 5</string>
-	<key>CFBundleName</key>
-	<string>wBlock 5</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/wBlock Foreign (iOS)/Info.plist
+++ b/wBlock Foreign (iOS)/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDisplayName</key>
-	<string>wBlock 4</string>
-	<key>CFBundleName</key>
-	<string>wBlock 4</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/wBlock Foreign/Info.plist
+++ b/wBlock Foreign/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDisplayName</key>
-	<string>wBlock 4</string>
-	<key>CFBundleName</key>
-	<string>wBlock 4</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/wBlock Privacy (iOS)/Info.plist
+++ b/wBlock Privacy (iOS)/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDisplayName</key>
-	<string>wBlock 2</string>
-	<key>CFBundleName</key>
-	<string>wBlock 2</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/wBlock Security (iOS)/Info.plist
+++ b/wBlock Security (iOS)/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDisplayName</key>
-	<string>wBlock 3</string>
-	<key>CFBundleName</key>
-	<string>wBlock 3</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/wBlock Security/Info.plist
+++ b/wBlock Security/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDisplayName</key>
-	<string>wBlock 3</string>
-	<key>CFBundleName</key>
-	<string>wBlock 3</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/wBlock.xcodeproj/project.pbxproj
+++ b/wBlock.xcodeproj/project.pbxproj
@@ -2477,7 +2477,7 @@
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Ads/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 1";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Ads";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2507,7 +2507,7 @@
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Ads/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 1";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Ads";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2535,7 +2535,7 @@
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Ads (iOS)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 1";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Ads";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2566,7 +2566,7 @@
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Ads (iOS)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 1";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Ads";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2765,7 +2765,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Security/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 3";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Security";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2797,7 +2797,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Security/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 3";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Security";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2829,7 +2829,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Ads/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 2";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Privacy";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2861,7 +2861,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Ads/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 2";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Privacy";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2893,7 +2893,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Foreign/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 4";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Foreign";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2925,7 +2925,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Foreign/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 4";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Foreign";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2957,7 +2957,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Custom/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 5";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Custom";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2989,7 +2989,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Custom/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 5";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Custom";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3017,7 +3017,7 @@
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Privacy (iOS)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 2";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Privacy";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3048,7 +3048,7 @@
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Privacy (iOS)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 2";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Privacy";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3080,7 +3080,7 @@
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Security (iOS)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 3";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Security";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3111,7 +3111,7 @@
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Security (iOS)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 3";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Security";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3143,7 +3143,7 @@
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Privacy (iOS)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 2";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Privacy";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3174,7 +3174,7 @@
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Privacy (iOS)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 2";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Privacy";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3269,7 +3269,7 @@
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Foreign (iOS)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 4";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Foreign";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3300,7 +3300,7 @@
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Foreign (iOS)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 4";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Foreign";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3395,7 +3395,7 @@
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Custom (iOS)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 5";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Custom";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3426,7 +3426,7 @@
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Custom (iOS)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 5";
+				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Custom";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/wBlock/AppFilterManager.swift
+++ b/wBlock/AppFilterManager.swift
@@ -452,7 +452,7 @@ class AppFilterManager: ObservableObject {
 
         for targetInfo in platformTargets {
             // Check if this extension has any rules before reloading
-            let rulesCount = self.ruleCountsByExtension[targetInfo.bundleIdentifier] ?? 0
+            let rulesCount = self.ruleCountsByCategory[targetInfo.primaryCategory] ?? 0
             if rulesCount > 0 {
                 let reloadSuccess = await reloadContentBlockerWithRetry(targetInfo: targetInfo)
                 if reloadSuccess {
@@ -464,7 +464,7 @@ class AppFilterManager: ObservableObject {
                 // Skip reload for empty extensions
                 await ConcurrentLogManager.shared.debug(
                     .filterApply, "Skipping reload for empty extension",
-                    metadata: ["target": targetDisplayName(for: targetInfo)])
+                    metadata: ["category": targetInfo.primaryCategory.rawValue])
             }
         }
 
@@ -747,29 +747,13 @@ class AppFilterManager: ObservableObject {
         showingCategoryWarningAlert = true
     }
 
-    func showTargetWarning(targetName: String, categories: [FilterListCategory]) {
-        let categoryList = categories.map(\.rawValue).sorted().joined(separator: ", ")
-        let ruleLimit = 150000
-
-        categoryWarningMessage = """
-            Content blocker "\(targetName)" exceeded its rule limit.
-
-            Affected categories: \(categoryList.isEmpty ? "Unknown" : categoryList)
-            Limit: \(ruleLimit.formatted())
-
-            Filters in these categories were reset to recommended lists to stay within Safari's content blocker limits.
-            """
-
-        showingCategoryWarningAlert = true
-    }
-
     // MARK: - Helper Methods
 
     /// Attempts to reload a content blocker with up to 5 retry attempts
     /// Returns true if successful, false if all attempts failed
     private func reloadContentBlockerWithRetry(targetInfo: ContentBlockerTargetInfo) async -> Bool {
         let maxRetries = 5
-        let categoryName = targetDisplayName(for: targetInfo)
+        let categoryName = targetInfo.primaryCategory.rawValue
 
         for attempt in 1...maxRetries {
             let result = await ContentBlockerService.reloadContentBlocker(
@@ -778,7 +762,7 @@ class AppFilterManager: ObservableObject {
                 if attempt > 1 {
                     await ConcurrentLogManager.shared.info(
                         .filterApply, "Content blocker reloaded successfully after retry",
-                        metadata: ["target": categoryName, "attempt": "\(attempt)"])
+                        metadata: ["category": categoryName, "attempt": "\(attempt)"])
                 }
                 return true
             } else if case .failure(let error) = result {
@@ -789,7 +773,7 @@ class AppFilterManager: ObservableObject {
                             ? "Content blocker reload failed after all attempts"
                             : "Content blocker reload failed",
                         metadata: [
-                            "target": categoryName, "attempt": "\(attempt)",
+                            "category": categoryName, "attempt": "\(attempt)",
                             "maxRetries": "\(maxRetries)", "error": error.localizedDescription,
                         ])
                 }
@@ -808,46 +792,6 @@ class AppFilterManager: ObservableObject {
         }
 
         return false
-    }
-
-    private func targetDisplayName(for targetInfo: ContentBlockerTargetInfo) -> String {
-        let platformTargets = ContentBlockerTargetManager.shared.allTargets(forPlatform: currentPlatform)
-        if let index = platformTargets.firstIndex(of: targetInfo) {
-            return "wBlock \(index + 1)"
-        }
-        return targetInfo.primaryCategory.rawValue
-    }
-
-    private func distributeFiltersToTargets(
-        _ filters: [FilterList]
-    ) -> (filtersByTarget: [ContentBlockerTargetInfo: [FilterList]],
-          sourceRuleCounts: [ContentBlockerTargetInfo: Int]) {
-        let platformTargets = ContentBlockerTargetManager.shared.allTargets(
-            forPlatform: currentPlatform)
-        var targetLoads: [ContentBlockerTargetInfo: Int] = [:]
-        var filtersByTarget: [ContentBlockerTargetInfo: [FilterList]] = [:]
-        var sourceRulesByTarget: [ContentBlockerTargetInfo: Int] = [:]
-
-        for target in platformTargets {
-            targetLoads[target] = 0
-        }
-
-        let sortedFilters = filters.sorted {
-            ($0.sourceRuleCount ?? 0) > ($1.sourceRuleCount ?? 0)
-        }
-
-        for filter in sortedFilters {
-            guard let target = targetLoads.min(by: { $0.value < $1.value })?.key else {
-                continue
-            }
-
-            filtersByTarget[target, default: []].append(filter)
-            let ruleCount = filter.sourceRuleCount ?? 0
-            sourceRulesByTarget[target, default: 0] += ruleCount
-            targetLoads[target, default: 0] += ruleCount
-        }
-
-        return (filtersByTarget, sourceRulesByTarget)
     }
 
     // MARK: - Delegated methods
@@ -980,207 +924,243 @@ class AppFilterManager: ObservableObject {
             return
         }
 
-        // Group filters by target ContentBlockerTargetInfo - avoid loading everything into memory at once
+        // Group filters by their target ContentBlockerTargetInfo - avoid loading everything into memory at once
         var filtersByTargetInfo: [ContentBlockerTargetInfo: [FilterList]] = [:]
         var sourceRulesByTargetInfo: [ContentBlockerTargetInfo: Int] = [:]
-        var advancedRulesByTarget: [String: String] = [:]
-        var overallSafariRulesApplied = 0
-        var totalFiltersCount = 0
-        let maxRedistributions = 3
-        var redistributionAttempt = 0
-        var didRedistribute = false
 
-        while redistributionAttempt < maxRedistributions {
-            redistributionAttempt += 1
-            didRedistribute = false
-
-            let distribution = distributeFiltersToTargets(allSelectedFilters)
-            filtersByTargetInfo = distribution.filtersByTarget
-            sourceRulesByTargetInfo = distribution.sourceRuleCounts
-
-            let platformTargets = ContentBlockerTargetManager.shared.allTargets(
-                forPlatform: self.currentPlatform)
-            await ConcurrentLogManager.shared.info(
-                .filterApply, "Distributed filters across content blocker targets",
-                metadata: [
-                    "filterCount": "\(allSelectedFilters.count)",
-                    "targetCount": "\(platformTargets.count)",
-                    "attempt": "\(redistributionAttempt)",
-                ])
-
-            totalFiltersCount = filtersByTargetInfo.keys.count
-            await MainActor.run {
-                self.sourceRulesCount = sourceRulesByTargetInfo.values.reduce(0, +)  // Sum of all source rules for UI
-                self.totalFiltersCount = totalFiltersCount  // Number of unique extensions to process
-
-                // Update ViewModel
-                self.applyProgressViewModel.updateProcessedCount(0, total: totalFiltersCount)
-                self.applyProgressViewModel.updateStageDescription("Starting conversion...")
-            }
-
-            if totalFiltersCount == 0 {
-                await MainActor.run {
-                    self.statusDescription = "No matching extensions for selected filters."
-                    self.isLoading = false
-                    self.showingApplyProgressSheet = false
-                }
-                return
-            }
-
-            overallSafariRulesApplied = 0
-            advancedRulesByTarget = [:]
-            let overallConversionStartTime = Date()
-
-            await MainActor.run {
-                self.processedFiltersCount = 0  // Use this to track processed targets for progress
-                self.isInConversionPhase = true
-
-                // Update ViewModel phase
-                self.applyProgressViewModel.updatePhaseCompletion(reading: true, converting: false)
-            }
-
-            for (targetInfo, filters) in filtersByTargetInfo {
-                let categoriesForTarget = Set(filters.map { $0.category })
-                await MainActor.run {
-                    self.processedFiltersCount += 1
-                    self.progress = Float(self.processedFiltersCount) / Float(totalFiltersCount) * 0.7  // Up to 70% for conversion
-                    let displayName = self.targetDisplayName(for: targetInfo)
-                    self.currentFilterName = displayName  // More user-friendly
-                    self.conversionStageDescription =
-                        "Converting \(displayName)..."
-                    self.isInSavingPhase = true  // Set saving phase for each conversion
-
-                    // Batched ViewModel update - single call with all data
-                    self.applyProgressViewModel.updateProgress(self.progress)
-                    self.applyProgressViewModel.updateCurrentFilter(displayName)
-                    self.applyProgressViewModel.updateProcessedCount(
-                        self.processedFiltersCount, total: totalFiltersCount)
-                    self.applyProgressViewModel.updateStageDescription(
-                        "Converting \(displayName)...")
-                }
-
-                // Yield to prevent main thread starvation on iOS
-                await Task.yield()
-
-                // Capture disabled sites
-                let disabledSites = self.dataManager.disabledSites
-
-                // Efficiently combine rules from multiple files without loading all into memory at once
-                let conversionResult = await Task.detached {
-                    return await self.convertFiltersMemoryEfficient(
-                        filters: filters, targetInfo: targetInfo, disabledSites: disabledSites)
-                }.value
-
-                await MainActor.run {
-                    self.isInSavingPhase = false  // Clear saving phase after conversion
-                }
-
-                let ruleCountForThisTarget = conversionResult.safariRulesCount
-
-                // Store advanced rules for later engine building
-                if let advancedRulesText = conversionResult.advancedRulesText,
-                    !conversionResult.advancedRulesText!.isEmpty
-                {
-                    advancedRulesByTarget[targetInfo.bundleIdentifier] = advancedRulesText
-                }
-
-                // Single consolidated log per target
-                let advancedCount =
-                    conversionResult.advancedRulesText?.isEmpty == false
-                    ? conversionResult.advancedRulesText!.components(separatedBy: .newlines).count : 0
-                await ConcurrentLogManager.shared.info(
-                    .filterApply, "Converted target rules",
+        for filter in allSelectedFilters {
+            guard
+                let targetInfo = ContentBlockerTargetManager.shared.targetInfo(
+                    forCategory: filter.category, platform: self.currentPlatform)
+            else {
+                await ConcurrentLogManager.shared.warning(
+                    .filterApply, "No target extension found for category, skipping filter",
                     metadata: [
-                        "target": targetDisplayName(for: targetInfo),
-                        "safariRules": "\(ruleCountForThisTarget)",
-                        "advancedRules": "\(advancedCount)",
+                        "category": filter.category.rawValue,
+                        "platform": self.currentPlatform == .macOS ? "macOS" : "iOS",
+                        "filter": filter.name,
                     ])
-
-                // Update per-extension rule count on main thread
-                await MainActor.run {
-                    self.ruleCountsByExtension[targetInfo.bundleIdentifier] = ruleCountForThisTarget
-                }
-
-                let ruleLimit = 150000
-                let warningThreshold = Int(Double(ruleLimit) * 0.8)  // 80% threshold
-
-                // Check if this extension is approaching the limit
-                await MainActor.run {
-                    if ruleCountForThisTarget >= warningThreshold && ruleCountForThisTarget < ruleLimit
-                    {
-                        self.extensionsApproachingLimit.insert(targetInfo.bundleIdentifier)
-                    } else {
-                        self.extensionsApproachingLimit.remove(targetInfo.bundleIdentifier)
-                    }
-                }
-
-                if ruleCountForThisTarget > ruleLimit {
-                    await ConcurrentLogManager.shared.error(
-                        .filterApply, "Rule limit exceeded for target",
-                        metadata: [
-                            "target": targetDisplayName(for: targetInfo),
-                            "ruleCount": "\(ruleCountForThisTarget)", "ruleLimit": "\(ruleLimit)",
-                        ])
-
-                    // Auto-reset categories assigned to this target and warn the user
-                    let affectedCategories = categoriesForTarget.filter { $0 != .all }
-                    for category in affectedCategories {
-                        await resetCategoryToRecommended(category)
-                    }
-
-                    await MainActor.run {
-                        self.showTargetWarning(targetName: targetDisplayName(for: targetInfo), categories: affectedCategories)
-                        self.showingAutoDisabledAlert = true
-                    }
-                    await ConcurrentLogManager.shared.info(
-                        .filterApply, "Auto-reset categories due to rule limit exceeded",
-                        metadata: ["target": targetDisplayName(for: targetInfo)])
-
-                    didRedistribute = true
-                    break
-                } else {
-                    overallSafariRulesApplied += ruleCountForThisTarget
-                }
-            }
-
-            if didRedistribute {
                 continue
             }
 
-            await MainActor.run {
-                self.isInConversionPhase = false
-                self.lastRuleCount = overallSafariRulesApplied
-                self.lastConversionTime = String(
-                    format: "%.2fs", Date().timeIntervalSince(overallConversionStartTime))
-                self.progress = 0.7
-
-                // Update ViewModel - conversion complete
-                self.applyProgressViewModel.updateProgress(self.progress)
-                self.applyProgressViewModel.updatePhaseCompletion(converting: true, saving: false)
-            }
-
-            await ConcurrentLogManager.shared.info(
-                .filterApply, "All conversions finished",
-                metadata: [
-                    "totalRules": "\(overallSafariRulesApplied)",
-                    "conversionTime": await MainActor.run { self.lastConversionTime },
-                ])
-            break
+            filtersByTargetInfo[targetInfo, default: []].append(filter)
+            sourceRulesByTargetInfo[targetInfo, default: 0] += filter.sourceRuleCount ?? 0
         }
 
-        if didRedistribute {
-            await ConcurrentLogManager.shared.warning(
-                .filterApply, "Redistribution retry limit reached after rule limit resets",
-                metadata: ["attempts": "\(redistributionAttempt)"])
+        let totalFiltersCount = filtersByTargetInfo.keys.count
+        await MainActor.run {
+            self.sourceRulesCount = sourceRulesByTargetInfo.values.reduce(0, +)  // Sum of all source rules for UI
+            self.totalFiltersCount = totalFiltersCount  // Number of unique extensions to process
+
+            // Update ViewModel
+            self.applyProgressViewModel.updateProcessedCount(0, total: totalFiltersCount)
+            self.applyProgressViewModel.updateStageDescription("Starting conversion...")
+        }
+
+        if totalFiltersCount == 0 {
             await MainActor.run {
-                self.statusDescription =
-                    "Unable to redistribute filters after multiple attempts. Please reduce enabled lists and try again."
-                self.hasError = true
+                self.statusDescription = "No matching extensions for selected filters."
                 self.isLoading = false
                 self.showingApplyProgressSheet = false
             }
             return
         }
+
+        var overallSafariRulesApplied = 0
+        let overallConversionStartTime = Date()
+
+        await MainActor.run {
+            self.processedFiltersCount = 0  // Use this to track processed targets for progress
+            self.isInConversionPhase = true
+
+            // Update ViewModel phase
+            self.applyProgressViewModel.updatePhaseCompletion(reading: true, converting: false)
+        }
+
+        // Collect advanced rules by target bundle ID (single storage)
+        var advancedRulesByTarget: [String: String] = [:]  // Track advanced rules by target bundle ID
+        for (targetInfo, filters) in filtersByTargetInfo {
+            await MainActor.run {
+                self.processedFiltersCount += 1
+                self.progress = Float(self.processedFiltersCount) / Float(totalFiltersCount) * 0.7  // Up to 70% for conversion
+                self.currentFilterName = targetInfo.primaryCategory.rawValue  // More user-friendly
+                self.conversionStageDescription =
+                    "Converting \(targetInfo.primaryCategory.rawValue)..."
+                self.isInSavingPhase = true  // Set saving phase for each conversion
+
+                // Batched ViewModel update - single call with all data
+                self.applyProgressViewModel.updateProgress(self.progress)
+                self.applyProgressViewModel.updateCurrentFilter(targetInfo.primaryCategory.rawValue)
+                self.applyProgressViewModel.updateProcessedCount(
+                    self.processedFiltersCount, total: totalFiltersCount)
+                self.applyProgressViewModel.updateStageDescription(
+                    "Converting \(targetInfo.primaryCategory.rawValue)...")
+            }
+
+            // Yield to prevent main thread starvation on iOS
+            await Task.yield()
+
+            // Capture disabled sites
+            let disabledSites = self.dataManager.disabledSites
+
+            // Efficiently combine rules from multiple files without loading all into memory at once
+            let conversionResult = await Task.detached {
+                return await self.convertFiltersMemoryEfficient(
+                    filters: filters, targetInfo: targetInfo, disabledSites: disabledSites)
+            }.value
+
+            await MainActor.run {
+                self.isInSavingPhase = false  // Clear saving phase after conversion
+            }
+
+            let ruleCountForThisTarget = conversionResult.safariRulesCount
+
+            // Store advanced rules for later engine building
+            if let advancedRulesText = conversionResult.advancedRulesText,
+                !conversionResult.advancedRulesText!.isEmpty
+            {
+                advancedRulesByTarget[targetInfo.bundleIdentifier] = advancedRulesText
+            }
+
+            // Single consolidated log per target
+            let advancedCount =
+                conversionResult.advancedRulesText?.isEmpty == false
+                ? conversionResult.advancedRulesText!.components(separatedBy: .newlines).count : 0
+            await ConcurrentLogManager.shared.info(
+                .filterApply, "Converted category rules",
+                metadata: [
+                    "category": targetInfo.primaryCategory.rawValue,
+                    "safariRules": "\(ruleCountForThisTarget)", "advancedRules": "\(advancedCount)",
+                ])
+
+            // Update per-extension rule count on main thread
+            await MainActor.run {
+                self.ruleCountsByExtension[targetInfo.bundleIdentifier] = ruleCountForThisTarget
+            }
+
+            let ruleLimit = 150000
+            let warningThreshold = Int(Double(ruleLimit) * 0.8)  // 80% threshold
+
+            // Check if this extension is approaching the limit
+            await MainActor.run {
+                if ruleCountForThisTarget >= warningThreshold && ruleCountForThisTarget < ruleLimit
+                {
+                    self.extensionsApproachingLimit.insert(targetInfo.bundleIdentifier)
+                } else {
+                    self.extensionsApproachingLimit.remove(targetInfo.bundleIdentifier)
+                }
+            }
+
+            if ruleCountForThisTarget > ruleLimit {
+                await ConcurrentLogManager.shared.error(
+                    .filterApply, "Rule limit exceeded for category",
+                    metadata: [
+                        "bundleId": targetInfo.bundleIdentifier,
+                        "ruleCount": "\(ruleCountForThisTarget)", "ruleLimit": "\(ruleLimit)",
+                    ])
+
+                // Auto-reset this specific category and warn the user
+                await resetCategoryToRecommended(targetInfo.primaryCategory)
+                if let secondaryCategory = targetInfo.secondaryCategory {
+                    await resetCategoryToRecommended(secondaryCategory)
+                }
+
+                await MainActor.run {
+                    self.showCategoryWarning(for: targetInfo.primaryCategory)
+                    self.showingAutoDisabledAlert = true
+                }
+                await ConcurrentLogManager.shared.info(
+                    .filterApply, "Auto-reset category due to rule limit exceeded",
+                    metadata: ["category": targetInfo.primaryCategory.rawValue])
+
+                // Re-process this target with the reset filters - on background thread
+                let disabledSites = self.dataManager.disabledSites
+                let resetResult = await Task.detached {
+                    let containerURL = await MainActor.run { self.loader.getSharedContainerURL() }
+                    var resetRulesChunks: [String] = []
+
+                    // Get the updated filter list after reset
+                    let updatedSelectedFilters = await MainActor.run {
+                        self.filterLists.filter { $0.isSelected }
+                    }
+                    resetRulesChunks.reserveCapacity(updatedSelectedFilters.count)
+
+                    for filter in updatedSelectedFilters {
+                        if filter.category == targetInfo.primaryCategory
+                            || (targetInfo.secondaryCategory != nil
+                                && filter.category == targetInfo.secondaryCategory!)
+                        {
+                            guard let containerURL = containerURL else { continue }
+                            let fileURL = containerURL.appendingPathComponent(
+                                self.loader.filename(for: filter)
+                            )
+                            if FileManager.default.fileExists(atPath: fileURL.path) {
+                                do {
+                                    resetRulesChunks.append(try String(contentsOf: fileURL, encoding: .utf8))
+                                } catch {
+                                    await ConcurrentLogManager.shared.error(
+                                        .filterApply, "Error reading filter after reset",
+                                        metadata: ["filter": filter.name, "error": "\(error)"])
+                                }
+                            }
+                        }
+                    }
+
+                    let resetRulesString = resetRulesChunks.joined(separator: "\n")
+                    return ContentBlockerService.convertFilter(
+                        rules: resetRulesString.isEmpty ? "[]" : resetRulesString,
+                        groupIdentifier: GroupIdentifier.shared.value,
+                        targetRulesFilename: targetInfo.rulesFilename,
+                        disabledSites: disabledSites
+                    )
+                }.value
+
+                let resetRuleCount = resetResult.safariRulesCount
+
+                // Update advanced rules from reset filters
+                if let resetAdvancedRulesText = resetResult.advancedRulesText,
+                    !resetResult.advancedRulesText!.isEmpty
+                {
+                    advancedRulesByTarget[targetInfo.bundleIdentifier] = resetAdvancedRulesText
+                } else {
+                    // Remove advanced rules for this target if reset resulted in none
+                    advancedRulesByTarget.removeValue(forKey: targetInfo.bundleIdentifier)
+                }
+
+                await MainActor.run {
+                    self.ruleCountsByExtension[targetInfo.bundleIdentifier] = resetRuleCount
+                    self.extensionsApproachingLimit.remove(targetInfo.bundleIdentifier)
+                }
+
+                overallSafariRulesApplied += resetRuleCount
+                await ConcurrentLogManager.shared.info(
+                    .filterApply, "After reset, category now has fewer rules",
+                    metadata: [
+                        "category": targetInfo.primaryCategory.rawValue,
+                        "ruleCount": "\(resetRuleCount)",
+                    ])
+                continue
+            } else {
+                overallSafariRulesApplied += ruleCountForThisTarget
+            }
+        }
+        await MainActor.run {
+            self.isInConversionPhase = false
+            self.lastRuleCount = overallSafariRulesApplied
+            self.lastConversionTime = String(
+                format: "%.2fs", Date().timeIntervalSince(overallConversionStartTime))
+            self.progress = 0.7
+
+            // Update ViewModel - conversion complete
+            self.applyProgressViewModel.updateProgress(self.progress)
+            self.applyProgressViewModel.updatePhaseCompletion(converting: true, saving: false)
+        }
+        await ConcurrentLogManager.shared.info(
+            .filterApply, "All conversions finished",
+            metadata: [
+                "totalRules": "\(overallSafariRulesApplied)",
+                "conversionTime": await MainActor.run { self.lastConversionTime },
+            ])
 
         // Reloading phase - reload all content blockers FIRST before building advanced engine
         await MainActor.run {
@@ -1201,12 +1181,11 @@ class AppFilterManager: ObservableObject {
                 self.processedFiltersCount += 1
                 self.progress =
                     0.7 + (Float(self.processedFiltersCount) / Float(totalFiltersCount) * 0.2)  // 70% to 90%
-                let displayName = targetDisplayName(for: targetInfo)
-                self.currentFilterName = displayName
+                self.currentFilterName = targetInfo.primaryCategory.rawValue
 
                 // Batched ViewModel update
                 self.applyProgressViewModel.updateProgress(self.progress)
-                self.applyProgressViewModel.updateCurrentFilter(displayName)
+                self.applyProgressViewModel.updateCurrentFilter(targetInfo.primaryCategory.rawValue)
             }
 
             // Yield to prevent blocking
@@ -1221,7 +1200,7 @@ class AppFilterManager: ObservableObject {
                 await MainActor.run {
                     if !self.hasError {
                         self.statusDescription =
-                            "Failed to reload \(targetDisplayName(for: targetInfo)) extension after 5 attempts."
+                            "Failed to reload \(targetInfo.primaryCategory.rawValue) extension after 5 attempts."
                     }
                     self.hasError = true
                 }
@@ -1259,7 +1238,7 @@ class AppFilterManager: ObservableObject {
                     await MainActor.run {
                         if !self.hasError {
                             self.statusDescription =
-                                "Failed to reload \(targetDisplayName(for: targetInfo)) extension after 5 attempts."
+                                "Failed to reload \(targetInfo.primaryCategory.rawValue) extension after 5 attempts."
                         }
                         self.hasError = true
                     }
@@ -1768,9 +1747,9 @@ class AppFilterManager: ObservableObject {
             if totalSourceLines > 10000 {
                 Task {
                     await ConcurrentLogManager.shared.debug(
-                        .filterApply, "Converting large target",
+                        .filterApply, "Converting large category",
                         metadata: [
-                            "target": targetDisplayName(for: targetInfo),
+                            "category": targetInfo.primaryCategory.rawValue,
                             "sourceLines": "\(totalSourceLines)",
                         ])
                 }


### PR DESCRIPTION
### Motivation
- Undo the previous change that split filters across multiple content-blocker targets and renamed extensions to numbered display names.  
- Restore the prior behavior of mapping filters to extensions by category and keep extension names descriptive in the Xcode project.  
- Ensure rule-count tracking and fast-update flows remain compatible with prior protobuf storage and extension mapping.  

### Description
- Reverted the redistribution logic and removed helper functions that distributed filters by load (removed `distributeFiltersToTargets` and `targetDisplayName`), instead assigning filters using `ContentBlockerTargetManager.targetInfo(forCategory:platform:)`.  
- Simplified conversion and reload flow in `AppFilterManager` to process filters per target category, update `ruleCountsByExtension`, and handle rule-limit conditions by resetting affected categories to recommended lists and reprocessing.  
- Updated logging and metadata keys from `target` names to `category`/`bundleId`, and adjusted retry/reload helpers to use `targetInfo.primaryCategory.rawValue`.  
- Restored extension display names in project build settings (`INFOPLIST_KEY_CFBundleDisplayName`) and removed the numbered `CFBundleDisplayName`/`CFBundleName` entries introduced earlier in several extension `Info.plist` files.  

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976a62b85a88327999e9cd5f17cb88c)