### PR TITLE
Add Element Zapper translations

### DIFF
--- a/wBlock Scripts (iOS)/Resources/_locales/ar/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ar/messages.json
@@ -4,7 +4,195 @@
     "description": "The display name for the extension."
   },
   "extension_description": {
-    "message": "يحظر الإعلانات وطرق التتبع الأكثر إزعاجًا، بما في ذلك YouTube.",
+    "message": "يحظر أكثر الإعلانات وطرق التتبع إزعاجًا، بما في ذلك YouTube.",
     "description": "Description of what the extension does."
+  },
+  "popup_status_loading": {
+    "message": "جارٍ التحميل…",
+    "description": "Popup status shown while loading state is being resolved."
+  },
+  "popup_disable_on_site": {
+    "message": "تعطيل على هذا الموقع",
+    "description": "Label for the site-specific disable toggle in the popup."
+  },
+  "popup_element_zapper": {
+    "message": "أداة إخفاء العناصر",
+    "description": "Section title for the element zapper controls in the popup."
+  },
+  "popup_button_activate": {
+    "message": "تفعيل",
+    "description": "Button label to activate element zapper mode."
+  },
+  "popup_button_clear": {
+    "message": "مسح",
+    "description": "Button label to clear all zapper rules for the current site."
+  },
+  "popup_hint_tap_to_hide": {
+    "message": "اضغط على عنصر في الصفحة لإخفائه. استخدم \"إضافة قاعدة\" في أداة الإخفاء للمحددات اليدوية.",
+    "description": "Help text shown in the popup for how to use the element zapper."
+  },
+  "popup_rules": {
+    "message": "القواعد",
+    "description": "Label for the disclosure button that expands saved zapper rules."
+  },
+  "popup_button_open_app": {
+    "message": "فتح تطبيق wBlock",
+    "description": "Button label to open the containing native app from the popup."
+  },
+  "popup_rules_empty": {
+    "message": "لا توجد قواعد",
+    "description": "Empty-state text shown when no zapper rules exist for the current site."
+  },
+  "popup_rule_delete_aria": {
+    "message": "حذف القاعدة",
+    "description": "Accessible label for deleting a saved zapper rule."
+  },
+  "popup_error_load_rules": {
+    "message": "تعذر تحميل القواعد.",
+    "description": "Error shown when popup fails to load zapper rules."
+  },
+  "popup_error_delete_rule": {
+    "message": "تعذر حذف القاعدة.",
+    "description": "Error shown when popup fails to delete a zapper rule."
+  },
+  "popup_status_disabling": {
+    "message": "جارٍ التعطيل…",
+    "description": "Transient status shown while disabling blocking on the current site."
+  },
+  "popup_status_enabling": {
+    "message": "جارٍ التفعيل…",
+    "description": "Transient status shown while enabling blocking on the current site."
+  },
+  "popup_status_disabled": {
+    "message": "معطّل",
+    "description": "Status label indicating blocking is disabled on the current site."
+  },
+  "popup_status_active": {
+    "message": "نشط",
+    "description": "Status label indicating blocking is active on the current site."
+  },
+  "popup_error_update_site_setting": {
+    "message": "تعذر تحديث إعداد الموقع.",
+    "description": "Error shown when popup fails to update per-site enabled state."
+  },
+  "popup_error_zapper_unavailable": {
+    "message": "أداة إخفاء العناصر غير متاحة في هذه الصفحة.",
+    "description": "Error shown when zapper cannot be activated on the current tab."
+  },
+  "popup_error_open_app": {
+    "message": "تعذر فتح التطبيق.",
+    "description": "Error shown when popup fails to open the containing app."
+  },
+  "popup_error_clear_rules": {
+    "message": "تعذر مسح قواعد الإخفاء.",
+    "description": "Error shown when popup fails to clear zapper rules for the current site."
+  },
+  "popup_status_unsupported": {
+    "message": "غير مدعوم",
+    "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_checking": {
+    "message": "جارٍ التحقق…",
+    "description": "Status label shown while popup checks current page and state."
+  },
+  "popup_error_load_popup": {
+    "message": "تعذر تحميل النافذة المنبثقة.",
+    "description": "Error shown if popup initialization fails."
+  },
+  "zapper_aria_label": {
+    "message": "أداة إخفاء العناصر في wBlock",
+    "description": "Accessible label for the in-page element zapper toolbar."
+  },
+  "zapper_status_tap_to_hide": {
+    "message": "أداة إخفاء العناصر: اضغط على عنصر لإخفائه.",
+    "description": "Default status text in the in-page element zapper toolbar."
+  },
+  "zapper_button_undo": {
+    "message": "تراجع",
+    "description": "Button label to undo last zapper action."
+  },
+  "zapper_button_more": {
+    "message": "خيارات إضافية",
+    "description": "Tooltip label for the overflow menu button in zapper toolbar."
+  },
+  "zapper_button_add_custom_rule": {
+    "message": "إضافة قاعدة CSS مخصصة…",
+    "description": "Menu item label for adding a manual CSS selector rule."
+  },
+  "zapper_button_done": {
+    "message": "تم",
+    "description": "Button label to finish zapper mode."
+  },
+  "zapper_button_select_parent": {
+    "message": "تحديد العنصر الأب",
+    "description": "Tooltip for choosing the parent element in refine mode."
+  },
+  "zapper_button_select_child": {
+    "message": "تحديد العنصر الفرعي",
+    "description": "Tooltip for choosing the child element in refine mode."
+  },
+  "zapper_button_hide": {
+    "message": "إخفاء",
+    "description": "Button label for confirming hide action in refine mode."
+  },
+  "zapper_error_enter_selector": {
+    "message": "أدخل محدد CSS.",
+    "description": "Validation error shown when manual selector input is empty."
+  },
+  "zapper_error_rule_syntax_invalid": {
+    "message": "صيغة قاعدة CSS غير صحيحة.",
+    "description": "Validation error shown when manual CSS rule syntax is invalid."
+  },
+  "zapper_error_selector_too_long": {
+    "message": "المحدد طويل جدًا.",
+    "description": "Validation error shown when manual selector exceeds max length."
+  },
+  "zapper_error_selector_syntax_invalid": {
+    "message": "صيغة المحدد غير صحيحة.",
+    "description": "Validation error shown when selector cannot be parsed."
+  },
+  "zapper_toast_rule_exists": {
+    "message": "القاعدة موجودة بالفعل.",
+    "description": "Toast shown when trying to add a duplicate manual rule."
+  },
+  "zapper_toast_already_hidden": {
+    "message": "مخفي بالفعل.",
+    "description": "Toast shown when picked element is already hidden by existing rule."
+  },
+  "zapper_toast_rule_saved": {
+    "message": "تم حفظ القاعدة لهذا الموقع.",
+    "description": "Toast shown after successfully adding a manual rule."
+  },
+  "zapper_toast_hidden_and_saved": {
+    "message": "تم الإخفاء. تم حفظ القاعدة لهذا الموقع.",
+    "description": "Toast shown after hiding selected element and saving generated rule."
+  },
+  "zapper_prompt_enter_selector": {
+    "message": "أدخل محدد CSS لهذا الموقع",
+    "description": "Prompt text shown when user adds a manual selector rule."
+  },
+  "zapper_toast_undone": {
+    "message": "تم التراجع.",
+    "description": "Toast shown after undoing the last zapper action."
+  },
+  "zapper_status_refine": {
+    "message": "$1 — ▲▼ للضبط، اضغط $2 للحفظ",
+    "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
+  },
+  "zapper_toast_unable_create_rule": {
+    "message": "تعذر إنشاء قاعدة لهذا العنصر.",
+    "description": "Toast shown when selector generation fails for selected element."
+  },
+  "zapper_toast_enabled": {
+    "message": "تم تفعيل أداة إخفاء العناصر.",
+    "description": "Toast shown when zapper mode is enabled."
+  },
+  "zapper_toast_disabled": {
+    "message": "تم تعطيل أداة إخفاء العناصر.",
+    "description": "Toast shown when zapper mode is disabled."
+  },
+  "zapper_status_off": {
+    "message": "أداة إخفاء العناصر: متوقفة",
+    "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/de/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/de/messages.json
@@ -6,5 +6,193 @@
   "extension_description": {
     "message": "Blockiert die lästigsten Werbeanzeigen und Tracking-Methoden, einschließlich YouTube.",
     "description": "Description of what the extension does."
+  },
+  "popup_status_loading": {
+    "message": "Wird geladen…",
+    "description": "Popup status shown while loading state is being resolved."
+  },
+  "popup_disable_on_site": {
+    "message": "Auf dieser Website deaktivieren",
+    "description": "Label for the site-specific disable toggle in the popup."
+  },
+  "popup_element_zapper": {
+    "message": "Element-Zapper",
+    "description": "Section title for the element zapper controls in the popup."
+  },
+  "popup_button_activate": {
+    "message": "Aktivieren",
+    "description": "Button label to activate element zapper mode."
+  },
+  "popup_button_clear": {
+    "message": "Löschen",
+    "description": "Button label to clear all zapper rules for the current site."
+  },
+  "popup_hint_tap_to_hide": {
+    "message": "Tippe auf ein Element auf der Seite, um es auszublenden. Verwende im Zapper „Regel hinzufügen“ für manuelle Selektoren.",
+    "description": "Help text shown in the popup for how to use the element zapper."
+  },
+  "popup_rules": {
+    "message": "Regeln",
+    "description": "Label for the disclosure button that expands saved zapper rules."
+  },
+  "popup_button_open_app": {
+    "message": "wBlock-App öffnen",
+    "description": "Button label to open the containing native app from the popup."
+  },
+  "popup_rules_empty": {
+    "message": "Keine Regeln",
+    "description": "Empty-state text shown when no zapper rules exist for the current site."
+  },
+  "popup_rule_delete_aria": {
+    "message": "Regel löschen",
+    "description": "Accessible label for deleting a saved zapper rule."
+  },
+  "popup_error_load_rules": {
+    "message": "Regeln konnten nicht geladen werden.",
+    "description": "Error shown when popup fails to load zapper rules."
+  },
+  "popup_error_delete_rule": {
+    "message": "Regel konnte nicht gelöscht werden.",
+    "description": "Error shown when popup fails to delete a zapper rule."
+  },
+  "popup_status_disabling": {
+    "message": "Wird deaktiviert…",
+    "description": "Transient status shown while disabling blocking on the current site."
+  },
+  "popup_status_enabling": {
+    "message": "Wird aktiviert…",
+    "description": "Transient status shown while enabling blocking on the current site."
+  },
+  "popup_status_disabled": {
+    "message": "Deaktiviert",
+    "description": "Status label indicating blocking is disabled on the current site."
+  },
+  "popup_status_active": {
+    "message": "Aktiv",
+    "description": "Status label indicating blocking is active on the current site."
+  },
+  "popup_error_update_site_setting": {
+    "message": "Website-Einstellung konnte nicht aktualisiert werden.",
+    "description": "Error shown when popup fails to update per-site enabled state."
+  },
+  "popup_error_zapper_unavailable": {
+    "message": "Der Element-Zapper ist auf dieser Seite nicht verfügbar.",
+    "description": "Error shown when zapper cannot be activated on the current tab."
+  },
+  "popup_error_open_app": {
+    "message": "Die App konnte nicht geöffnet werden.",
+    "description": "Error shown when popup fails to open the containing app."
+  },
+  "popup_error_clear_rules": {
+    "message": "Zapper-Regeln konnten nicht gelöscht werden.",
+    "description": "Error shown when popup fails to clear zapper rules for the current site."
+  },
+  "popup_status_unsupported": {
+    "message": "Nicht unterstützt",
+    "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_checking": {
+    "message": "Wird geprüft…",
+    "description": "Status label shown while popup checks current page and state."
+  },
+  "popup_error_load_popup": {
+    "message": "Popup konnte nicht geladen werden.",
+    "description": "Error shown if popup initialization fails."
+  },
+  "zapper_aria_label": {
+    "message": "wBlock Element-Zapper",
+    "description": "Accessible label for the in-page element zapper toolbar."
+  },
+  "zapper_status_tap_to_hide": {
+    "message": "Element-Zapper: Tippe auf ein Element, um es auszublenden.",
+    "description": "Default status text in the in-page element zapper toolbar."
+  },
+  "zapper_button_undo": {
+    "message": "Rückgängig",
+    "description": "Button label to undo last zapper action."
+  },
+  "zapper_button_more": {
+    "message": "Weitere Optionen",
+    "description": "Tooltip label for the overflow menu button in zapper toolbar."
+  },
+  "zapper_button_add_custom_rule": {
+    "message": "Eigene CSS-Regel hinzufügen…",
+    "description": "Menu item label for adding a manual CSS selector rule."
+  },
+  "zapper_button_done": {
+    "message": "Fertig",
+    "description": "Button label to finish zapper mode."
+  },
+  "zapper_button_select_parent": {
+    "message": "Elternelement auswählen",
+    "description": "Tooltip for choosing the parent element in refine mode."
+  },
+  "zapper_button_select_child": {
+    "message": "Kindelement auswählen",
+    "description": "Tooltip for choosing the child element in refine mode."
+  },
+  "zapper_button_hide": {
+    "message": "Ausblenden",
+    "description": "Button label for confirming hide action in refine mode."
+  },
+  "zapper_error_enter_selector": {
+    "message": "Gib einen CSS-Selektor ein.",
+    "description": "Validation error shown when manual selector input is empty."
+  },
+  "zapper_error_rule_syntax_invalid": {
+    "message": "Die CSS-Regel-Syntax ist ungültig.",
+    "description": "Validation error shown when manual CSS rule syntax is invalid."
+  },
+  "zapper_error_selector_too_long": {
+    "message": "Der Selektor ist zu lang.",
+    "description": "Validation error shown when manual selector exceeds max length."
+  },
+  "zapper_error_selector_syntax_invalid": {
+    "message": "Die Selektor-Syntax ist ungültig.",
+    "description": "Validation error shown when selector cannot be parsed."
+  },
+  "zapper_toast_rule_exists": {
+    "message": "Regel existiert bereits.",
+    "description": "Toast shown when trying to add a duplicate manual rule."
+  },
+  "zapper_toast_already_hidden": {
+    "message": "Bereits ausgeblendet.",
+    "description": "Toast shown when picked element is already hidden by existing rule."
+  },
+  "zapper_toast_rule_saved": {
+    "message": "Regel für diese Website gespeichert.",
+    "description": "Toast shown after successfully adding a manual rule."
+  },
+  "zapper_toast_hidden_and_saved": {
+    "message": "Ausgeblendet. Regel für diese Website gespeichert.",
+    "description": "Toast shown after hiding selected element and saving generated rule."
+  },
+  "zapper_prompt_enter_selector": {
+    "message": "CSS-Selektor für diese Website eingeben",
+    "description": "Prompt text shown when user adds a manual selector rule."
+  },
+  "zapper_toast_undone": {
+    "message": "Rückgängig gemacht.",
+    "description": "Toast shown after undoing the last zapper action."
+  },
+  "zapper_status_refine": {
+    "message": "$1 — ▲▼ zum Anpassen, tippe auf $2 zum Speichern",
+    "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
+  },
+  "zapper_toast_unable_create_rule": {
+    "message": "Für dieses Element konnte keine Regel erstellt werden.",
+    "description": "Toast shown when selector generation fails for selected element."
+  },
+  "zapper_toast_enabled": {
+    "message": "Element-Zapper aktiviert.",
+    "description": "Toast shown when zapper mode is enabled."
+  },
+  "zapper_toast_disabled": {
+    "message": "Element-Zapper deaktiviert.",
+    "description": "Toast shown when zapper mode is disabled."
+  },
+  "zapper_status_off": {
+    "message": "Element-Zapper: Aus",
+    "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/el/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/el/messages.json
@@ -4,195 +4,195 @@
     "description": "The display name for the extension."
   },
   "extension_description": {
-    "message": "Блокирует самую надоедливую рекламу и методы отслеживания, включая YouTube.",
+    "message": "Αποκλείει τις πιο ενοχλητικές διαφημίσεις και μεθόδους παρακολούθησης, συμπεριλαμβανομένου του YouTube.",
     "description": "Description of what the extension does."
   },
   "popup_status_loading": {
-    "message": "Загрузка…",
+    "message": "Φόρτωση…",
     "description": "Popup status shown while loading state is being resolved."
   },
   "popup_disable_on_site": {
-    "message": "Отключить на этом сайте",
+    "message": "Απενεργοποίηση σε αυτόν τον ιστότοπο",
     "description": "Label for the site-specific disable toggle in the popup."
   },
   "popup_element_zapper": {
-    "message": "Скрытие элементов",
+    "message": "Αποκλεισμός στοιχείου",
     "description": "Section title for the element zapper controls in the popup."
   },
   "popup_button_activate": {
-    "message": "Включить",
+    "message": "Ενεργοποίηση",
     "description": "Button label to activate element zapper mode."
   },
   "popup_button_clear": {
-    "message": "Очистить",
+    "message": "Εκκαθάριση",
     "description": "Button label to clear all zapper rules for the current site."
   },
   "popup_hint_tap_to_hide": {
-    "message": "Нажмите на элемент на странице, чтобы скрыть его. Используйте «Добавить правило» в скрытии элементов для ручных селекторов.",
+    "message": "Πατήστε ένα στοιχείο στη σελίδα για να το κρύψετε. Χρησιμοποιήστε «Προσθήκη κανόνα» στον αποκλεισμό για χειροκίνητους επιλογείς.",
     "description": "Help text shown in the popup for how to use the element zapper."
   },
   "popup_rules": {
-    "message": "Правила",
+    "message": "Κανόνες",
     "description": "Label for the disclosure button that expands saved zapper rules."
   },
   "popup_button_open_app": {
-    "message": "Открыть приложение wBlock",
+    "message": "Άνοιγμα εφαρμογής wBlock",
     "description": "Button label to open the containing native app from the popup."
   },
   "popup_rules_empty": {
-    "message": "Нет правил",
+    "message": "Δεν υπάρχουν κανόνες",
     "description": "Empty-state text shown when no zapper rules exist for the current site."
   },
   "popup_rule_delete_aria": {
-    "message": "Удалить правило",
+    "message": "Διαγραφή κανόνα",
     "description": "Accessible label for deleting a saved zapper rule."
   },
   "popup_error_load_rules": {
-    "message": "Не удалось загрузить правила.",
+    "message": "Αποτυχία φόρτωσης κανόνων.",
     "description": "Error shown when popup fails to load zapper rules."
   },
   "popup_error_delete_rule": {
-    "message": "Не удалось удалить правило.",
+    "message": "Αποτυχία διαγραφής κανόνα.",
     "description": "Error shown when popup fails to delete a zapper rule."
   },
   "popup_status_disabling": {
-    "message": "Отключение…",
+    "message": "Απενεργοποίηση…",
     "description": "Transient status shown while disabling blocking on the current site."
   },
   "popup_status_enabling": {
-    "message": "Включение…",
+    "message": "Ενεργοποίηση…",
     "description": "Transient status shown while enabling blocking on the current site."
   },
   "popup_status_disabled": {
-    "message": "Отключено",
+    "message": "Απενεργοποιημένο",
     "description": "Status label indicating blocking is disabled on the current site."
   },
   "popup_status_active": {
-    "message": "Активно",
+    "message": "Ενεργή",
     "description": "Status label indicating blocking is active on the current site."
   },
   "popup_error_update_site_setting": {
-    "message": "Не удалось обновить настройку сайта.",
+    "message": "Αποτυχία ενημέρωσης ρύθμισης ιστότοπου.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
   "popup_error_zapper_unavailable": {
-    "message": "Скрытие элементов недоступно на этой странице.",
+    "message": "Ο αποκλεισμός στοιχείου δεν είναι διαθέσιμος σε αυτή τη σελίδα.",
     "description": "Error shown when zapper cannot be activated on the current tab."
   },
   "popup_error_open_app": {
-    "message": "Не удалось открыть приложение.",
+    "message": "Αποτυχία ανοίγματος της εφαρμογής.",
     "description": "Error shown when popup fails to open the containing app."
   },
   "popup_error_clear_rules": {
-    "message": "Не удалось очистить правила скрытия элементов.",
+    "message": "Αποτυχία εκκαθάρισης των κανόνων αποκλεισμού.",
     "description": "Error shown when popup fails to clear zapper rules for the current site."
   },
   "popup_status_unsupported": {
-    "message": "Не поддерживается",
+    "message": "Δεν υποστηρίζεται",
     "description": "Status label indicating current page does not support popup actions."
   },
   "popup_status_checking": {
-    "message": "Проверка…",
+    "message": "Έλεγχος…",
     "description": "Status label shown while popup checks current page and state."
   },
   "popup_error_load_popup": {
-    "message": "Не удалось загрузить всплывающее окно.",
+    "message": "Αποτυχία φόρτωσης αναδυόμενου παραθύρου.",
     "description": "Error shown if popup initialization fails."
   },
   "zapper_aria_label": {
-    "message": "Скрытие элементов wBlock",
+    "message": "Αποκλεισμός στοιχείου wBlock",
     "description": "Accessible label for the in-page element zapper toolbar."
   },
   "zapper_status_tap_to_hide": {
-    "message": "Скрытие элементов: нажмите на элемент, чтобы скрыть его.",
+    "message": "Αποκλεισμός στοιχείου: πατήστε ένα στοιχείο για να το κρύψετε.",
     "description": "Default status text in the in-page element zapper toolbar."
   },
   "zapper_button_undo": {
-    "message": "Отменить",
+    "message": "Αναίρεση",
     "description": "Button label to undo last zapper action."
   },
   "zapper_button_more": {
-    "message": "Больше опций",
+    "message": "Περισσότερες επιλογές",
     "description": "Tooltip label for the overflow menu button in zapper toolbar."
   },
   "zapper_button_add_custom_rule": {
-    "message": "Добавить пользовательское правило CSS…",
+    "message": "Προσθήκη προσαρμοσμένου κανόνα CSS…",
     "description": "Menu item label for adding a manual CSS selector rule."
   },
   "zapper_button_done": {
-    "message": "Готово",
+    "message": "Ολοκληρώθηκε",
     "description": "Button label to finish zapper mode."
   },
   "zapper_button_select_parent": {
-    "message": "Выбрать родительский элемент",
+    "message": "Επιλογή γονικού στοιχείου",
     "description": "Tooltip for choosing the parent element in refine mode."
   },
   "zapper_button_select_child": {
-    "message": "Выбрать дочерний элемент",
+    "message": "Επιλογή παιδικού στοιχείου",
     "description": "Tooltip for choosing the child element in refine mode."
   },
   "zapper_button_hide": {
-    "message": "Скрыть",
+    "message": "Απόκρυψη",
     "description": "Button label for confirming hide action in refine mode."
   },
   "zapper_error_enter_selector": {
-    "message": "Введите CSS-селектор.",
+    "message": "Εισαγάγετε έναν επιλογέα CSS.",
     "description": "Validation error shown when manual selector input is empty."
   },
   "zapper_error_rule_syntax_invalid": {
-    "message": "Некорректный синтаксис правила CSS.",
+    "message": "Η σύνταξη του κανόνα CSS δεν είναι έγκυρη.",
     "description": "Validation error shown when manual CSS rule syntax is invalid."
   },
   "zapper_error_selector_too_long": {
-    "message": "Селектор слишком длинный.",
+    "message": "Ο επιλογέας είναι πολύ μεγάλος.",
     "description": "Validation error shown when manual selector exceeds max length."
   },
   "zapper_error_selector_syntax_invalid": {
-    "message": "Некорректный синтаксис селектора.",
+    "message": "Η σύνταξη του επιλογέα δεν είναι έγκυρη.",
     "description": "Validation error shown when selector cannot be parsed."
   },
   "zapper_toast_rule_exists": {
-    "message": "Правило уже существует.",
+    "message": "Ο κανόνας υπάρχει ήδη.",
     "description": "Toast shown when trying to add a duplicate manual rule."
   },
   "zapper_toast_already_hidden": {
-    "message": "Уже скрыто.",
+    "message": "Είναι ήδη κρυφό.",
     "description": "Toast shown when picked element is already hidden by existing rule."
   },
   "zapper_toast_rule_saved": {
-    "message": "Правило сохранено для этого сайта.",
+    "message": "Ο κανόνας αποθηκεύτηκε για αυτόν τον ιστότοπο.",
     "description": "Toast shown after successfully adding a manual rule."
   },
   "zapper_toast_hidden_and_saved": {
-    "message": "Скрыто. Правило сохранено для этого сайта.",
+    "message": "Κρύφτηκε. Ο κανόνας αποθηκεύτηκε για αυτόν τον ιστότοπο.",
     "description": "Toast shown after hiding selected element and saving generated rule."
   },
   "zapper_prompt_enter_selector": {
-    "message": "Введите CSS-селектор для этого сайта",
+    "message": "Εισαγάγετε επιλογέα CSS για αυτόν τον ιστότοπο",
     "description": "Prompt text shown when user adds a manual selector rule."
   },
   "zapper_toast_undone": {
-    "message": "Отменено.",
+    "message": "Αναιρέθηκε.",
     "description": "Toast shown after undoing the last zapper action."
   },
   "zapper_status_refine": {
-    "message": "$1 — ▲▼ для настройки, нажмите $2, чтобы сохранить",
+    "message": "$1 — ▲▼ για προσαρμογή, πατήστε $2 για αποθήκευση",
     "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
   },
   "zapper_toast_unable_create_rule": {
-    "message": "Не удалось создать правило для этого элемента.",
+    "message": "Δεν ήταν δυνατή η δημιουργία κανόνα για αυτό το στοιχείο.",
     "description": "Toast shown when selector generation fails for selected element."
   },
   "zapper_toast_enabled": {
-    "message": "Скрытие элементов включено.",
+    "message": "Ο αποκλεισμός στοιχείου ενεργοποιήθηκε.",
     "description": "Toast shown when zapper mode is enabled."
   },
   "zapper_toast_disabled": {
-    "message": "Скрытие элементов отключено.",
+    "message": "Ο αποκλεισμός στοιχείου απενεργοποιήθηκε.",
     "description": "Toast shown when zapper mode is disabled."
   },
   "zapper_status_off": {
-    "message": "Скрытие элементов: Выкл.",
+    "message": "Αποκλεισμός στοιχείου: Ανενεργό",
     "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/en/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/en/messages.json
@@ -6,5 +6,193 @@
   "extension_description": {
     "message": "Blocks the peskiest ads and tracking methods, including YouTube.",
     "description": "Description of what the extension does."
+  },
+  "popup_status_loading": {
+    "message": "Loading…",
+    "description": "Popup status shown while loading state is being resolved."
+  },
+  "popup_disable_on_site": {
+    "message": "Disable on this site",
+    "description": "Label for the site-specific disable toggle in the popup."
+  },
+  "popup_element_zapper": {
+    "message": "Element zapper",
+    "description": "Section title for the element zapper controls in the popup."
+  },
+  "popup_button_activate": {
+    "message": "Activate",
+    "description": "Button label to activate element zapper mode."
+  },
+  "popup_button_clear": {
+    "message": "Clear",
+    "description": "Button label to clear all zapper rules for the current site."
+  },
+  "popup_hint_tap_to_hide": {
+    "message": "Tap an element on the page to hide it. Use \"Add Rule\" in the zapper for manual selectors.",
+    "description": "Help text shown in the popup for how to use the element zapper."
+  },
+  "popup_rules": {
+    "message": "Rules",
+    "description": "Label for the disclosure button that expands saved zapper rules."
+  },
+  "popup_button_open_app": {
+    "message": "Open wBlock App",
+    "description": "Button label to open the containing native app from the popup."
+  },
+  "popup_rules_empty": {
+    "message": "No Element Zapper Rules",
+    "description": "Empty-state text shown when no zapper rules exist for the current site."
+  },
+  "popup_rule_delete_aria": {
+    "message": "Delete rule",
+    "description": "Accessible label for deleting a saved zapper rule."
+  },
+  "popup_error_load_rules": {
+    "message": "Failed to load rules.",
+    "description": "Error shown when popup fails to load zapper rules."
+  },
+  "popup_error_delete_rule": {
+    "message": "Failed to delete rule.",
+    "description": "Error shown when popup fails to delete a zapper rule."
+  },
+  "popup_status_disabling": {
+    "message": "Disabling…",
+    "description": "Transient status shown while disabling blocking on the current site."
+  },
+  "popup_status_enabling": {
+    "message": "Enabling…",
+    "description": "Transient status shown while enabling blocking on the current site."
+  },
+  "popup_status_disabled": {
+    "message": "Disabled",
+    "description": "Status label indicating blocking is disabled on the current site."
+  },
+  "popup_status_active": {
+    "message": "Active",
+    "description": "Status label indicating blocking is active on the current site."
+  },
+  "popup_error_update_site_setting": {
+    "message": "Failed to update site setting.",
+    "description": "Error shown when popup fails to update per-site enabled state."
+  },
+  "popup_error_zapper_unavailable": {
+    "message": "Element Zapper is unavailable on this page.",
+    "description": "Error shown when zapper cannot be activated on the current tab."
+  },
+  "popup_error_open_app": {
+    "message": "Failed to open the app.",
+    "description": "Error shown when popup fails to open the containing app."
+  },
+  "popup_error_clear_rules": {
+    "message": "Failed to clear zapper rules.",
+    "description": "Error shown when popup fails to clear zapper rules for the current site."
+  },
+  "popup_status_unsupported": {
+    "message": "Unsupported",
+    "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_checking": {
+    "message": "Checking…",
+    "description": "Status label shown while popup checks current page and state."
+  },
+  "popup_error_load_popup": {
+    "message": "Failed to load popup.",
+    "description": "Error shown if popup initialization fails."
+  },
+  "zapper_aria_label": {
+    "message": "wBlock Element Zapper",
+    "description": "Accessible label for the in-page element zapper toolbar."
+  },
+  "zapper_status_tap_to_hide": {
+    "message": "Element Zapper: Tap an element to hide it.",
+    "description": "Default status text in the in-page element zapper toolbar."
+  },
+  "zapper_button_undo": {
+    "message": "Undo",
+    "description": "Button label to undo last zapper action."
+  },
+  "zapper_button_more": {
+    "message": "More options",
+    "description": "Tooltip label for the overflow menu button in zapper toolbar."
+  },
+  "zapper_button_add_custom_rule": {
+    "message": "Add custom CSS rule…",
+    "description": "Menu item label for adding a manual CSS selector rule."
+  },
+  "zapper_button_done": {
+    "message": "Done",
+    "description": "Button label to finish zapper mode."
+  },
+  "zapper_button_select_parent": {
+    "message": "Select parent element",
+    "description": "Tooltip for choosing the parent element in refine mode."
+  },
+  "zapper_button_select_child": {
+    "message": "Select child element",
+    "description": "Tooltip for choosing the child element in refine mode."
+  },
+  "zapper_button_hide": {
+    "message": "Hide",
+    "description": "Button label for confirming hide action in refine mode."
+  },
+  "zapper_error_enter_selector": {
+    "message": "Enter a CSS selector.",
+    "description": "Validation error shown when manual selector input is empty."
+  },
+  "zapper_error_rule_syntax_invalid": {
+    "message": "CSS rule syntax is invalid.",
+    "description": "Validation error shown when manual CSS rule syntax is invalid."
+  },
+  "zapper_error_selector_too_long": {
+    "message": "Selector is too long.",
+    "description": "Validation error shown when manual selector exceeds max length."
+  },
+  "zapper_error_selector_syntax_invalid": {
+    "message": "Selector syntax is invalid.",
+    "description": "Validation error shown when selector cannot be parsed."
+  },
+  "zapper_toast_rule_exists": {
+    "message": "Rule already exists.",
+    "description": "Toast shown when trying to add a duplicate manual rule."
+  },
+  "zapper_toast_already_hidden": {
+    "message": "Already hidden.",
+    "description": "Toast shown when picked element is already hidden by existing rule."
+  },
+  "zapper_toast_rule_saved": {
+    "message": "Rule saved for this site.",
+    "description": "Toast shown after successfully adding a manual rule."
+  },
+  "zapper_toast_hidden_and_saved": {
+    "message": "Hidden. Rule saved for this site.",
+    "description": "Toast shown after hiding selected element and saving generated rule."
+  },
+  "zapper_prompt_enter_selector": {
+    "message": "Enter CSS selector for this site",
+    "description": "Prompt text shown when user adds a manual selector rule."
+  },
+  "zapper_toast_undone": {
+    "message": "Undone.",
+    "description": "Toast shown after undoing the last zapper action."
+  },
+  "zapper_status_refine": {
+    "message": "$1 — ▲▼ to adjust, tap $2 to save",
+    "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
+  },
+  "zapper_toast_unable_create_rule": {
+    "message": "Unable to create a rule for that element.",
+    "description": "Toast shown when selector generation fails for selected element."
+  },
+  "zapper_toast_enabled": {
+    "message": "Element Zapper enabled.",
+    "description": "Toast shown when zapper mode is enabled."
+  },
+  "zapper_toast_disabled": {
+    "message": "Element Zapper disabled.",
+    "description": "Toast shown when zapper mode is disabled."
+  },
+  "zapper_status_off": {
+    "message": "Element Zapper: Off",
+    "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/es/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/es/messages.json
@@ -6,5 +6,193 @@
   "extension_description": {
     "message": "Bloquea los anuncios y métodos de seguimiento más molestos, incluido YouTube.",
     "description": "Description of what the extension does."
+  },
+  "popup_status_loading": {
+    "message": "Cargando…",
+    "description": "Popup status shown while loading state is being resolved."
+  },
+  "popup_disable_on_site": {
+    "message": "Desactivar en este sitio",
+    "description": "Label for the site-specific disable toggle in the popup."
+  },
+  "popup_element_zapper": {
+    "message": "Ocultador de elementos",
+    "description": "Section title for the element zapper controls in the popup."
+  },
+  "popup_button_activate": {
+    "message": "Activar",
+    "description": "Button label to activate element zapper mode."
+  },
+  "popup_button_clear": {
+    "message": "Borrar",
+    "description": "Button label to clear all zapper rules for the current site."
+  },
+  "popup_hint_tap_to_hide": {
+    "message": "Toca un elemento de la página para ocultarlo. Usa «Agregar regla» en el ocultador para selectores manuales.",
+    "description": "Help text shown in the popup for how to use the element zapper."
+  },
+  "popup_rules": {
+    "message": "Reglas",
+    "description": "Label for the disclosure button that expands saved zapper rules."
+  },
+  "popup_button_open_app": {
+    "message": "Abrir app de wBlock",
+    "description": "Button label to open the containing native app from the popup."
+  },
+  "popup_rules_empty": {
+    "message": "Sin reglas",
+    "description": "Empty-state text shown when no zapper rules exist for the current site."
+  },
+  "popup_rule_delete_aria": {
+    "message": "Eliminar regla",
+    "description": "Accessible label for deleting a saved zapper rule."
+  },
+  "popup_error_load_rules": {
+    "message": "No se pudieron cargar las reglas.",
+    "description": "Error shown when popup fails to load zapper rules."
+  },
+  "popup_error_delete_rule": {
+    "message": "No se pudo eliminar la regla.",
+    "description": "Error shown when popup fails to delete a zapper rule."
+  },
+  "popup_status_disabling": {
+    "message": "Desactivando…",
+    "description": "Transient status shown while disabling blocking on the current site."
+  },
+  "popup_status_enabling": {
+    "message": "Activando…",
+    "description": "Transient status shown while enabling blocking on the current site."
+  },
+  "popup_status_disabled": {
+    "message": "Desactivado",
+    "description": "Status label indicating blocking is disabled on the current site."
+  },
+  "popup_status_active": {
+    "message": "Activo",
+    "description": "Status label indicating blocking is active on the current site."
+  },
+  "popup_error_update_site_setting": {
+    "message": "No se pudo actualizar la configuración del sitio.",
+    "description": "Error shown when popup fails to update per-site enabled state."
+  },
+  "popup_error_zapper_unavailable": {
+    "message": "El ocultador de elementos no está disponible en esta página.",
+    "description": "Error shown when zapper cannot be activated on the current tab."
+  },
+  "popup_error_open_app": {
+    "message": "No se pudo abrir la app.",
+    "description": "Error shown when popup fails to open the containing app."
+  },
+  "popup_error_clear_rules": {
+    "message": "No se pudieron borrar las reglas del ocultador.",
+    "description": "Error shown when popup fails to clear zapper rules for the current site."
+  },
+  "popup_status_unsupported": {
+    "message": "No compatible",
+    "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_checking": {
+    "message": "Comprobando…",
+    "description": "Status label shown while popup checks current page and state."
+  },
+  "popup_error_load_popup": {
+    "message": "No se pudo cargar la ventana emergente.",
+    "description": "Error shown if popup initialization fails."
+  },
+  "zapper_aria_label": {
+    "message": "Ocultador de elementos de wBlock",
+    "description": "Accessible label for the in-page element zapper toolbar."
+  },
+  "zapper_status_tap_to_hide": {
+    "message": "Ocultador de elementos: toca un elemento para ocultarlo.",
+    "description": "Default status text in the in-page element zapper toolbar."
+  },
+  "zapper_button_undo": {
+    "message": "Deshacer",
+    "description": "Button label to undo last zapper action."
+  },
+  "zapper_button_more": {
+    "message": "Más opciones",
+    "description": "Tooltip label for the overflow menu button in zapper toolbar."
+  },
+  "zapper_button_add_custom_rule": {
+    "message": "Agregar regla CSS personalizada…",
+    "description": "Menu item label for adding a manual CSS selector rule."
+  },
+  "zapper_button_done": {
+    "message": "Listo",
+    "description": "Button label to finish zapper mode."
+  },
+  "zapper_button_select_parent": {
+    "message": "Seleccionar elemento padre",
+    "description": "Tooltip for choosing the parent element in refine mode."
+  },
+  "zapper_button_select_child": {
+    "message": "Seleccionar elemento hijo",
+    "description": "Tooltip for choosing the child element in refine mode."
+  },
+  "zapper_button_hide": {
+    "message": "Ocultar",
+    "description": "Button label for confirming hide action in refine mode."
+  },
+  "zapper_error_enter_selector": {
+    "message": "Introduce un selector CSS.",
+    "description": "Validation error shown when manual selector input is empty."
+  },
+  "zapper_error_rule_syntax_invalid": {
+    "message": "La sintaxis de la regla CSS no es válida.",
+    "description": "Validation error shown when manual CSS rule syntax is invalid."
+  },
+  "zapper_error_selector_too_long": {
+    "message": "El selector es demasiado largo.",
+    "description": "Validation error shown when manual selector exceeds max length."
+  },
+  "zapper_error_selector_syntax_invalid": {
+    "message": "La sintaxis del selector no es válida.",
+    "description": "Validation error shown when selector cannot be parsed."
+  },
+  "zapper_toast_rule_exists": {
+    "message": "La regla ya existe.",
+    "description": "Toast shown when trying to add a duplicate manual rule."
+  },
+  "zapper_toast_already_hidden": {
+    "message": "Ya está oculto.",
+    "description": "Toast shown when picked element is already hidden by existing rule."
+  },
+  "zapper_toast_rule_saved": {
+    "message": "Regla guardada para este sitio.",
+    "description": "Toast shown after successfully adding a manual rule."
+  },
+  "zapper_toast_hidden_and_saved": {
+    "message": "Ocultado. Regla guardada para este sitio.",
+    "description": "Toast shown after hiding selected element and saving generated rule."
+  },
+  "zapper_prompt_enter_selector": {
+    "message": "Introduce un selector CSS para este sitio",
+    "description": "Prompt text shown when user adds a manual selector rule."
+  },
+  "zapper_toast_undone": {
+    "message": "Deshecho.",
+    "description": "Toast shown after undoing the last zapper action."
+  },
+  "zapper_status_refine": {
+    "message": "$1 — ▲▼ para ajustar, toca $2 para guardar",
+    "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
+  },
+  "zapper_toast_unable_create_rule": {
+    "message": "No se pudo crear una regla para ese elemento.",
+    "description": "Toast shown when selector generation fails for selected element."
+  },
+  "zapper_toast_enabled": {
+    "message": "Ocultador de elementos activado.",
+    "description": "Toast shown when zapper mode is enabled."
+  },
+  "zapper_toast_disabled": {
+    "message": "Ocultador de elementos desactivado.",
+    "description": "Toast shown when zapper mode is disabled."
+  },
+  "zapper_status_off": {
+    "message": "Ocultador de elementos: Desactivado",
+    "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/fr/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/fr/messages.json
@@ -6,5 +6,193 @@
   "extension_description": {
     "message": "Bloque les publicités et les méthodes de suivi les plus embêtantes, y compris YouTube.",
     "description": "Description of what the extension does."
+  },
+  "popup_status_loading": {
+    "message": "Chargement…",
+    "description": "Popup status shown while loading state is being resolved."
+  },
+  "popup_disable_on_site": {
+    "message": "Désactiver sur ce site",
+    "description": "Label for the site-specific disable toggle in the popup."
+  },
+  "popup_element_zapper": {
+    "message": "Zappeur d’éléments",
+    "description": "Section title for the element zapper controls in the popup."
+  },
+  "popup_button_activate": {
+    "message": "Activer",
+    "description": "Button label to activate element zapper mode."
+  },
+  "popup_button_clear": {
+    "message": "Effacer",
+    "description": "Button label to clear all zapper rules for the current site."
+  },
+  "popup_hint_tap_to_hide": {
+    "message": "Touchez un élément de la page pour le masquer. Utilisez « Ajouter une règle » dans le zappeur pour les sélecteurs manuels.",
+    "description": "Help text shown in the popup for how to use the element zapper."
+  },
+  "popup_rules": {
+    "message": "Règles",
+    "description": "Label for the disclosure button that expands saved zapper rules."
+  },
+  "popup_button_open_app": {
+    "message": "Ouvrir l’app wBlock",
+    "description": "Button label to open the containing native app from the popup."
+  },
+  "popup_rules_empty": {
+    "message": "Aucune règle",
+    "description": "Empty-state text shown when no zapper rules exist for the current site."
+  },
+  "popup_rule_delete_aria": {
+    "message": "Supprimer la règle",
+    "description": "Accessible label for deleting a saved zapper rule."
+  },
+  "popup_error_load_rules": {
+    "message": "Impossible de charger les règles.",
+    "description": "Error shown when popup fails to load zapper rules."
+  },
+  "popup_error_delete_rule": {
+    "message": "Impossible de supprimer la règle.",
+    "description": "Error shown when popup fails to delete a zapper rule."
+  },
+  "popup_status_disabling": {
+    "message": "Désactivation…",
+    "description": "Transient status shown while disabling blocking on the current site."
+  },
+  "popup_status_enabling": {
+    "message": "Activation…",
+    "description": "Transient status shown while enabling blocking on the current site."
+  },
+  "popup_status_disabled": {
+    "message": "Désactivé",
+    "description": "Status label indicating blocking is disabled on the current site."
+  },
+  "popup_status_active": {
+    "message": "Actif",
+    "description": "Status label indicating blocking is active on the current site."
+  },
+  "popup_error_update_site_setting": {
+    "message": "Impossible de mettre à jour le paramètre du site.",
+    "description": "Error shown when popup fails to update per-site enabled state."
+  },
+  "popup_error_zapper_unavailable": {
+    "message": "Le zappeur d’éléments n’est pas disponible sur cette page.",
+    "description": "Error shown when zapper cannot be activated on the current tab."
+  },
+  "popup_error_open_app": {
+    "message": "Impossible d’ouvrir l’app.",
+    "description": "Error shown when popup fails to open the containing app."
+  },
+  "popup_error_clear_rules": {
+    "message": "Impossible d’effacer les règles du zappeur.",
+    "description": "Error shown when popup fails to clear zapper rules for the current site."
+  },
+  "popup_status_unsupported": {
+    "message": "Non pris en charge",
+    "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_checking": {
+    "message": "Vérification…",
+    "description": "Status label shown while popup checks current page and state."
+  },
+  "popup_error_load_popup": {
+    "message": "Impossible de charger le popup.",
+    "description": "Error shown if popup initialization fails."
+  },
+  "zapper_aria_label": {
+    "message": "Zappeur d’éléments wBlock",
+    "description": "Accessible label for the in-page element zapper toolbar."
+  },
+  "zapper_status_tap_to_hide": {
+    "message": "Zappeur d’éléments : touchez un élément pour le masquer.",
+    "description": "Default status text in the in-page element zapper toolbar."
+  },
+  "zapper_button_undo": {
+    "message": "Annuler",
+    "description": "Button label to undo last zapper action."
+  },
+  "zapper_button_more": {
+    "message": "Plus d’options",
+    "description": "Tooltip label for the overflow menu button in zapper toolbar."
+  },
+  "zapper_button_add_custom_rule": {
+    "message": "Ajouter une règle CSS personnalisée…",
+    "description": "Menu item label for adding a manual CSS selector rule."
+  },
+  "zapper_button_done": {
+    "message": "Terminé",
+    "description": "Button label to finish zapper mode."
+  },
+  "zapper_button_select_parent": {
+    "message": "Sélectionner l’élément parent",
+    "description": "Tooltip for choosing the parent element in refine mode."
+  },
+  "zapper_button_select_child": {
+    "message": "Sélectionner l’élément enfant",
+    "description": "Tooltip for choosing the child element in refine mode."
+  },
+  "zapper_button_hide": {
+    "message": "Masquer",
+    "description": "Button label for confirming hide action in refine mode."
+  },
+  "zapper_error_enter_selector": {
+    "message": "Saisissez un sélecteur CSS.",
+    "description": "Validation error shown when manual selector input is empty."
+  },
+  "zapper_error_rule_syntax_invalid": {
+    "message": "La syntaxe de la règle CSS est invalide.",
+    "description": "Validation error shown when manual CSS rule syntax is invalid."
+  },
+  "zapper_error_selector_too_long": {
+    "message": "Le sélecteur est trop long.",
+    "description": "Validation error shown when manual selector exceeds max length."
+  },
+  "zapper_error_selector_syntax_invalid": {
+    "message": "La syntaxe du sélecteur est invalide.",
+    "description": "Validation error shown when selector cannot be parsed."
+  },
+  "zapper_toast_rule_exists": {
+    "message": "La règle existe déjà.",
+    "description": "Toast shown when trying to add a duplicate manual rule."
+  },
+  "zapper_toast_already_hidden": {
+    "message": "Déjà masqué.",
+    "description": "Toast shown when picked element is already hidden by existing rule."
+  },
+  "zapper_toast_rule_saved": {
+    "message": "Règle enregistrée pour ce site.",
+    "description": "Toast shown after successfully adding a manual rule."
+  },
+  "zapper_toast_hidden_and_saved": {
+    "message": "Masqué. Règle enregistrée pour ce site.",
+    "description": "Toast shown after hiding selected element and saving generated rule."
+  },
+  "zapper_prompt_enter_selector": {
+    "message": "Saisissez un sélecteur CSS pour ce site",
+    "description": "Prompt text shown when user adds a manual selector rule."
+  },
+  "zapper_toast_undone": {
+    "message": "Annulé.",
+    "description": "Toast shown after undoing the last zapper action."
+  },
+  "zapper_status_refine": {
+    "message": "$1 — ▲▼ pour ajuster, touchez $2 pour enregistrer",
+    "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
+  },
+  "zapper_toast_unable_create_rule": {
+    "message": "Impossible de créer une règle pour cet élément.",
+    "description": "Toast shown when selector generation fails for selected element."
+  },
+  "zapper_toast_enabled": {
+    "message": "Zappeur d’éléments activé.",
+    "description": "Toast shown when zapper mode is enabled."
+  },
+  "zapper_toast_disabled": {
+    "message": "Zappeur d’éléments désactivé.",
+    "description": "Toast shown when zapper mode is disabled."
+  },
+  "zapper_status_off": {
+    "message": "Zappeur d’éléments : Désactivé",
+    "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/hu/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/hu/messages.json
@@ -4,195 +4,195 @@
     "description": "The display name for the extension."
   },
   "extension_description": {
-    "message": "Блокирует самую надоедливую рекламу и методы отслеживания, включая YouTube.",
+    "message": "Blokkolja a legidegesítőbb hirdetéseket és követési módszereket, beleértve a YouTube-ot is.",
     "description": "Description of what the extension does."
   },
   "popup_status_loading": {
-    "message": "Загрузка…",
+    "message": "Betöltés…",
     "description": "Popup status shown while loading state is being resolved."
   },
   "popup_disable_on_site": {
-    "message": "Отключить на этом сайте",
+    "message": "Letiltás ezen a webhelyen",
     "description": "Label for the site-specific disable toggle in the popup."
   },
   "popup_element_zapper": {
-    "message": "Скрытие элементов",
+    "message": "Elemeltávolító",
     "description": "Section title for the element zapper controls in the popup."
   },
   "popup_button_activate": {
-    "message": "Включить",
+    "message": "Aktiválás",
     "description": "Button label to activate element zapper mode."
   },
   "popup_button_clear": {
-    "message": "Очистить",
+    "message": "Törlés",
     "description": "Button label to clear all zapper rules for the current site."
   },
   "popup_hint_tap_to_hide": {
-    "message": "Нажмите на элемент на странице, чтобы скрыть его. Используйте «Добавить правило» в скрытии элементов для ручных селекторов.",
+    "message": "Koppints az oldalon egy elemre az elrejtéséhez. A kézi szelektorokhoz használd a „Szabály hozzáadása” opciót az elemeltávolítóban.",
     "description": "Help text shown in the popup for how to use the element zapper."
   },
   "popup_rules": {
-    "message": "Правила",
+    "message": "Szabályok",
     "description": "Label for the disclosure button that expands saved zapper rules."
   },
   "popup_button_open_app": {
-    "message": "Открыть приложение wBlock",
+    "message": "wBlock alkalmazás megnyitása",
     "description": "Button label to open the containing native app from the popup."
   },
   "popup_rules_empty": {
-    "message": "Нет правил",
+    "message": "Nincsenek szabályok",
     "description": "Empty-state text shown when no zapper rules exist for the current site."
   },
   "popup_rule_delete_aria": {
-    "message": "Удалить правило",
+    "message": "Szabály törlése",
     "description": "Accessible label for deleting a saved zapper rule."
   },
   "popup_error_load_rules": {
-    "message": "Не удалось загрузить правила.",
+    "message": "Nem sikerült betölteni a szabályokat.",
     "description": "Error shown when popup fails to load zapper rules."
   },
   "popup_error_delete_rule": {
-    "message": "Не удалось удалить правило.",
+    "message": "Nem sikerült törölni a szabályt.",
     "description": "Error shown when popup fails to delete a zapper rule."
   },
   "popup_status_disabling": {
-    "message": "Отключение…",
+    "message": "Letiltás…",
     "description": "Transient status shown while disabling blocking on the current site."
   },
   "popup_status_enabling": {
-    "message": "Включение…",
+    "message": "Engedélyezés…",
     "description": "Transient status shown while enabling blocking on the current site."
   },
   "popup_status_disabled": {
-    "message": "Отключено",
+    "message": "Letiltva",
     "description": "Status label indicating blocking is disabled on the current site."
   },
   "popup_status_active": {
-    "message": "Активно",
+    "message": "Aktív",
     "description": "Status label indicating blocking is active on the current site."
   },
   "popup_error_update_site_setting": {
-    "message": "Не удалось обновить настройку сайта.",
+    "message": "Nem sikerült frissíteni a webhely beállítását.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
   "popup_error_zapper_unavailable": {
-    "message": "Скрытие элементов недоступно на этой странице.",
+    "message": "Az elemeltávolító nem érhető el ezen az oldalon.",
     "description": "Error shown when zapper cannot be activated on the current tab."
   },
   "popup_error_open_app": {
-    "message": "Не удалось открыть приложение.",
+    "message": "Nem sikerült megnyitni az alkalmazást.",
     "description": "Error shown when popup fails to open the containing app."
   },
   "popup_error_clear_rules": {
-    "message": "Не удалось очистить правила скрытия элементов.",
+    "message": "Nem sikerült törölni az elemeltávolító szabályait.",
     "description": "Error shown when popup fails to clear zapper rules for the current site."
   },
   "popup_status_unsupported": {
-    "message": "Не поддерживается",
+    "message": "Nem támogatott",
     "description": "Status label indicating current page does not support popup actions."
   },
   "popup_status_checking": {
-    "message": "Проверка…",
+    "message": "Ellenőrzés…",
     "description": "Status label shown while popup checks current page and state."
   },
   "popup_error_load_popup": {
-    "message": "Не удалось загрузить всплывающее окно.",
+    "message": "Nem sikerült betölteni a felugró ablakot.",
     "description": "Error shown if popup initialization fails."
   },
   "zapper_aria_label": {
-    "message": "Скрытие элементов wBlock",
+    "message": "wBlock Elemeltávolító",
     "description": "Accessible label for the in-page element zapper toolbar."
   },
   "zapper_status_tap_to_hide": {
-    "message": "Скрытие элементов: нажмите на элемент, чтобы скрыть его.",
+    "message": "Elemeltávolító: koppints egy elemre az elrejtéshez.",
     "description": "Default status text in the in-page element zapper toolbar."
   },
   "zapper_button_undo": {
-    "message": "Отменить",
+    "message": "Visszavonás",
     "description": "Button label to undo last zapper action."
   },
   "zapper_button_more": {
-    "message": "Больше опций",
+    "message": "További lehetőségek",
     "description": "Tooltip label for the overflow menu button in zapper toolbar."
   },
   "zapper_button_add_custom_rule": {
-    "message": "Добавить пользовательское правило CSS…",
+    "message": "Egyéni CSS-szabály hozzáadása…",
     "description": "Menu item label for adding a manual CSS selector rule."
   },
   "zapper_button_done": {
-    "message": "Готово",
+    "message": "Kész",
     "description": "Button label to finish zapper mode."
   },
   "zapper_button_select_parent": {
-    "message": "Выбрать родительский элемент",
+    "message": "Szülőelem kijelölése",
     "description": "Tooltip for choosing the parent element in refine mode."
   },
   "zapper_button_select_child": {
-    "message": "Выбрать дочерний элемент",
+    "message": "Gyermekelem kijelölése",
     "description": "Tooltip for choosing the child element in refine mode."
   },
   "zapper_button_hide": {
-    "message": "Скрыть",
+    "message": "Elrejtés",
     "description": "Button label for confirming hide action in refine mode."
   },
   "zapper_error_enter_selector": {
-    "message": "Введите CSS-селектор.",
+    "message": "Adj meg egy CSS-szelektort.",
     "description": "Validation error shown when manual selector input is empty."
   },
   "zapper_error_rule_syntax_invalid": {
-    "message": "Некорректный синтаксис правила CSS.",
+    "message": "A CSS-szabály szintaxisa érvénytelen.",
     "description": "Validation error shown when manual CSS rule syntax is invalid."
   },
   "zapper_error_selector_too_long": {
-    "message": "Селектор слишком длинный.",
+    "message": "A szelektor túl hosszú.",
     "description": "Validation error shown when manual selector exceeds max length."
   },
   "zapper_error_selector_syntax_invalid": {
-    "message": "Некорректный синтаксис селектора.",
+    "message": "A szelektor szintaxisa érvénytelen.",
     "description": "Validation error shown when selector cannot be parsed."
   },
   "zapper_toast_rule_exists": {
-    "message": "Правило уже существует.",
+    "message": "A szabály már létezik.",
     "description": "Toast shown when trying to add a duplicate manual rule."
   },
   "zapper_toast_already_hidden": {
-    "message": "Уже скрыто.",
+    "message": "Már el van rejtve.",
     "description": "Toast shown when picked element is already hidden by existing rule."
   },
   "zapper_toast_rule_saved": {
-    "message": "Правило сохранено для этого сайта.",
+    "message": "Szabály mentve ehhez a webhelyhez.",
     "description": "Toast shown after successfully adding a manual rule."
   },
   "zapper_toast_hidden_and_saved": {
-    "message": "Скрыто. Правило сохранено для этого сайта.",
+    "message": "Elrejtve. Szabály mentve ehhez a webhelyhez.",
     "description": "Toast shown after hiding selected element and saving generated rule."
   },
   "zapper_prompt_enter_selector": {
-    "message": "Введите CSS-селектор для этого сайта",
+    "message": "Adj meg egy CSS-szelektort ehhez a webhelyhez",
     "description": "Prompt text shown when user adds a manual selector rule."
   },
   "zapper_toast_undone": {
-    "message": "Отменено.",
+    "message": "Visszavonva.",
     "description": "Toast shown after undoing the last zapper action."
   },
   "zapper_status_refine": {
-    "message": "$1 — ▲▼ для настройки, нажмите $2, чтобы сохранить",
+    "message": "$1 — ▲▼ a finomításhoz, koppints a(z) $2 gombra a mentéshez",
     "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
   },
   "zapper_toast_unable_create_rule": {
-    "message": "Не удалось создать правило для этого элемента.",
+    "message": "Ehhez az elemhez nem sikerült szabályt létrehozni.",
     "description": "Toast shown when selector generation fails for selected element."
   },
   "zapper_toast_enabled": {
-    "message": "Скрытие элементов включено.",
+    "message": "Az elemeltávolító bekapcsolva.",
     "description": "Toast shown when zapper mode is enabled."
   },
   "zapper_toast_disabled": {
-    "message": "Скрытие элементов отключено.",
+    "message": "Az elemeltávolító kikapcsolva.",
     "description": "Toast shown when zapper mode is disabled."
   },
   "zapper_status_off": {
-    "message": "Скрытие элементов: Выкл.",
+    "message": "Elemeltávolító: Kikapcsolva",
     "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/it/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/it/messages.json
@@ -6,5 +6,193 @@
   "extension_description": {
     "message": "Blocca gli annunci e i metodi di tracciamento più fastidiosi, incluso YouTube.",
     "description": "Description of what the extension does."
+  },
+  "popup_status_loading": {
+    "message": "Caricamento…",
+    "description": "Popup status shown while loading state is being resolved."
+  },
+  "popup_disable_on_site": {
+    "message": "Disattiva su questo sito",
+    "description": "Label for the site-specific disable toggle in the popup."
+  },
+  "popup_element_zapper": {
+    "message": "Zapper elementi",
+    "description": "Section title for the element zapper controls in the popup."
+  },
+  "popup_button_activate": {
+    "message": "Attiva",
+    "description": "Button label to activate element zapper mode."
+  },
+  "popup_button_clear": {
+    "message": "Cancella",
+    "description": "Button label to clear all zapper rules for the current site."
+  },
+  "popup_hint_tap_to_hide": {
+    "message": "Tocca un elemento nella pagina per nasconderlo. Usa «Aggiungi regola» nello zapper per selettori manuali.",
+    "description": "Help text shown in the popup for how to use the element zapper."
+  },
+  "popup_rules": {
+    "message": "Regole",
+    "description": "Label for the disclosure button that expands saved zapper rules."
+  },
+  "popup_button_open_app": {
+    "message": "Apri app wBlock",
+    "description": "Button label to open the containing native app from the popup."
+  },
+  "popup_rules_empty": {
+    "message": "Nessuna regola",
+    "description": "Empty-state text shown when no zapper rules exist for the current site."
+  },
+  "popup_rule_delete_aria": {
+    "message": "Elimina regola",
+    "description": "Accessible label for deleting a saved zapper rule."
+  },
+  "popup_error_load_rules": {
+    "message": "Impossibile caricare le regole.",
+    "description": "Error shown when popup fails to load zapper rules."
+  },
+  "popup_error_delete_rule": {
+    "message": "Impossibile eliminare la regola.",
+    "description": "Error shown when popup fails to delete a zapper rule."
+  },
+  "popup_status_disabling": {
+    "message": "Disattivazione…",
+    "description": "Transient status shown while disabling blocking on the current site."
+  },
+  "popup_status_enabling": {
+    "message": "Attivazione…",
+    "description": "Transient status shown while enabling blocking on the current site."
+  },
+  "popup_status_disabled": {
+    "message": "Disabilitato",
+    "description": "Status label indicating blocking is disabled on the current site."
+  },
+  "popup_status_active": {
+    "message": "Attivo",
+    "description": "Status label indicating blocking is active on the current site."
+  },
+  "popup_error_update_site_setting": {
+    "message": "Impossibile aggiornare l’impostazione del sito.",
+    "description": "Error shown when popup fails to update per-site enabled state."
+  },
+  "popup_error_zapper_unavailable": {
+    "message": "Lo Zapper elementi non è disponibile su questa pagina.",
+    "description": "Error shown when zapper cannot be activated on the current tab."
+  },
+  "popup_error_open_app": {
+    "message": "Impossibile aprire l’app.",
+    "description": "Error shown when popup fails to open the containing app."
+  },
+  "popup_error_clear_rules": {
+    "message": "Impossibile cancellare le regole dello zapper.",
+    "description": "Error shown when popup fails to clear zapper rules for the current site."
+  },
+  "popup_status_unsupported": {
+    "message": "Non supportato",
+    "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_checking": {
+    "message": "Verifica in corso…",
+    "description": "Status label shown while popup checks current page and state."
+  },
+  "popup_error_load_popup": {
+    "message": "Impossibile caricare il popup.",
+    "description": "Error shown if popup initialization fails."
+  },
+  "zapper_aria_label": {
+    "message": "Zapper elementi wBlock",
+    "description": "Accessible label for the in-page element zapper toolbar."
+  },
+  "zapper_status_tap_to_hide": {
+    "message": "Zapper elementi: tocca un elemento per nasconderlo.",
+    "description": "Default status text in the in-page element zapper toolbar."
+  },
+  "zapper_button_undo": {
+    "message": "Annulla",
+    "description": "Button label to undo last zapper action."
+  },
+  "zapper_button_more": {
+    "message": "Altre opzioni",
+    "description": "Tooltip label for the overflow menu button in zapper toolbar."
+  },
+  "zapper_button_add_custom_rule": {
+    "message": "Aggiungi regola CSS personalizzata…",
+    "description": "Menu item label for adding a manual CSS selector rule."
+  },
+  "zapper_button_done": {
+    "message": "Fatto",
+    "description": "Button label to finish zapper mode."
+  },
+  "zapper_button_select_parent": {
+    "message": "Seleziona elemento genitore",
+    "description": "Tooltip for choosing the parent element in refine mode."
+  },
+  "zapper_button_select_child": {
+    "message": "Seleziona elemento figlio",
+    "description": "Tooltip for choosing the child element in refine mode."
+  },
+  "zapper_button_hide": {
+    "message": "Nascondi",
+    "description": "Button label for confirming hide action in refine mode."
+  },
+  "zapper_error_enter_selector": {
+    "message": "Inserisci un selettore CSS.",
+    "description": "Validation error shown when manual selector input is empty."
+  },
+  "zapper_error_rule_syntax_invalid": {
+    "message": "La sintassi della regola CSS non è valida.",
+    "description": "Validation error shown when manual CSS rule syntax is invalid."
+  },
+  "zapper_error_selector_too_long": {
+    "message": "Il selettore è troppo lungo.",
+    "description": "Validation error shown when manual selector exceeds max length."
+  },
+  "zapper_error_selector_syntax_invalid": {
+    "message": "La sintassi del selettore non è valida.",
+    "description": "Validation error shown when selector cannot be parsed."
+  },
+  "zapper_toast_rule_exists": {
+    "message": "La regola esiste già.",
+    "description": "Toast shown when trying to add a duplicate manual rule."
+  },
+  "zapper_toast_already_hidden": {
+    "message": "Già nascosto.",
+    "description": "Toast shown when picked element is already hidden by existing rule."
+  },
+  "zapper_toast_rule_saved": {
+    "message": "Regola salvata per questo sito.",
+    "description": "Toast shown after successfully adding a manual rule."
+  },
+  "zapper_toast_hidden_and_saved": {
+    "message": "Nascosto. Regola salvata per questo sito.",
+    "description": "Toast shown after hiding selected element and saving generated rule."
+  },
+  "zapper_prompt_enter_selector": {
+    "message": "Inserisci un selettore CSS per questo sito",
+    "description": "Prompt text shown when user adds a manual selector rule."
+  },
+  "zapper_toast_undone": {
+    "message": "Annullato.",
+    "description": "Toast shown after undoing the last zapper action."
+  },
+  "zapper_status_refine": {
+    "message": "$1 — ▲▼ per regolare, tocca $2 per salvare",
+    "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
+  },
+  "zapper_toast_unable_create_rule": {
+    "message": "Impossibile creare una regola per quell’elemento.",
+    "description": "Toast shown when selector generation fails for selected element."
+  },
+  "zapper_toast_enabled": {
+    "message": "Zapper elementi attivato.",
+    "description": "Toast shown when zapper mode is enabled."
+  },
+  "zapper_toast_disabled": {
+    "message": "Zapper elementi disattivato.",
+    "description": "Toast shown when zapper mode is disabled."
+  },
+  "zapper_status_off": {
+    "message": "Zapper elementi: Disattivato",
+    "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/ja/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ja/messages.json
@@ -4,7 +4,195 @@
     "description": "The display name for the extension."
   },
   "extension_description": {
-    "message": "YouTube などの最も厄介な広告や追跡方法をブロックします。",
+    "message": "YouTube を含む、最もしつこい広告や追跡手法をブロックします。",
     "description": "Description of what the extension does."
+  },
+  "popup_status_loading": {
+    "message": "読み込み中…",
+    "description": "Popup status shown while loading state is being resolved."
+  },
+  "popup_disable_on_site": {
+    "message": "このサイトで無効化",
+    "description": "Label for the site-specific disable toggle in the popup."
+  },
+  "popup_element_zapper": {
+    "message": "要素ザッパー",
+    "description": "Section title for the element zapper controls in the popup."
+  },
+  "popup_button_activate": {
+    "message": "有効化",
+    "description": "Button label to activate element zapper mode."
+  },
+  "popup_button_clear": {
+    "message": "クリア",
+    "description": "Button label to clear all zapper rules for the current site."
+  },
+  "popup_hint_tap_to_hide": {
+    "message": "ページ上の要素をタップすると非表示にできます。手動セレクタはザッパーの「ルール追加」を使用してください。",
+    "description": "Help text shown in the popup for how to use the element zapper."
+  },
+  "popup_rules": {
+    "message": "ルール",
+    "description": "Label for the disclosure button that expands saved zapper rules."
+  },
+  "popup_button_open_app": {
+    "message": "wBlock アプリを開く",
+    "description": "Button label to open the containing native app from the popup."
+  },
+  "popup_rules_empty": {
+    "message": "ルールがありません",
+    "description": "Empty-state text shown when no zapper rules exist for the current site."
+  },
+  "popup_rule_delete_aria": {
+    "message": "ルールを削除",
+    "description": "Accessible label for deleting a saved zapper rule."
+  },
+  "popup_error_load_rules": {
+    "message": "ルールの読み込みに失敗しました。",
+    "description": "Error shown when popup fails to load zapper rules."
+  },
+  "popup_error_delete_rule": {
+    "message": "ルールの削除に失敗しました。",
+    "description": "Error shown when popup fails to delete a zapper rule."
+  },
+  "popup_status_disabling": {
+    "message": "無効化中…",
+    "description": "Transient status shown while disabling blocking on the current site."
+  },
+  "popup_status_enabling": {
+    "message": "有効化中…",
+    "description": "Transient status shown while enabling blocking on the current site."
+  },
+  "popup_status_disabled": {
+    "message": "無効",
+    "description": "Status label indicating blocking is disabled on the current site."
+  },
+  "popup_status_active": {
+    "message": "アクティブ",
+    "description": "Status label indicating blocking is active on the current site."
+  },
+  "popup_error_update_site_setting": {
+    "message": "サイト設定の更新に失敗しました。",
+    "description": "Error shown when popup fails to update per-site enabled state."
+  },
+  "popup_error_zapper_unavailable": {
+    "message": "このページでは要素ザッパーを利用できません。",
+    "description": "Error shown when zapper cannot be activated on the current tab."
+  },
+  "popup_error_open_app": {
+    "message": "アプリを開けませんでした。",
+    "description": "Error shown when popup fails to open the containing app."
+  },
+  "popup_error_clear_rules": {
+    "message": "ザッパールールのクリアに失敗しました。",
+    "description": "Error shown when popup fails to clear zapper rules for the current site."
+  },
+  "popup_status_unsupported": {
+    "message": "非対応",
+    "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_checking": {
+    "message": "確認中…",
+    "description": "Status label shown while popup checks current page and state."
+  },
+  "popup_error_load_popup": {
+    "message": "ポップアップの読み込みに失敗しました。",
+    "description": "Error shown if popup initialization fails."
+  },
+  "zapper_aria_label": {
+    "message": "wBlock 要素ザッパー",
+    "description": "Accessible label for the in-page element zapper toolbar."
+  },
+  "zapper_status_tap_to_hide": {
+    "message": "要素ザッパー: 要素をタップして非表示にします。",
+    "description": "Default status text in the in-page element zapper toolbar."
+  },
+  "zapper_button_undo": {
+    "message": "元に戻す",
+    "description": "Button label to undo last zapper action."
+  },
+  "zapper_button_more": {
+    "message": "その他のオプション",
+    "description": "Tooltip label for the overflow menu button in zapper toolbar."
+  },
+  "zapper_button_add_custom_rule": {
+    "message": "カスタム CSS ルールを追加…",
+    "description": "Menu item label for adding a manual CSS selector rule."
+  },
+  "zapper_button_done": {
+    "message": "完了",
+    "description": "Button label to finish zapper mode."
+  },
+  "zapper_button_select_parent": {
+    "message": "親要素を選択",
+    "description": "Tooltip for choosing the parent element in refine mode."
+  },
+  "zapper_button_select_child": {
+    "message": "子要素を選択",
+    "description": "Tooltip for choosing the child element in refine mode."
+  },
+  "zapper_button_hide": {
+    "message": "非表示",
+    "description": "Button label for confirming hide action in refine mode."
+  },
+  "zapper_error_enter_selector": {
+    "message": "CSS セレクタを入力してください。",
+    "description": "Validation error shown when manual selector input is empty."
+  },
+  "zapper_error_rule_syntax_invalid": {
+    "message": "CSS ルールの構文が正しくありません。",
+    "description": "Validation error shown when manual CSS rule syntax is invalid."
+  },
+  "zapper_error_selector_too_long": {
+    "message": "セレクタが長すぎます。",
+    "description": "Validation error shown when manual selector exceeds max length."
+  },
+  "zapper_error_selector_syntax_invalid": {
+    "message": "セレクタの構文が正しくありません。",
+    "description": "Validation error shown when selector cannot be parsed."
+  },
+  "zapper_toast_rule_exists": {
+    "message": "ルールはすでに存在します。",
+    "description": "Toast shown when trying to add a duplicate manual rule."
+  },
+  "zapper_toast_already_hidden": {
+    "message": "すでに非表示です。",
+    "description": "Toast shown when picked element is already hidden by existing rule."
+  },
+  "zapper_toast_rule_saved": {
+    "message": "このサイトのルールを保存しました。",
+    "description": "Toast shown after successfully adding a manual rule."
+  },
+  "zapper_toast_hidden_and_saved": {
+    "message": "非表示にしました。このサイトのルールを保存しました。",
+    "description": "Toast shown after hiding selected element and saving generated rule."
+  },
+  "zapper_prompt_enter_selector": {
+    "message": "このサイトの CSS セレクタを入力",
+    "description": "Prompt text shown when user adds a manual selector rule."
+  },
+  "zapper_toast_undone": {
+    "message": "元に戻しました。",
+    "description": "Toast shown after undoing the last zapper action."
+  },
+  "zapper_status_refine": {
+    "message": "$1 — ▲▼で調整し、$2 をタップして保存",
+    "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
+  },
+  "zapper_toast_unable_create_rule": {
+    "message": "その要素のルールを作成できませんでした。",
+    "description": "Toast shown when selector generation fails for selected element."
+  },
+  "zapper_toast_enabled": {
+    "message": "要素ザッパーを有効化しました。",
+    "description": "Toast shown when zapper mode is enabled."
+  },
+  "zapper_toast_disabled": {
+    "message": "要素ザッパーを無効化しました。",
+    "description": "Toast shown when zapper mode is disabled."
+  },
+  "zapper_status_off": {
+    "message": "要素ザッパー: オフ",
+    "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/ko/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ko/messages.json
@@ -4,7 +4,195 @@
     "description": "The display name for the extension."
   },
   "extension_description": {
-    "message": "YouTube를 포함하여 가장 성가신 광고 및 추적 방법을 차단합니다.",
+    "message": "YouTube를 포함해 가장 성가신 광고와 추적 방식을 차단합니다.",
     "description": "Description of what the extension does."
+  },
+  "popup_status_loading": {
+    "message": "로딩 중…",
+    "description": "Popup status shown while loading state is being resolved."
+  },
+  "popup_disable_on_site": {
+    "message": "이 사이트에서 비활성화",
+    "description": "Label for the site-specific disable toggle in the popup."
+  },
+  "popup_element_zapper": {
+    "message": "요소 제거기",
+    "description": "Section title for the element zapper controls in the popup."
+  },
+  "popup_button_activate": {
+    "message": "활성화",
+    "description": "Button label to activate element zapper mode."
+  },
+  "popup_button_clear": {
+    "message": "지우기",
+    "description": "Button label to clear all zapper rules for the current site."
+  },
+  "popup_hint_tap_to_hide": {
+    "message": "페이지의 요소를 탭하면 숨길 수 있습니다. 수동 선택자는 요소 제거기에서 \"규칙 추가\"를 사용하세요.",
+    "description": "Help text shown in the popup for how to use the element zapper."
+  },
+  "popup_rules": {
+    "message": "규칙",
+    "description": "Label for the disclosure button that expands saved zapper rules."
+  },
+  "popup_button_open_app": {
+    "message": "wBlock 앱 열기",
+    "description": "Button label to open the containing native app from the popup."
+  },
+  "popup_rules_empty": {
+    "message": "규칙 없음",
+    "description": "Empty-state text shown when no zapper rules exist for the current site."
+  },
+  "popup_rule_delete_aria": {
+    "message": "규칙 삭제",
+    "description": "Accessible label for deleting a saved zapper rule."
+  },
+  "popup_error_load_rules": {
+    "message": "규칙을 불러오지 못했습니다.",
+    "description": "Error shown when popup fails to load zapper rules."
+  },
+  "popup_error_delete_rule": {
+    "message": "규칙을 삭제하지 못했습니다.",
+    "description": "Error shown when popup fails to delete a zapper rule."
+  },
+  "popup_status_disabling": {
+    "message": "비활성화 중…",
+    "description": "Transient status shown while disabling blocking on the current site."
+  },
+  "popup_status_enabling": {
+    "message": "활성화 중…",
+    "description": "Transient status shown while enabling blocking on the current site."
+  },
+  "popup_status_disabled": {
+    "message": "비활성화됨",
+    "description": "Status label indicating blocking is disabled on the current site."
+  },
+  "popup_status_active": {
+    "message": "활성",
+    "description": "Status label indicating blocking is active on the current site."
+  },
+  "popup_error_update_site_setting": {
+    "message": "사이트 설정을 업데이트하지 못했습니다.",
+    "description": "Error shown when popup fails to update per-site enabled state."
+  },
+  "popup_error_zapper_unavailable": {
+    "message": "이 페이지에서는 요소 제거기를 사용할 수 없습니다.",
+    "description": "Error shown when zapper cannot be activated on the current tab."
+  },
+  "popup_error_open_app": {
+    "message": "앱을 열지 못했습니다.",
+    "description": "Error shown when popup fails to open the containing app."
+  },
+  "popup_error_clear_rules": {
+    "message": "요소 제거기 규칙을 지우지 못했습니다.",
+    "description": "Error shown when popup fails to clear zapper rules for the current site."
+  },
+  "popup_status_unsupported": {
+    "message": "지원되지 않음",
+    "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_checking": {
+    "message": "확인 중…",
+    "description": "Status label shown while popup checks current page and state."
+  },
+  "popup_error_load_popup": {
+    "message": "팝업을 불러오지 못했습니다.",
+    "description": "Error shown if popup initialization fails."
+  },
+  "zapper_aria_label": {
+    "message": "wBlock 요소 제거기",
+    "description": "Accessible label for the in-page element zapper toolbar."
+  },
+  "zapper_status_tap_to_hide": {
+    "message": "요소 제거기: 요소를 탭해 숨기세요.",
+    "description": "Default status text in the in-page element zapper toolbar."
+  },
+  "zapper_button_undo": {
+    "message": "실행 취소",
+    "description": "Button label to undo last zapper action."
+  },
+  "zapper_button_more": {
+    "message": "추가 옵션",
+    "description": "Tooltip label for the overflow menu button in zapper toolbar."
+  },
+  "zapper_button_add_custom_rule": {
+    "message": "사용자 지정 CSS 규칙 추가…",
+    "description": "Menu item label for adding a manual CSS selector rule."
+  },
+  "zapper_button_done": {
+    "message": "완료",
+    "description": "Button label to finish zapper mode."
+  },
+  "zapper_button_select_parent": {
+    "message": "상위 요소 선택",
+    "description": "Tooltip for choosing the parent element in refine mode."
+  },
+  "zapper_button_select_child": {
+    "message": "하위 요소 선택",
+    "description": "Tooltip for choosing the child element in refine mode."
+  },
+  "zapper_button_hide": {
+    "message": "숨기기",
+    "description": "Button label for confirming hide action in refine mode."
+  },
+  "zapper_error_enter_selector": {
+    "message": "CSS 선택자를 입력하세요.",
+    "description": "Validation error shown when manual selector input is empty."
+  },
+  "zapper_error_rule_syntax_invalid": {
+    "message": "CSS 규칙 구문이 올바르지 않습니다.",
+    "description": "Validation error shown when manual CSS rule syntax is invalid."
+  },
+  "zapper_error_selector_too_long": {
+    "message": "선택자가 너무 깁니다.",
+    "description": "Validation error shown when manual selector exceeds max length."
+  },
+  "zapper_error_selector_syntax_invalid": {
+    "message": "선택자 구문이 올바르지 않습니다.",
+    "description": "Validation error shown when selector cannot be parsed."
+  },
+  "zapper_toast_rule_exists": {
+    "message": "규칙이 이미 존재합니다.",
+    "description": "Toast shown when trying to add a duplicate manual rule."
+  },
+  "zapper_toast_already_hidden": {
+    "message": "이미 숨겨져 있습니다.",
+    "description": "Toast shown when picked element is already hidden by existing rule."
+  },
+  "zapper_toast_rule_saved": {
+    "message": "이 사이트에 대한 규칙이 저장되었습니다.",
+    "description": "Toast shown after successfully adding a manual rule."
+  },
+  "zapper_toast_hidden_and_saved": {
+    "message": "숨김 처리됨. 이 사이트에 대한 규칙이 저장되었습니다.",
+    "description": "Toast shown after hiding selected element and saving generated rule."
+  },
+  "zapper_prompt_enter_selector": {
+    "message": "이 사이트의 CSS 선택자를 입력하세요",
+    "description": "Prompt text shown when user adds a manual selector rule."
+  },
+  "zapper_toast_undone": {
+    "message": "되돌렸습니다.",
+    "description": "Toast shown after undoing the last zapper action."
+  },
+  "zapper_status_refine": {
+    "message": "$1 — ▲▼로 조정하고, 저장하려면 $2 탭",
+    "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
+  },
+  "zapper_toast_unable_create_rule": {
+    "message": "해당 요소에 대한 규칙을 만들 수 없습니다.",
+    "description": "Toast shown when selector generation fails for selected element."
+  },
+  "zapper_toast_enabled": {
+    "message": "요소 제거기가 활성화되었습니다.",
+    "description": "Toast shown when zapper mode is enabled."
+  },
+  "zapper_toast_disabled": {
+    "message": "요소 제거기가 비활성화되었습니다.",
+    "description": "Toast shown when zapper mode is disabled."
+  },
+  "zapper_status_off": {
+    "message": "요소 제거기: 꺼짐",
+    "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/pl/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/pl/messages.json
@@ -6,5 +6,193 @@
   "extension_description": {
     "message": "Blokuje najbardziej uciążliwe reklamy i metody śledzenia, w tym YouTube.",
     "description": "Description of what the extension does."
+  },
+  "popup_status_loading": {
+    "message": "Ładowanie…",
+    "description": "Popup status shown while loading state is being resolved."
+  },
+  "popup_disable_on_site": {
+    "message": "Wyłącz w tej witrynie",
+    "description": "Label for the site-specific disable toggle in the popup."
+  },
+  "popup_element_zapper": {
+    "message": "Usuwacz elementów",
+    "description": "Section title for the element zapper controls in the popup."
+  },
+  "popup_button_activate": {
+    "message": "Aktywuj",
+    "description": "Button label to activate element zapper mode."
+  },
+  "popup_button_clear": {
+    "message": "Wyczyść",
+    "description": "Button label to clear all zapper rules for the current site."
+  },
+  "popup_hint_tap_to_hide": {
+    "message": "Kliknij element na stronie, aby go ukryć. Użyj „Dodaj regułę” w usuwaczu do ręcznych selektorów.",
+    "description": "Help text shown in the popup for how to use the element zapper."
+  },
+  "popup_rules": {
+    "message": "Reguły",
+    "description": "Label for the disclosure button that expands saved zapper rules."
+  },
+  "popup_button_open_app": {
+    "message": "Otwórz aplikację wBlock",
+    "description": "Button label to open the containing native app from the popup."
+  },
+  "popup_rules_empty": {
+    "message": "Brak reguł",
+    "description": "Empty-state text shown when no zapper rules exist for the current site."
+  },
+  "popup_rule_delete_aria": {
+    "message": "Usuń regułę",
+    "description": "Accessible label for deleting a saved zapper rule."
+  },
+  "popup_error_load_rules": {
+    "message": "Nie udało się załadować reguł.",
+    "description": "Error shown when popup fails to load zapper rules."
+  },
+  "popup_error_delete_rule": {
+    "message": "Nie udało się usunąć reguły.",
+    "description": "Error shown when popup fails to delete a zapper rule."
+  },
+  "popup_status_disabling": {
+    "message": "Wyłączanie…",
+    "description": "Transient status shown while disabling blocking on the current site."
+  },
+  "popup_status_enabling": {
+    "message": "Włączanie…",
+    "description": "Transient status shown while enabling blocking on the current site."
+  },
+  "popup_status_disabled": {
+    "message": "Wyłączone",
+    "description": "Status label indicating blocking is disabled on the current site."
+  },
+  "popup_status_active": {
+    "message": "Aktywne",
+    "description": "Status label indicating blocking is active on the current site."
+  },
+  "popup_error_update_site_setting": {
+    "message": "Nie udało się zaktualizować ustawienia witryny.",
+    "description": "Error shown when popup fails to update per-site enabled state."
+  },
+  "popup_error_zapper_unavailable": {
+    "message": "Usuwacz elementów jest niedostępny na tej stronie.",
+    "description": "Error shown when zapper cannot be activated on the current tab."
+  },
+  "popup_error_open_app": {
+    "message": "Nie udało się otworzyć aplikacji.",
+    "description": "Error shown when popup fails to open the containing app."
+  },
+  "popup_error_clear_rules": {
+    "message": "Nie udało się wyczyścić reguł usuwacza.",
+    "description": "Error shown when popup fails to clear zapper rules for the current site."
+  },
+  "popup_status_unsupported": {
+    "message": "Nieobsługiwane",
+    "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_checking": {
+    "message": "Sprawdzanie…",
+    "description": "Status label shown while popup checks current page and state."
+  },
+  "popup_error_load_popup": {
+    "message": "Nie udało się załadować wyskakującego okna.",
+    "description": "Error shown if popup initialization fails."
+  },
+  "zapper_aria_label": {
+    "message": "Usuwacz elementów wBlock",
+    "description": "Accessible label for the in-page element zapper toolbar."
+  },
+  "zapper_status_tap_to_hide": {
+    "message": "Usuwacz elementów: kliknij element, aby go ukryć.",
+    "description": "Default status text in the in-page element zapper toolbar."
+  },
+  "zapper_button_undo": {
+    "message": "Cofnij",
+    "description": "Button label to undo last zapper action."
+  },
+  "zapper_button_more": {
+    "message": "Więcej opcji",
+    "description": "Tooltip label for the overflow menu button in zapper toolbar."
+  },
+  "zapper_button_add_custom_rule": {
+    "message": "Dodaj niestandardową regułę CSS…",
+    "description": "Menu item label for adding a manual CSS selector rule."
+  },
+  "zapper_button_done": {
+    "message": "Gotowe",
+    "description": "Button label to finish zapper mode."
+  },
+  "zapper_button_select_parent": {
+    "message": "Wybierz element nadrzędny",
+    "description": "Tooltip for choosing the parent element in refine mode."
+  },
+  "zapper_button_select_child": {
+    "message": "Wybierz element podrzędny",
+    "description": "Tooltip for choosing the child element in refine mode."
+  },
+  "zapper_button_hide": {
+    "message": "Ukryj",
+    "description": "Button label for confirming hide action in refine mode."
+  },
+  "zapper_error_enter_selector": {
+    "message": "Wprowadź selektor CSS.",
+    "description": "Validation error shown when manual selector input is empty."
+  },
+  "zapper_error_rule_syntax_invalid": {
+    "message": "Składnia reguły CSS jest nieprawidłowa.",
+    "description": "Validation error shown when manual CSS rule syntax is invalid."
+  },
+  "zapper_error_selector_too_long": {
+    "message": "Selektor jest zbyt długi.",
+    "description": "Validation error shown when manual selector exceeds max length."
+  },
+  "zapper_error_selector_syntax_invalid": {
+    "message": "Składnia selektora jest nieprawidłowa.",
+    "description": "Validation error shown when selector cannot be parsed."
+  },
+  "zapper_toast_rule_exists": {
+    "message": "Reguła już istnieje.",
+    "description": "Toast shown when trying to add a duplicate manual rule."
+  },
+  "zapper_toast_already_hidden": {
+    "message": "Już ukryte.",
+    "description": "Toast shown when picked element is already hidden by existing rule."
+  },
+  "zapper_toast_rule_saved": {
+    "message": "Reguła zapisana dla tej witryny.",
+    "description": "Toast shown after successfully adding a manual rule."
+  },
+  "zapper_toast_hidden_and_saved": {
+    "message": "Ukryto. Reguła zapisana dla tej witryny.",
+    "description": "Toast shown after hiding selected element and saving generated rule."
+  },
+  "zapper_prompt_enter_selector": {
+    "message": "Wprowadź selektor CSS dla tej witryny",
+    "description": "Prompt text shown when user adds a manual selector rule."
+  },
+  "zapper_toast_undone": {
+    "message": "Cofnięto.",
+    "description": "Toast shown after undoing the last zapper action."
+  },
+  "zapper_status_refine": {
+    "message": "$1 — ▲▼ aby dopasować, kliknij $2, aby zapisać",
+    "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
+  },
+  "zapper_toast_unable_create_rule": {
+    "message": "Nie udało się utworzyć reguły dla tego elementu.",
+    "description": "Toast shown when selector generation fails for selected element."
+  },
+  "zapper_toast_enabled": {
+    "message": "Usuwacz elementów włączony.",
+    "description": "Toast shown when zapper mode is enabled."
+  },
+  "zapper_toast_disabled": {
+    "message": "Usuwacz elementów wyłączony.",
+    "description": "Toast shown when zapper mode is disabled."
+  },
+  "zapper_status_off": {
+    "message": "Usuwacz elementów: Wyłączony",
+    "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/pt_BR/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/pt_BR/messages.json
@@ -6,5 +6,193 @@
   "extension_description": {
     "message": "Bloqueia os anúncios e métodos de rastreamento mais incômodos, incluindo o YouTube.",
     "description": "Description of what the extension does."
+  },
+  "popup_status_loading": {
+    "message": "Carregando…",
+    "description": "Popup status shown while loading state is being resolved."
+  },
+  "popup_disable_on_site": {
+    "message": "Desativar neste site",
+    "description": "Label for the site-specific disable toggle in the popup."
+  },
+  "popup_element_zapper": {
+    "message": "Ocultador de elementos",
+    "description": "Section title for the element zapper controls in the popup."
+  },
+  "popup_button_activate": {
+    "message": "Ativar",
+    "description": "Button label to activate element zapper mode."
+  },
+  "popup_button_clear": {
+    "message": "Limpar",
+    "description": "Button label to clear all zapper rules for the current site."
+  },
+  "popup_hint_tap_to_hide": {
+    "message": "Toque em um elemento da página para ocultá-lo. Use \"Adicionar regra\" no ocultador para seletores manuais.",
+    "description": "Help text shown in the popup for how to use the element zapper."
+  },
+  "popup_rules": {
+    "message": "Regras",
+    "description": "Label for the disclosure button that expands saved zapper rules."
+  },
+  "popup_button_open_app": {
+    "message": "Abrir app do wBlock",
+    "description": "Button label to open the containing native app from the popup."
+  },
+  "popup_rules_empty": {
+    "message": "Sem regras",
+    "description": "Empty-state text shown when no zapper rules exist for the current site."
+  },
+  "popup_rule_delete_aria": {
+    "message": "Excluir regra",
+    "description": "Accessible label for deleting a saved zapper rule."
+  },
+  "popup_error_load_rules": {
+    "message": "Falha ao carregar as regras.",
+    "description": "Error shown when popup fails to load zapper rules."
+  },
+  "popup_error_delete_rule": {
+    "message": "Falha ao excluir a regra.",
+    "description": "Error shown when popup fails to delete a zapper rule."
+  },
+  "popup_status_disabling": {
+    "message": "Desativando…",
+    "description": "Transient status shown while disabling blocking on the current site."
+  },
+  "popup_status_enabling": {
+    "message": "Ativando…",
+    "description": "Transient status shown while enabling blocking on the current site."
+  },
+  "popup_status_disabled": {
+    "message": "Desativado",
+    "description": "Status label indicating blocking is disabled on the current site."
+  },
+  "popup_status_active": {
+    "message": "Ativo",
+    "description": "Status label indicating blocking is active on the current site."
+  },
+  "popup_error_update_site_setting": {
+    "message": "Falha ao atualizar a configuração do site.",
+    "description": "Error shown when popup fails to update per-site enabled state."
+  },
+  "popup_error_zapper_unavailable": {
+    "message": "O ocultador de elementos não está disponível nesta página.",
+    "description": "Error shown when zapper cannot be activated on the current tab."
+  },
+  "popup_error_open_app": {
+    "message": "Falha ao abrir o app.",
+    "description": "Error shown when popup fails to open the containing app."
+  },
+  "popup_error_clear_rules": {
+    "message": "Falha ao limpar as regras do ocultador.",
+    "description": "Error shown when popup fails to clear zapper rules for the current site."
+  },
+  "popup_status_unsupported": {
+    "message": "Não compatível",
+    "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_checking": {
+    "message": "Verificando…",
+    "description": "Status label shown while popup checks current page and state."
+  },
+  "popup_error_load_popup": {
+    "message": "Falha ao carregar o popup.",
+    "description": "Error shown if popup initialization fails."
+  },
+  "zapper_aria_label": {
+    "message": "Ocultador de elementos do wBlock",
+    "description": "Accessible label for the in-page element zapper toolbar."
+  },
+  "zapper_status_tap_to_hide": {
+    "message": "Ocultador de elementos: toque em um elemento para ocultá-lo.",
+    "description": "Default status text in the in-page element zapper toolbar."
+  },
+  "zapper_button_undo": {
+    "message": "Desfazer",
+    "description": "Button label to undo last zapper action."
+  },
+  "zapper_button_more": {
+    "message": "Mais opções",
+    "description": "Tooltip label for the overflow menu button in zapper toolbar."
+  },
+  "zapper_button_add_custom_rule": {
+    "message": "Adicionar regra CSS personalizada…",
+    "description": "Menu item label for adding a manual CSS selector rule."
+  },
+  "zapper_button_done": {
+    "message": "Concluído",
+    "description": "Button label to finish zapper mode."
+  },
+  "zapper_button_select_parent": {
+    "message": "Selecionar elemento pai",
+    "description": "Tooltip for choosing the parent element in refine mode."
+  },
+  "zapper_button_select_child": {
+    "message": "Selecionar elemento filho",
+    "description": "Tooltip for choosing the child element in refine mode."
+  },
+  "zapper_button_hide": {
+    "message": "Ocultar",
+    "description": "Button label for confirming hide action in refine mode."
+  },
+  "zapper_error_enter_selector": {
+    "message": "Digite um seletor CSS.",
+    "description": "Validation error shown when manual selector input is empty."
+  },
+  "zapper_error_rule_syntax_invalid": {
+    "message": "A sintaxe da regra CSS é inválida.",
+    "description": "Validation error shown when manual CSS rule syntax is invalid."
+  },
+  "zapper_error_selector_too_long": {
+    "message": "O seletor é longo demais.",
+    "description": "Validation error shown when manual selector exceeds max length."
+  },
+  "zapper_error_selector_syntax_invalid": {
+    "message": "A sintaxe do seletor é inválida.",
+    "description": "Validation error shown when selector cannot be parsed."
+  },
+  "zapper_toast_rule_exists": {
+    "message": "A regra já existe.",
+    "description": "Toast shown when trying to add a duplicate manual rule."
+  },
+  "zapper_toast_already_hidden": {
+    "message": "Já está oculto.",
+    "description": "Toast shown when picked element is already hidden by existing rule."
+  },
+  "zapper_toast_rule_saved": {
+    "message": "Regra salva para este site.",
+    "description": "Toast shown after successfully adding a manual rule."
+  },
+  "zapper_toast_hidden_and_saved": {
+    "message": "Ocultado. Regra salva para este site.",
+    "description": "Toast shown after hiding selected element and saving generated rule."
+  },
+  "zapper_prompt_enter_selector": {
+    "message": "Digite um seletor CSS para este site",
+    "description": "Prompt text shown when user adds a manual selector rule."
+  },
+  "zapper_toast_undone": {
+    "message": "Desfeito.",
+    "description": "Toast shown after undoing the last zapper action."
+  },
+  "zapper_status_refine": {
+    "message": "$1 — ▲▼ para ajustar, toque em $2 para salvar",
+    "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
+  },
+  "zapper_toast_unable_create_rule": {
+    "message": "Não foi possível criar uma regra para esse elemento.",
+    "description": "Toast shown when selector generation fails for selected element."
+  },
+  "zapper_toast_enabled": {
+    "message": "Ocultador de elementos ativado.",
+    "description": "Toast shown when zapper mode is enabled."
+  },
+  "zapper_toast_disabled": {
+    "message": "Ocultador de elementos desativado.",
+    "description": "Toast shown when zapper mode is disabled."
+  },
+  "zapper_status_off": {
+    "message": "Ocultador de elementos: Desativado",
+    "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/ro/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ro/messages.json
@@ -6,5 +6,193 @@
   "extension_description": {
     "message": "Blochează cele mai enervante reclame și metode de urmărire, inclusiv YouTube.",
     "description": "Description of what the extension does."
+  },
+  "popup_status_loading": {
+    "message": "Se încarcă…",
+    "description": "Popup status shown while loading state is being resolved."
+  },
+  "popup_disable_on_site": {
+    "message": "Dezactivează pe acest site",
+    "description": "Label for the site-specific disable toggle in the popup."
+  },
+  "popup_element_zapper": {
+    "message": "Eliminator de elemente",
+    "description": "Section title for the element zapper controls in the popup."
+  },
+  "popup_button_activate": {
+    "message": "Activează",
+    "description": "Button label to activate element zapper mode."
+  },
+  "popup_button_clear": {
+    "message": "Șterge",
+    "description": "Button label to clear all zapper rules for the current site."
+  },
+  "popup_hint_tap_to_hide": {
+    "message": "Atinge un element din pagină pentru a-l ascunde. Folosește „Adaugă regulă” în eliminator pentru selectori manuali.",
+    "description": "Help text shown in the popup for how to use the element zapper."
+  },
+  "popup_rules": {
+    "message": "Reguli",
+    "description": "Label for the disclosure button that expands saved zapper rules."
+  },
+  "popup_button_open_app": {
+    "message": "Deschide aplicația wBlock",
+    "description": "Button label to open the containing native app from the popup."
+  },
+  "popup_rules_empty": {
+    "message": "Nicio regulă",
+    "description": "Empty-state text shown when no zapper rules exist for the current site."
+  },
+  "popup_rule_delete_aria": {
+    "message": "Șterge regula",
+    "description": "Accessible label for deleting a saved zapper rule."
+  },
+  "popup_error_load_rules": {
+    "message": "Nu s-au putut încărca regulile.",
+    "description": "Error shown when popup fails to load zapper rules."
+  },
+  "popup_error_delete_rule": {
+    "message": "Nu s-a putut șterge regula.",
+    "description": "Error shown when popup fails to delete a zapper rule."
+  },
+  "popup_status_disabling": {
+    "message": "Se dezactivează…",
+    "description": "Transient status shown while disabling blocking on the current site."
+  },
+  "popup_status_enabling": {
+    "message": "Se activează…",
+    "description": "Transient status shown while enabling blocking on the current site."
+  },
+  "popup_status_disabled": {
+    "message": "Dezactivat",
+    "description": "Status label indicating blocking is disabled on the current site."
+  },
+  "popup_status_active": {
+    "message": "Activ",
+    "description": "Status label indicating blocking is active on the current site."
+  },
+  "popup_error_update_site_setting": {
+    "message": "Nu s-a putut actualiza setarea site-ului.",
+    "description": "Error shown when popup fails to update per-site enabled state."
+  },
+  "popup_error_zapper_unavailable": {
+    "message": "Eliminatorul de elemente nu este disponibil pe această pagină.",
+    "description": "Error shown when zapper cannot be activated on the current tab."
+  },
+  "popup_error_open_app": {
+    "message": "Nu s-a putut deschide aplicația.",
+    "description": "Error shown when popup fails to open the containing app."
+  },
+  "popup_error_clear_rules": {
+    "message": "Nu s-au putut șterge regulile eliminatorului.",
+    "description": "Error shown when popup fails to clear zapper rules for the current site."
+  },
+  "popup_status_unsupported": {
+    "message": "Nesuportat",
+    "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_checking": {
+    "message": "Se verifică…",
+    "description": "Status label shown while popup checks current page and state."
+  },
+  "popup_error_load_popup": {
+    "message": "Nu s-a putut încărca popup-ul.",
+    "description": "Error shown if popup initialization fails."
+  },
+  "zapper_aria_label": {
+    "message": "Eliminator de elemente wBlock",
+    "description": "Accessible label for the in-page element zapper toolbar."
+  },
+  "zapper_status_tap_to_hide": {
+    "message": "Eliminator de elemente: atinge un element pentru a-l ascunde.",
+    "description": "Default status text in the in-page element zapper toolbar."
+  },
+  "zapper_button_undo": {
+    "message": "Anulează",
+    "description": "Button label to undo last zapper action."
+  },
+  "zapper_button_more": {
+    "message": "Mai multe opțiuni",
+    "description": "Tooltip label for the overflow menu button in zapper toolbar."
+  },
+  "zapper_button_add_custom_rule": {
+    "message": "Adaugă regulă CSS personalizată…",
+    "description": "Menu item label for adding a manual CSS selector rule."
+  },
+  "zapper_button_done": {
+    "message": "Gata",
+    "description": "Button label to finish zapper mode."
+  },
+  "zapper_button_select_parent": {
+    "message": "Selectează elementul părinte",
+    "description": "Tooltip for choosing the parent element in refine mode."
+  },
+  "zapper_button_select_child": {
+    "message": "Selectează elementul copil",
+    "description": "Tooltip for choosing the child element in refine mode."
+  },
+  "zapper_button_hide": {
+    "message": "Ascunde",
+    "description": "Button label for confirming hide action in refine mode."
+  },
+  "zapper_error_enter_selector": {
+    "message": "Introdu un selector CSS.",
+    "description": "Validation error shown when manual selector input is empty."
+  },
+  "zapper_error_rule_syntax_invalid": {
+    "message": "Sintaxa regulii CSS este invalidă.",
+    "description": "Validation error shown when manual CSS rule syntax is invalid."
+  },
+  "zapper_error_selector_too_long": {
+    "message": "Selectorul este prea lung.",
+    "description": "Validation error shown when manual selector exceeds max length."
+  },
+  "zapper_error_selector_syntax_invalid": {
+    "message": "Sintaxa selectorului este invalidă.",
+    "description": "Validation error shown when selector cannot be parsed."
+  },
+  "zapper_toast_rule_exists": {
+    "message": "Regula există deja.",
+    "description": "Toast shown when trying to add a duplicate manual rule."
+  },
+  "zapper_toast_already_hidden": {
+    "message": "Deja ascuns.",
+    "description": "Toast shown when picked element is already hidden by existing rule."
+  },
+  "zapper_toast_rule_saved": {
+    "message": "Regulă salvată pentru acest site.",
+    "description": "Toast shown after successfully adding a manual rule."
+  },
+  "zapper_toast_hidden_and_saved": {
+    "message": "Ascuns. Regulă salvată pentru acest site.",
+    "description": "Toast shown after hiding selected element and saving generated rule."
+  },
+  "zapper_prompt_enter_selector": {
+    "message": "Introdu un selector CSS pentru acest site",
+    "description": "Prompt text shown when user adds a manual selector rule."
+  },
+  "zapper_toast_undone": {
+    "message": "Anulat.",
+    "description": "Toast shown after undoing the last zapper action."
+  },
+  "zapper_status_refine": {
+    "message": "$1 — ▲▼ pentru ajustare, atinge $2 pentru salvare",
+    "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
+  },
+  "zapper_toast_unable_create_rule": {
+    "message": "Nu s-a putut crea o regulă pentru acel element.",
+    "description": "Toast shown when selector generation fails for selected element."
+  },
+  "zapper_toast_enabled": {
+    "message": "Eliminatorul de elemente a fost activat.",
+    "description": "Toast shown when zapper mode is enabled."
+  },
+  "zapper_toast_disabled": {
+    "message": "Eliminatorul de elemente a fost dezactivat.",
+    "description": "Toast shown when zapper mode is disabled."
+  },
+  "zapper_status_off": {
+    "message": "Eliminator de elemente: Oprit",
+    "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/tr/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/tr/messages.json
@@ -4,195 +4,195 @@
     "description": "The display name for the extension."
   },
   "extension_description": {
-    "message": "Блокирует самую надоедливую рекламу и методы отслеживания, включая YouTube.",
+    "message": "YouTube dahil en can sıkıcı reklamları ve takip yöntemlerini engeller.",
     "description": "Description of what the extension does."
   },
   "popup_status_loading": {
-    "message": "Загрузка…",
+    "message": "Yükleniyor…",
     "description": "Popup status shown while loading state is being resolved."
   },
   "popup_disable_on_site": {
-    "message": "Отключить на этом сайте",
+    "message": "Bu sitede devre dışı bırak",
     "description": "Label for the site-specific disable toggle in the popup."
   },
   "popup_element_zapper": {
-    "message": "Скрытие элементов",
+    "message": "Öğe Zaplayıcı",
     "description": "Section title for the element zapper controls in the popup."
   },
   "popup_button_activate": {
-    "message": "Включить",
+    "message": "Etkinleştir",
     "description": "Button label to activate element zapper mode."
   },
   "popup_button_clear": {
-    "message": "Очистить",
+    "message": "Temizle",
     "description": "Button label to clear all zapper rules for the current site."
   },
   "popup_hint_tap_to_hide": {
-    "message": "Нажмите на элемент на странице, чтобы скрыть его. Используйте «Добавить правило» в скрытии элементов для ручных селекторов.",
+    "message": "Gizlemek için sayfadaki bir öğeye dokun. Elle seçici eklemek için zaplayıcıda \"Kural Ekle\"yi kullan.",
     "description": "Help text shown in the popup for how to use the element zapper."
   },
   "popup_rules": {
-    "message": "Правила",
+    "message": "Kurallar",
     "description": "Label for the disclosure button that expands saved zapper rules."
   },
   "popup_button_open_app": {
-    "message": "Открыть приложение wBlock",
+    "message": "wBlock Uygulamasını Aç",
     "description": "Button label to open the containing native app from the popup."
   },
   "popup_rules_empty": {
-    "message": "Нет правил",
+    "message": "Öğe Zaplayıcı Kuralı Yok",
     "description": "Empty-state text shown when no zapper rules exist for the current site."
   },
   "popup_rule_delete_aria": {
-    "message": "Удалить правило",
+    "message": "Kuralı sil",
     "description": "Accessible label for deleting a saved zapper rule."
   },
   "popup_error_load_rules": {
-    "message": "Не удалось загрузить правила.",
+    "message": "Kurallar yüklenemedi.",
     "description": "Error shown when popup fails to load zapper rules."
   },
   "popup_error_delete_rule": {
-    "message": "Не удалось удалить правило.",
+    "message": "Kural silinemedi.",
     "description": "Error shown when popup fails to delete a zapper rule."
   },
   "popup_status_disabling": {
-    "message": "Отключение…",
+    "message": "Devre dışı bırakılıyor…",
     "description": "Transient status shown while disabling blocking on the current site."
   },
   "popup_status_enabling": {
-    "message": "Включение…",
+    "message": "Etkinleştiriliyor…",
     "description": "Transient status shown while enabling blocking on the current site."
   },
   "popup_status_disabled": {
-    "message": "Отключено",
+    "message": "Devre Dışı",
     "description": "Status label indicating blocking is disabled on the current site."
   },
   "popup_status_active": {
-    "message": "Активно",
+    "message": "Aktif",
     "description": "Status label indicating blocking is active on the current site."
   },
   "popup_error_update_site_setting": {
-    "message": "Не удалось обновить настройку сайта.",
+    "message": "Site ayarı güncellenemedi.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
   "popup_error_zapper_unavailable": {
-    "message": "Скрытие элементов недоступно на этой странице.",
+    "message": "Öğe Zaplayıcı bu sayfada kullanılamıyor.",
     "description": "Error shown when zapper cannot be activated on the current tab."
   },
   "popup_error_open_app": {
-    "message": "Не удалось открыть приложение.",
+    "message": "Uygulama açılamadı.",
     "description": "Error shown when popup fails to open the containing app."
   },
   "popup_error_clear_rules": {
-    "message": "Не удалось очистить правила скрытия элементов.",
+    "message": "Zaplayıcı kuralları temizlenemedi.",
     "description": "Error shown when popup fails to clear zapper rules for the current site."
   },
   "popup_status_unsupported": {
-    "message": "Не поддерживается",
+    "message": "Desteklenmiyor",
     "description": "Status label indicating current page does not support popup actions."
   },
   "popup_status_checking": {
-    "message": "Проверка…",
+    "message": "Kontrol ediliyor…",
     "description": "Status label shown while popup checks current page and state."
   },
   "popup_error_load_popup": {
-    "message": "Не удалось загрузить всплывающее окно.",
+    "message": "Açılır pencere yüklenemedi.",
     "description": "Error shown if popup initialization fails."
   },
   "zapper_aria_label": {
-    "message": "Скрытие элементов wBlock",
+    "message": "wBlock Öğe Zaplayıcı",
     "description": "Accessible label for the in-page element zapper toolbar."
   },
   "zapper_status_tap_to_hide": {
-    "message": "Скрытие элементов: нажмите на элемент, чтобы скрыть его.",
+    "message": "Öğe Zaplayıcı: Gizlemek için bir öğeye dokun.",
     "description": "Default status text in the in-page element zapper toolbar."
   },
   "zapper_button_undo": {
-    "message": "Отменить",
+    "message": "Geri Al",
     "description": "Button label to undo last zapper action."
   },
   "zapper_button_more": {
-    "message": "Больше опций",
+    "message": "Daha fazla seçenek",
     "description": "Tooltip label for the overflow menu button in zapper toolbar."
   },
   "zapper_button_add_custom_rule": {
-    "message": "Добавить пользовательское правило CSS…",
+    "message": "Özel CSS kuralı ekle…",
     "description": "Menu item label for adding a manual CSS selector rule."
   },
   "zapper_button_done": {
-    "message": "Готово",
+    "message": "Bitti",
     "description": "Button label to finish zapper mode."
   },
   "zapper_button_select_parent": {
-    "message": "Выбрать родительский элемент",
+    "message": "Üst öğeyi seç",
     "description": "Tooltip for choosing the parent element in refine mode."
   },
   "zapper_button_select_child": {
-    "message": "Выбрать дочерний элемент",
+    "message": "Alt öğeyi seç",
     "description": "Tooltip for choosing the child element in refine mode."
   },
   "zapper_button_hide": {
-    "message": "Скрыть",
+    "message": "Gizle",
     "description": "Button label for confirming hide action in refine mode."
   },
   "zapper_error_enter_selector": {
-    "message": "Введите CSS-селектор.",
+    "message": "Bir CSS seçicisi gir.",
     "description": "Validation error shown when manual selector input is empty."
   },
   "zapper_error_rule_syntax_invalid": {
-    "message": "Некорректный синтаксис правила CSS.",
+    "message": "CSS kuralı söz dizimi geçersiz.",
     "description": "Validation error shown when manual CSS rule syntax is invalid."
   },
   "zapper_error_selector_too_long": {
-    "message": "Селектор слишком длинный.",
+    "message": "Seçici çok uzun.",
     "description": "Validation error shown when manual selector exceeds max length."
   },
   "zapper_error_selector_syntax_invalid": {
-    "message": "Некорректный синтаксис селектора.",
+    "message": "Seçici söz dizimi geçersiz.",
     "description": "Validation error shown when selector cannot be parsed."
   },
   "zapper_toast_rule_exists": {
-    "message": "Правило уже существует.",
+    "message": "Kural zaten var.",
     "description": "Toast shown when trying to add a duplicate manual rule."
   },
   "zapper_toast_already_hidden": {
-    "message": "Уже скрыто.",
+    "message": "Zaten gizli.",
     "description": "Toast shown when picked element is already hidden by existing rule."
   },
   "zapper_toast_rule_saved": {
-    "message": "Правило сохранено для этого сайта.",
+    "message": "Kural bu site için kaydedildi.",
     "description": "Toast shown after successfully adding a manual rule."
   },
   "zapper_toast_hidden_and_saved": {
-    "message": "Скрыто. Правило сохранено для этого сайта.",
+    "message": "Gizlendi. Kural bu site için kaydedildi.",
     "description": "Toast shown after hiding selected element and saving generated rule."
   },
   "zapper_prompt_enter_selector": {
-    "message": "Введите CSS-селектор для этого сайта",
+    "message": "Bu site için CSS seçicisi gir",
     "description": "Prompt text shown when user adds a manual selector rule."
   },
   "zapper_toast_undone": {
-    "message": "Отменено.",
+    "message": "Geri alındı.",
     "description": "Toast shown after undoing the last zapper action."
   },
   "zapper_status_refine": {
-    "message": "$1 — ▲▼ для настройки, нажмите $2, чтобы сохранить",
+    "message": "$1 — ▲▼ ile ayarla, kaydetmek için $2 öğesine dokun",
     "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
   },
   "zapper_toast_unable_create_rule": {
-    "message": "Не удалось создать правило для этого элемента.",
+    "message": "Bu öğe için kural oluşturulamadı.",
     "description": "Toast shown when selector generation fails for selected element."
   },
   "zapper_toast_enabled": {
-    "message": "Скрытие элементов включено.",
+    "message": "Öğe Zaplayıcı etkinleştirildi.",
     "description": "Toast shown when zapper mode is enabled."
   },
   "zapper_toast_disabled": {
-    "message": "Скрытие элементов отключено.",
+    "message": "Öğe Zaplayıcı devre dışı bırakıldı.",
     "description": "Toast shown when zapper mode is disabled."
   },
   "zapper_status_off": {
-    "message": "Скрытие элементов: Выкл.",
+    "message": "Öğe Zaplayıcı: Kapalı",
     "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/zh_CN/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/zh_CN/messages.json
@@ -4,7 +4,195 @@
     "description": "The display name for the extension."
   },
   "extension_description": {
-    "message": "阻止最烦人的广告和跟踪方法，包括 YouTube。",
+    "message": "拦截最烦人的广告和跟踪方式，包括 YouTube。",
     "description": "Description of what the extension does."
+  },
+  "popup_status_loading": {
+    "message": "加载中…",
+    "description": "Popup status shown while loading state is being resolved."
+  },
+  "popup_disable_on_site": {
+    "message": "在此网站禁用",
+    "description": "Label for the site-specific disable toggle in the popup."
+  },
+  "popup_element_zapper": {
+    "message": "元素清除器",
+    "description": "Section title for the element zapper controls in the popup."
+  },
+  "popup_button_activate": {
+    "message": "启用",
+    "description": "Button label to activate element zapper mode."
+  },
+  "popup_button_clear": {
+    "message": "清除",
+    "description": "Button label to clear all zapper rules for the current site."
+  },
+  "popup_hint_tap_to_hide": {
+    "message": "点按页面上的元素即可隐藏。若需手动选择器，请在清除器中使用“添加规则”。",
+    "description": "Help text shown in the popup for how to use the element zapper."
+  },
+  "popup_rules": {
+    "message": "规则",
+    "description": "Label for the disclosure button that expands saved zapper rules."
+  },
+  "popup_button_open_app": {
+    "message": "打开 wBlock 应用",
+    "description": "Button label to open the containing native app from the popup."
+  },
+  "popup_rules_empty": {
+    "message": "没有规则",
+    "description": "Empty-state text shown when no zapper rules exist for the current site."
+  },
+  "popup_rule_delete_aria": {
+    "message": "删除规则",
+    "description": "Accessible label for deleting a saved zapper rule."
+  },
+  "popup_error_load_rules": {
+    "message": "加载规则失败。",
+    "description": "Error shown when popup fails to load zapper rules."
+  },
+  "popup_error_delete_rule": {
+    "message": "删除规则失败。",
+    "description": "Error shown when popup fails to delete a zapper rule."
+  },
+  "popup_status_disabling": {
+    "message": "正在禁用…",
+    "description": "Transient status shown while disabling blocking on the current site."
+  },
+  "popup_status_enabling": {
+    "message": "正在启用…",
+    "description": "Transient status shown while enabling blocking on the current site."
+  },
+  "popup_status_disabled": {
+    "message": "已禁用",
+    "description": "Status label indicating blocking is disabled on the current site."
+  },
+  "popup_status_active": {
+    "message": "已启用",
+    "description": "Status label indicating blocking is active on the current site."
+  },
+  "popup_error_update_site_setting": {
+    "message": "更新网站设置失败。",
+    "description": "Error shown when popup fails to update per-site enabled state."
+  },
+  "popup_error_zapper_unavailable": {
+    "message": "此页面无法使用元素清除器。",
+    "description": "Error shown when zapper cannot be activated on the current tab."
+  },
+  "popup_error_open_app": {
+    "message": "打开应用失败。",
+    "description": "Error shown when popup fails to open the containing app."
+  },
+  "popup_error_clear_rules": {
+    "message": "清除元素清除规则失败。",
+    "description": "Error shown when popup fails to clear zapper rules for the current site."
+  },
+  "popup_status_unsupported": {
+    "message": "不支持",
+    "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_checking": {
+    "message": "正在检查…",
+    "description": "Status label shown while popup checks current page and state."
+  },
+  "popup_error_load_popup": {
+    "message": "加载弹窗失败。",
+    "description": "Error shown if popup initialization fails."
+  },
+  "zapper_aria_label": {
+    "message": "wBlock 元素清除器",
+    "description": "Accessible label for the in-page element zapper toolbar."
+  },
+  "zapper_status_tap_to_hide": {
+    "message": "元素清除器：点按元素即可隐藏。",
+    "description": "Default status text in the in-page element zapper toolbar."
+  },
+  "zapper_button_undo": {
+    "message": "撤销",
+    "description": "Button label to undo last zapper action."
+  },
+  "zapper_button_more": {
+    "message": "更多选项",
+    "description": "Tooltip label for the overflow menu button in zapper toolbar."
+  },
+  "zapper_button_add_custom_rule": {
+    "message": "添加自定义 CSS 规则…",
+    "description": "Menu item label for adding a manual CSS selector rule."
+  },
+  "zapper_button_done": {
+    "message": "完成",
+    "description": "Button label to finish zapper mode."
+  },
+  "zapper_button_select_parent": {
+    "message": "选择父元素",
+    "description": "Tooltip for choosing the parent element in refine mode."
+  },
+  "zapper_button_select_child": {
+    "message": "选择子元素",
+    "description": "Tooltip for choosing the child element in refine mode."
+  },
+  "zapper_button_hide": {
+    "message": "隐藏",
+    "description": "Button label for confirming hide action in refine mode."
+  },
+  "zapper_error_enter_selector": {
+    "message": "请输入 CSS 选择器。",
+    "description": "Validation error shown when manual selector input is empty."
+  },
+  "zapper_error_rule_syntax_invalid": {
+    "message": "CSS 规则语法无效。",
+    "description": "Validation error shown when manual CSS rule syntax is invalid."
+  },
+  "zapper_error_selector_too_long": {
+    "message": "选择器过长。",
+    "description": "Validation error shown when manual selector exceeds max length."
+  },
+  "zapper_error_selector_syntax_invalid": {
+    "message": "选择器语法无效。",
+    "description": "Validation error shown when selector cannot be parsed."
+  },
+  "zapper_toast_rule_exists": {
+    "message": "规则已存在。",
+    "description": "Toast shown when trying to add a duplicate manual rule."
+  },
+  "zapper_toast_already_hidden": {
+    "message": "已隐藏。",
+    "description": "Toast shown when picked element is already hidden by existing rule."
+  },
+  "zapper_toast_rule_saved": {
+    "message": "规则已保存到此网站。",
+    "description": "Toast shown after successfully adding a manual rule."
+  },
+  "zapper_toast_hidden_and_saved": {
+    "message": "已隐藏。规则已保存到此网站。",
+    "description": "Toast shown after hiding selected element and saving generated rule."
+  },
+  "zapper_prompt_enter_selector": {
+    "message": "请输入此网站的 CSS 选择器",
+    "description": "Prompt text shown when user adds a manual selector rule."
+  },
+  "zapper_toast_undone": {
+    "message": "已撤销。",
+    "description": "Toast shown after undoing the last zapper action."
+  },
+  "zapper_status_refine": {
+    "message": "$1 — ▲▼ 调整，点按 $2 保存",
+    "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
+  },
+  "zapper_toast_unable_create_rule": {
+    "message": "无法为该元素创建规则。",
+    "description": "Toast shown when selector generation fails for selected element."
+  },
+  "zapper_toast_enabled": {
+    "message": "元素清除器已启用。",
+    "description": "Toast shown when zapper mode is enabled."
+  },
+  "zapper_toast_disabled": {
+    "message": "元素清除器已禁用。",
+    "description": "Toast shown when zapper mode is disabled."
+  },
+  "zapper_status_off": {
+    "message": "元素清除器：关闭",
+    "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/zh_TW/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/zh_TW/messages.json
@@ -4,7 +4,195 @@
     "description": "The display name for the extension."
   },
   "extension_description": {
-    "message": "阻止最煩人的廣告和追蹤方法，包括 YouTube。",
+    "message": "封鎖最惱人的廣告與追蹤方式（包含 YouTube）。",
     "description": "Description of what the extension does."
+  },
+  "popup_status_loading": {
+    "message": "載入中…",
+    "description": "Popup status shown while loading state is being resolved."
+  },
+  "popup_disable_on_site": {
+    "message": "在此網站停用",
+    "description": "Label for the site-specific disable toggle in the popup."
+  },
+  "popup_element_zapper": {
+    "message": "元素消除器",
+    "description": "Section title for the element zapper controls in the popup."
+  },
+  "popup_button_activate": {
+    "message": "啟用",
+    "description": "Button label to activate element zapper mode."
+  },
+  "popup_button_clear": {
+    "message": "清除",
+    "description": "Button label to clear all zapper rules for the current site."
+  },
+  "popup_hint_tap_to_hide": {
+    "message": "點一下頁面上的元素即可隱藏。若需手動選擇器，請在消除器中使用「新增規則」。",
+    "description": "Help text shown in the popup for how to use the element zapper."
+  },
+  "popup_rules": {
+    "message": "規則",
+    "description": "Label for the disclosure button that expands saved zapper rules."
+  },
+  "popup_button_open_app": {
+    "message": "開啟 wBlock App",
+    "description": "Button label to open the containing native app from the popup."
+  },
+  "popup_rules_empty": {
+    "message": "沒有規則",
+    "description": "Empty-state text shown when no zapper rules exist for the current site."
+  },
+  "popup_rule_delete_aria": {
+    "message": "刪除規則",
+    "description": "Accessible label for deleting a saved zapper rule."
+  },
+  "popup_error_load_rules": {
+    "message": "載入規則失敗。",
+    "description": "Error shown when popup fails to load zapper rules."
+  },
+  "popup_error_delete_rule": {
+    "message": "刪除規則失敗。",
+    "description": "Error shown when popup fails to delete a zapper rule."
+  },
+  "popup_status_disabling": {
+    "message": "停用中…",
+    "description": "Transient status shown while disabling blocking on the current site."
+  },
+  "popup_status_enabling": {
+    "message": "啟用中…",
+    "description": "Transient status shown while enabling blocking on the current site."
+  },
+  "popup_status_disabled": {
+    "message": "已停用",
+    "description": "Status label indicating blocking is disabled on the current site."
+  },
+  "popup_status_active": {
+    "message": "作用中",
+    "description": "Status label indicating blocking is active on the current site."
+  },
+  "popup_error_update_site_setting": {
+    "message": "更新網站設定失敗。",
+    "description": "Error shown when popup fails to update per-site enabled state."
+  },
+  "popup_error_zapper_unavailable": {
+    "message": "此頁面無法使用元素消除器。",
+    "description": "Error shown when zapper cannot be activated on the current tab."
+  },
+  "popup_error_open_app": {
+    "message": "開啟 App 失敗。",
+    "description": "Error shown when popup fails to open the containing app."
+  },
+  "popup_error_clear_rules": {
+    "message": "清除元素消除規則失敗。",
+    "description": "Error shown when popup fails to clear zapper rules for the current site."
+  },
+  "popup_status_unsupported": {
+    "message": "不支援",
+    "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_checking": {
+    "message": "檢查中…",
+    "description": "Status label shown while popup checks current page and state."
+  },
+  "popup_error_load_popup": {
+    "message": "載入彈出視窗失敗。",
+    "description": "Error shown if popup initialization fails."
+  },
+  "zapper_aria_label": {
+    "message": "wBlock 元素消除器",
+    "description": "Accessible label for the in-page element zapper toolbar."
+  },
+  "zapper_status_tap_to_hide": {
+    "message": "元素消除器：點擊元素即可隱藏。",
+    "description": "Default status text in the in-page element zapper toolbar."
+  },
+  "zapper_button_undo": {
+    "message": "復原",
+    "description": "Button label to undo last zapper action."
+  },
+  "zapper_button_more": {
+    "message": "更多選項",
+    "description": "Tooltip label for the overflow menu button in zapper toolbar."
+  },
+  "zapper_button_add_custom_rule": {
+    "message": "新增自訂 CSS 規則…",
+    "description": "Menu item label for adding a manual CSS selector rule."
+  },
+  "zapper_button_done": {
+    "message": "完成",
+    "description": "Button label to finish zapper mode."
+  },
+  "zapper_button_select_parent": {
+    "message": "選擇父元素",
+    "description": "Tooltip for choosing the parent element in refine mode."
+  },
+  "zapper_button_select_child": {
+    "message": "選擇子元素",
+    "description": "Tooltip for choosing the child element in refine mode."
+  },
+  "zapper_button_hide": {
+    "message": "隱藏",
+    "description": "Button label for confirming hide action in refine mode."
+  },
+  "zapper_error_enter_selector": {
+    "message": "請輸入 CSS 選擇器。",
+    "description": "Validation error shown when manual selector input is empty."
+  },
+  "zapper_error_rule_syntax_invalid": {
+    "message": "CSS 規則語法無效。",
+    "description": "Validation error shown when manual CSS rule syntax is invalid."
+  },
+  "zapper_error_selector_too_long": {
+    "message": "選擇器太長。",
+    "description": "Validation error shown when manual selector exceeds max length."
+  },
+  "zapper_error_selector_syntax_invalid": {
+    "message": "選擇器語法無效。",
+    "description": "Validation error shown when selector cannot be parsed."
+  },
+  "zapper_toast_rule_exists": {
+    "message": "規則已存在。",
+    "description": "Toast shown when trying to add a duplicate manual rule."
+  },
+  "zapper_toast_already_hidden": {
+    "message": "已隱藏。",
+    "description": "Toast shown when picked element is already hidden by existing rule."
+  },
+  "zapper_toast_rule_saved": {
+    "message": "規則已儲存至此網站。",
+    "description": "Toast shown after successfully adding a manual rule."
+  },
+  "zapper_toast_hidden_and_saved": {
+    "message": "已隱藏。規則已儲存至此網站。",
+    "description": "Toast shown after hiding selected element and saving generated rule."
+  },
+  "zapper_prompt_enter_selector": {
+    "message": "請輸入此網站的 CSS 選擇器",
+    "description": "Prompt text shown when user adds a manual selector rule."
+  },
+  "zapper_toast_undone": {
+    "message": "已復原。",
+    "description": "Toast shown after undoing the last zapper action."
+  },
+  "zapper_status_refine": {
+    "message": "$1 — ▲▼ 可調整，點擊 $2 以儲存",
+    "description": "Refine-mode status text. Placeholder 1 is element label and placeholder 2 is hide action label."
+  },
+  "zapper_toast_unable_create_rule": {
+    "message": "無法為該元素建立規則。",
+    "description": "Toast shown when selector generation fails for selected element."
+  },
+  "zapper_toast_enabled": {
+    "message": "元素消除器已啟用。",
+    "description": "Toast shown when zapper mode is enabled."
+  },
+  "zapper_toast_disabled": {
+    "message": "元素消除器已停用。",
+    "description": "Toast shown when zapper mode is disabled."
+  },
+  "zapper_status_off": {
+    "message": "元素消除器：關閉",
+    "description": "Status text shown after disabling zapper while keeping toolbar visible."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.html
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.html
@@ -13,7 +13,7 @@
             <div class="top-text">
                 <div class="title-row">
                     <div class="title">wBlock</div>
-                    <div id="blocking-status" class="pill">Loading…</div>
+                    <div id="blocking-status" class="pill" data-i18n="popup_status_loading">Loading…</div>
                 </div>
                 <div class="subtitle" id="site-host">—</div>
             </div>
@@ -21,7 +21,7 @@
 
         <div class="section">
             <label class="toggle-row" for="disable-toggle">
-                <span class="label">Disable on this site</span>
+                <span class="label" data-i18n="popup_disable_on_site">Disable on this site</span>
                 <span class="switch">
                     <input id="disable-toggle" type="checkbox" />
                     <span class="slider" aria-hidden="true"></span>
@@ -31,24 +31,24 @@
 
         <div class="section">
             <div class="row">
-                <div class="label">Element zapper</div>
+                <div class="label" data-i18n="popup_element_zapper">Element zapper</div>
                 <div id="zapper-count" class="value">0</div>
             </div>
             <div class="button-row">
-                <button id="zapper-activate" class="btn btn-primary" type="button">Activate</button>
-                <button id="zapper-clear" class="btn btn-secondary" type="button" disabled>Clear</button>
+                <button id="zapper-activate" class="btn btn-primary" type="button" data-i18n="popup_button_activate">Activate</button>
+                <button id="zapper-clear" class="btn btn-secondary" type="button" disabled data-i18n="popup_button_clear">Clear</button>
             </div>
-            <div class="hint">Tap an element on the page to hide it. Use "Add Rule" in the zapper for manual selectors.</div>
+            <div class="hint" data-i18n="popup_hint_tap_to_hide">Tap an element on the page to hide it. Use "Add Rule" in the zapper for manual selectors.</div>
 
             <button id="zapper-rules-toggle" class="disclosure" type="button" aria-expanded="false">
-                <span>Rules</span>
+                <span data-i18n="popup_rules">Rules</span>
                 <span id="zapper-rules-chevron" class="chevron" aria-hidden="true">▾</span>
             </button>
             <div id="zapper-rules" class="rules" hidden></div>
         </div>
 
         <footer class="footer">
-            <button id="open-app" class="btn footer-btn" type="button" hidden>Open wBlock App</button>
+            <button id="open-app" class="btn footer-btn" type="button" hidden data-i18n="popup_button_open_app">Open wBlock App</button>
             <div id="error" class="error" hidden></div>
         </footer>
     </div>

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.js
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.js
@@ -3,6 +3,25 @@ const ZAPPER_STORAGE_PREFIX = 'wblock.zapperRules.v1:';
 const ZAPPER_META_PREFIX = 'wblock.zapperMeta.v1:';
 const SUPPORT_PROBE_TIMEOUT_MS = 800;
 
+function t(key, substitutions, fallback = '') {
+    const message = browser.i18n.getMessage(key, substitutions);
+    if (typeof message === 'string' && message.length > 0) {
+        return message;
+    }
+    return fallback;
+}
+
+function localizeStaticPopupText() {
+    const nodes = document.querySelectorAll('[data-i18n]');
+    for (const node of nodes) {
+        const key = node.getAttribute('data-i18n');
+        if (!key) continue;
+        const localized = t(key, undefined, '');
+        if (!localized) continue;
+        node.textContent = localized;
+    }
+}
+
 function normalizeDiagnosticFields(fields) {
     return Object.fromEntries(
         Object.entries(fields)
@@ -322,7 +341,7 @@ function renderZapperRules(rules) {
     if (!rules.length) {
         const empty = document.createElement('div');
         empty.className = 'rule-empty';
-        empty.textContent = 'No rules';
+        empty.textContent = t('popup_rules_empty', undefined, 'No rules');
         container.appendChild(empty);
         return;
     }
@@ -340,7 +359,7 @@ function renderZapperRules(rules) {
         del.type = 'button';
         del.className = 'rule-delete';
         del.setAttribute('data-index', String(index));
-        del.setAttribute('aria-label', 'Delete rule');
+        del.setAttribute('aria-label', t('popup_rule_delete_aria', undefined, 'Delete rule'));
         del.textContent = '✕';
 
         row.appendChild(text);
@@ -417,7 +436,7 @@ function setupListeners() {
                 renderZapperRules(currentZapperRules);
             } catch (error) {
                 console.error('[wBlock] Failed to toggle rules:', error);
-                setError('Failed to load rules.');
+                setError(t('popup_error_load_rules', undefined, 'Failed to load rules.'));
             }
         });
     }
@@ -440,7 +459,7 @@ function setupListeners() {
                 await notifyZapperRulesChanged(tab.id);
             } catch (error) {
                 console.error('[wBlock] Failed to delete rule:', error);
-                setError('Failed to delete rule.');
+                setError(t('popup_error_delete_rule', undefined, 'Failed to delete rule.'));
             }
         });
     }
@@ -451,7 +470,9 @@ function setupListeners() {
                 setError('');
                 disableToggle.disabled = true;
                 const next = disableToggle.checked;
-                setStatus(next ? 'Disabling…' : 'Enabling…', 'neutral');
+                setStatus(next
+                    ? t('popup_status_disabling', undefined, 'Disabling…')
+                    : t('popup_status_enabling', undefined, 'Enabling…'), 'neutral');
                 const updateResult = await setSiteDisabledState(host, next);
                 try {
                     await browser.runtime.sendMessage({ action: 'wblock:clearCache' });
@@ -460,11 +481,14 @@ function setupListeners() {
                 }
                 const settleMs = updateResult && updateResult.failedTargets > 0 ? 1200 : 350;
                 await sleep(settleMs);
-                setStatus(next ? 'Disabled' : 'Active', next ? 'disabled' : 'active');
+                setStatus(next
+                    ? t('popup_status_disabled', undefined, 'Disabled')
+                    : t('popup_status_active', undefined, 'Active'),
+                next ? 'disabled' : 'active');
                 await reloadActiveTab(tab.id);
             } catch (error) {
                 console.error('[wBlock] Failed to update disabled state:', error);
-                setError('Failed to update site setting.');
+                setError(t('popup_error_update_site_setting', undefined, 'Failed to update site setting.'));
                 disableToggle.checked = !disableToggle.checked;
             } finally {
                 disableToggle.disabled = false;
@@ -480,7 +504,7 @@ function setupListeners() {
                 window.close();
             } catch (error) {
                 console.error('[wBlock] Failed to activate zapper:', error);
-                setError('Element Zapper is unavailable on this page.');
+                setError(t('popup_error_zapper_unavailable', undefined, 'Element Zapper is unavailable on this page.'));
             }
         });
     }
@@ -498,10 +522,10 @@ function setupListeners() {
                     return;
                 }
 
-                setError((response && response.error) || 'Failed to open the app.');
+                setError((response && response.error) || t('popup_error_open_app', undefined, 'Failed to open the app.'));
             } catch (error) {
                 console.error('[wBlock] Failed to open app:', error);
-                setError('Failed to open the app.');
+                setError(t('popup_error_open_app', undefined, 'Failed to open the app.'));
             } finally {
                 openAppButton.disabled = false;
             }
@@ -522,7 +546,7 @@ function setupListeners() {
                 await reloadActiveTab(tab.id);
             } catch (error) {
                 console.error('[wBlock] Failed to clear zaps:', error);
-                setError('Failed to clear zapper rules.');
+                setError(t('popup_error_clear_rules', undefined, 'Failed to clear zapper rules.'));
             }
         });
     }
@@ -548,7 +572,7 @@ async function refreshUi() {
     if (hostEl) hostEl.textContent = host || '—';
 
     if (!pageSupport.supported || !contentScriptReachable) {
-        setStatus('Unsupported', 'neutral');
+        setStatus(t('popup_status_unsupported', undefined, 'Unsupported'), 'neutral');
         if (disableToggle) disableToggle.disabled = true;
         if (zapperActivate) zapperActivate.disabled = true;
         if (rulesToggle) rulesToggle.disabled = true;
@@ -566,14 +590,17 @@ async function refreshUi() {
         return;
     }
 
-    setStatus('Checking…', 'neutral');
+    setStatus(t('popup_status_checking', undefined, 'Checking…'), 'neutral');
 
     const disabled = await getSiteDisabledState(host);
     if (disableToggle) {
         disableToggle.checked = disabled;
         disableToggle.disabled = false;
     }
-    setStatus(disabled ? 'Disabled' : 'Active', disabled ? 'disabled' : 'active');
+    setStatus(disabled
+        ? t('popup_status_disabled', undefined, 'Disabled')
+        : t('popup_status_active', undefined, 'Active'),
+    disabled ? 'disabled' : 'active');
 
     if (rulesToggle) {
         rulesToggle.disabled = false;
@@ -587,9 +614,10 @@ async function refreshUi() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+    localizeStaticPopupText();
     setupListeners();
     refreshUi().catch((error) => {
         console.error('[wBlock] Popup init failed:', error);
-        setError('Failed to load popup.');
+        setError(t('popup_error_load_popup', undefined, 'Failed to load popup.'));
     });
 });

--- a/wBlock Scripts (iOS)/Resources/zapper-content.js
+++ b/wBlock Scripts (iOS)/Resources/zapper-content.js
@@ -17,6 +17,14 @@
   const MAX_RULES_PER_SITE = 200;
   const RULE_SYNC_INTERVAL_MS = 5000;
 
+  function t(key, substitutions, fallback = '') {
+    const message = browser.i18n.getMessage(key, substitutions);
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+    return fallback;
+  }
+
   const state = {
     active: false,
     host: '',
@@ -413,7 +421,7 @@
     const root = document.createElement('div');
     root.id = UI_ROOT_ID;
     root.setAttribute('role', 'dialog');
-    root.setAttribute('aria-label', 'wBlock Element Zapper');
+    root.setAttribute('aria-label', t('zapper_aria_label', undefined, 'wBlock Element Zapper'));
 
     const dragHint = document.createElement('div');
     dragHint.className = 'wblock-drag-hint';
@@ -423,14 +431,14 @@
 
     const status = document.createElement('div');
     status.className = 'wblock-status';
-    status.textContent = 'Element Zapper: Tap an element to hide it.';
+    status.textContent = t('zapper_status_tap_to_hide', undefined, 'Element Zapper: Tap an element to hide it.');
 
     const actions = document.createElement('div');
     actions.className = 'wblock-actions';
 
     const undoButton = document.createElement('button');
     undoButton.type = 'button';
-    undoButton.textContent = 'Undo';
+    undoButton.textContent = t('zapper_button_undo', undefined, 'Undo');
     undoButton.disabled = true;
     const onUndo = (e) => {
       if (e) {
@@ -450,14 +458,14 @@
     moreButton.type = 'button';
     moreButton.className = 'wblock-more-btn';
     moreButton.textContent = '\u00B7\u00B7\u00B7';
-    moreButton.title = 'More options';
+    moreButton.title = t('zapper_button_more', undefined, 'More options');
 
     const overflowMenu = document.createElement('div');
     overflowMenu.className = 'wblock-overflow';
 
     const manualButton = document.createElement('button');
     manualButton.type = 'button';
-    manualButton.textContent = 'Add custom CSS rule\u2026';
+    manualButton.textContent = t('zapper_button_add_custom_rule', undefined, 'Add custom CSS rule\u2026');
     const onManualRule = (e) => {
       if (e) {
         e.preventDefault();
@@ -494,7 +502,7 @@
     const doneButton = document.createElement('button');
     doneButton.type = 'button';
     doneButton.className = 'wblock-done-btn';
-    doneButton.textContent = 'Done';
+    doneButton.textContent = t('zapper_button_done', undefined, 'Done');
     const onDone = (e) => {
       if (e) {
         e.preventDefault();
@@ -519,7 +527,7 @@
     const parentButton = document.createElement('button');
     parentButton.type = 'button';
     parentButton.textContent = '\u25B2';
-    parentButton.title = 'Select parent element';
+    parentButton.title = t('zapper_button_select_parent', undefined, 'Select parent element');
     parentButton.disabled = true;
     const onParent = (e) => {
       if (e) { e.preventDefault(); e.stopPropagation(); if (typeof e.stopImmediatePropagation === 'function') e.stopImmediatePropagation(); }
@@ -530,7 +538,7 @@
     const childButton = document.createElement('button');
     childButton.type = 'button';
     childButton.textContent = '\u25BC';
-    childButton.title = 'Select child element';
+    childButton.title = t('zapper_button_select_child', undefined, 'Select child element');
     childButton.disabled = true;
     const onChild = (e) => {
       if (e) { e.preventDefault(); e.stopPropagation(); if (typeof e.stopImmediatePropagation === 'function') e.stopImmediatePropagation(); }
@@ -541,7 +549,7 @@
     const hideButton = document.createElement('button');
     hideButton.type = 'button';
     hideButton.className = 'wblock-hide-btn';
-    hideButton.textContent = '\u2713 Hide';
+    hideButton.textContent = `\u2713 ${t('zapper_button_hide', undefined, 'Hide')}`;
     const onHide = (e) => {
       if (e) { e.preventDefault(); e.stopPropagation(); if (typeof e.stopImmediatePropagation === 'function') e.stopImmediatePropagation(); }
       confirmHide();
@@ -720,7 +728,7 @@
   function parseManualRuleInput(input) {
     const raw = String(input || '').trim();
     if (!raw) {
-      return { selector: '', error: 'Enter a CSS selector.' };
+      return { selector: '', error: t('zapper_error_enter_selector', undefined, 'Enter a CSS selector.') };
     }
 
     let selector = raw;
@@ -728,24 +736,24 @@
       const openIndex = raw.indexOf('{');
       const closeIndex = raw.lastIndexOf('}');
       if (closeIndex <= openIndex) {
-        return { selector: '', error: 'CSS rule syntax is invalid.' };
+        return { selector: '', error: t('zapper_error_rule_syntax_invalid', undefined, 'CSS rule syntax is invalid.') };
       }
       if (raw.slice(closeIndex + 1).trim().length > 0) {
-        return { selector: '', error: 'CSS rule syntax is invalid.' };
+        return { selector: '', error: t('zapper_error_rule_syntax_invalid', undefined, 'CSS rule syntax is invalid.') };
       }
       selector = raw.slice(0, openIndex).trim();
     } else if (raw.includes('}')) {
-      return { selector: '', error: 'CSS rule syntax is invalid.' };
+      return { selector: '', error: t('zapper_error_rule_syntax_invalid', undefined, 'CSS rule syntax is invalid.') };
     }
 
     if (!selector) {
-      return { selector: '', error: 'Enter a CSS selector.' };
+      return { selector: '', error: t('zapper_error_enter_selector', undefined, 'Enter a CSS selector.') };
     }
     if (selector.length > 512) {
-      return { selector: '', error: 'Selector is too long.' };
+      return { selector: '', error: t('zapper_error_selector_too_long', undefined, 'Selector is too long.') };
     }
     if (!isValidCssSelector(selector)) {
-      return { selector: '', error: 'Selector syntax is invalid.' };
+      return { selector: '', error: t('zapper_error_selector_syntax_invalid', undefined, 'Selector syntax is invalid.') };
     }
 
     return { selector, error: '' };
@@ -755,7 +763,9 @@
     const normalized = (selector || '').trim();
     if (!normalized) return;
     if (state.rules.includes(normalized)) {
-      showToast(options.manual ? 'Rule already exists.' : 'Already hidden.');
+      showToast(options.manual
+        ? t('zapper_toast_rule_exists', undefined, 'Rule already exists.')
+        : t('zapper_toast_already_hidden', undefined, 'Already hidden.'));
       return;
     }
     state.rules = state.rules.concat([normalized]).slice(0, MAX_RULES_PER_SITE);
@@ -763,11 +773,13 @@
     await trackPendingSave(saveRulesForHost(state.host, state.rules));
     applyRulesToPage(state.rules);
     if (state.ui.undoButton) state.ui.undoButton.disabled = false;
-    showToast(options.manual ? 'Rule saved for this site.' : 'Hidden. Rule saved for this site.');
+    showToast(options.manual
+      ? t('zapper_toast_rule_saved', undefined, 'Rule saved for this site.')
+      : t('zapper_toast_hidden_and_saved', undefined, 'Hidden. Rule saved for this site.'));
   }
 
   async function addManualRuleFromPrompt() {
-    const rawInput = window.prompt('Enter CSS selector for this site');
+    const rawInput = window.prompt(t('zapper_prompt_enter_selector', undefined, 'Enter CSS selector for this site'));
     if (rawInput === null) return;
 
     const parsed = parseManualRuleInput(rawInput);
@@ -786,7 +798,7 @@
     await trackPendingSave(saveRulesForHost(state.host, state.rules));
     applyRulesToPage(state.rules);
     if (state.ui.undoButton) state.ui.undoButton.disabled = state.undoStack.length === 0;
-    showToast('Undone.');
+    showToast(t('zapper_toast_undone', undefined, 'Undone.'));
   }
 
   function addCleanup(fn) {
@@ -883,14 +895,22 @@
     if (state.ui.defaultGroup) state.ui.defaultGroup.style.display = 'flex';
     const actionsEl = state.ui.doneButton && state.ui.doneButton.parentElement;
     if (actionsEl) actionsEl.classList.remove('wblock-refine-active');
-    if (state.ui.statusText) state.ui.statusText.textContent = 'Element Zapper: Tap an element to hide it.';
+    if (state.ui.statusText) {
+      state.ui.statusText.textContent = t('zapper_status_tap_to_hide', undefined, 'Element Zapper: Tap an element to hide it.');
+    }
   }
 
   function updateRefineStatus() {
     const el = state.candidateElement;
     if (!el) return;
     const label = elementLabel(el);
-    if (state.ui.statusText) state.ui.statusText.textContent = `${label} — ▲▼ to adjust, tap Hide to save`;
+    if (state.ui.statusText) {
+      state.ui.statusText.textContent = t(
+        'zapper_status_refine',
+        [label, t('zapper_button_hide', undefined, 'Hide')],
+        `${label} — ▲▼ to adjust, tap Hide to save`
+      );
+    }
     const parent = el.parentElement;
     const atTop = !parent || parent === document.body || parent === document.documentElement;
     if (state.ui.parentButton) state.ui.parentButton.disabled = atTop;
@@ -921,7 +941,7 @@
     if (!el) return;
     const selector = selectorForElement(el);
     if (!selector) {
-      showToast('Unable to create a rule for that element.');
+      showToast(t('zapper_toast_unable_create_rule', undefined, 'Unable to create a rule for that element.'));
       exitRefineMode();
       return;
     }
@@ -943,8 +963,10 @@
     if (state.ui.undoButton) state.ui.undoButton.disabled = true;
     if (state.ui.navGroup) state.ui.navGroup.classList.remove('wblock-active');
     if (state.ui.defaultGroup) state.ui.defaultGroup.style.display = 'flex';
-    if (state.ui.statusText) state.ui.statusText.textContent = 'Element Zapper: Tap an element to hide it.';
-    showToast('Element Zapper enabled.');
+    if (state.ui.statusText) {
+      state.ui.statusText.textContent = t('zapper_status_tap_to_hide', undefined, 'Element Zapper: Tap an element to hide it.');
+    }
+    showToast(t('zapper_toast_enabled', undefined, 'Element Zapper enabled.'));
 
     // After the popup closes, keyboard focus stays on Safari's chrome.
     // Without explicit focus, keydown events (like Escape) never reach our
@@ -1083,8 +1105,8 @@
       return;
     }
 
-    showToast('Element Zapper disabled.');
-    if (state.ui.statusText) state.ui.statusText.textContent = 'Element Zapper: Off';
+    showToast(t('zapper_toast_disabled', undefined, 'Element Zapper disabled.'));
+    if (state.ui.statusText) state.ui.statusText.textContent = t('zapper_status_off', undefined, 'Element Zapper: Off');
   }
 
   async function refreshRulesFromNativeIfNeeded() {


### PR DESCRIPTION
Translations are generated by LLM, taking into account the existing translations in the project. Still needs QA.
Javascript i18n only. Independent from swift localization.strings.