### PR TITLE
Replace GM.xmlhttpRequest to GM.xmlHttpRequest

### DIFF
--- a/wBlock Scripts (iOS)/Resources/userscript-injector.js
+++ b/wBlock Scripts (iOS)/Resources/userscript-injector.js
@@ -905,7 +905,7 @@ if (window.wBlockUserscriptInjectorHasRun) {
         },
 
         xmlHttpRequest: function(details) {
-            return this.xmlhttpRequest(details);
+            return GM.xmlhttpRequest(details);
         },
 
         // Provide access to the real page window object
@@ -930,7 +930,6 @@ if (window.wBlockUserscriptInjectorHasRun) {
     window.GM_openInTab = GM.openInTab;
     window.GM_notification = GM.notification;
     window.GM_xmlhttpRequest = GM.xmlhttpRequest;
-    window.GM_xmlhttpRequest = GM.xmlHttpRequest;
     window.GM_registerMenuCommand = GM.registerMenuCommand;
     window.GM_unregisterMenuCommand = GM.unregisterMenuCommand;
 


### PR DESCRIPTION
Many injectors define the API as GM.xmlHttpRequest (uppercase 'h'), but the wBlock used GM.xmlhttpRequest (lowercase 'H').
[Tampermonkey Documentation](https://www.tampermonkey.net/documentation.php?q=GM_xmlhttpRequest)
> GM.xmlHttpRequest returns a promise that resolves to the response and also has an abort function.

[Violentmonkey Guide](https://violentmonkey.github.io/api/gm/#gm)
> (async since VM2.18.3), H is uppercase