### PR TITLE
fix: ensure AppIdentifierPrefix is set for Safari extension

### DIFF
--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -22,7 +22,7 @@ DMG_PATH="${OUT_DIR}/${DMG_NAME}"
 mkdir -p "${OUT_DIR}"
 rm -f "${DMG_PATH}"
 
-TEAM_ID="${TEAM_ID:-}"
+TEAM_ID="${TEAM_ID:-DNP7DGUB7B}"
 
 echo "Building ${SCHEME} (${CONFIGURATION})…"
 xcodebuild \


### PR DESCRIPTION
Fixes #273

The build script patches the AppIdentifierPrefix in the Safari extension
Info.plist to allow Safari to properly identify the extension and its
associated content blockers. However, when TEAM_ID is not set, this patch
was skipped, causing Safari to show only "wBlock 1" without proper
permissions.

This fix provides a default team ID (DNP7DGUB7B) to ensure the patch
always runs, which allows Safari to properly recognize the extension
with all its content blockers and permissions.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*