### PR TITLE
support older apple os releases

### DIFF
--- a/FilterUpdateAgent/main.swift
+++ b/FilterUpdateAgent/main.swift
@@ -7,7 +7,7 @@ let logger = Logger(subsystem: "skula.wBlock.FilterUpdateAgent", category: "Auto
 
 Task {
     logger.info("Launch agent helper started")
-    let success = await FilterUpdateClient.shared.updateFilters(timeout: 180)
+    let success = await FilterAutoUpdateRunner.run(trigger: "LaunchAgent", timeout: 180)
     logger.info("Launch agent helper finished with success=\(success, privacy: .public)")
     exit(success ? EXIT_SUCCESS : EXIT_FAILURE)
 }

--- a/FilterUpdateLoginItem/FilterUpdateLoginItem.entitlements
+++ b/FilterUpdateLoginItem/FilterUpdateLoginItem.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.skula.wBlock</string>
+	</array>
+</dict>
+</plist>

--- a/FilterUpdateLoginItem/Info.plist
+++ b/FilterUpdateLoginItem/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSBackgroundOnly</key>
+	<true/>
+</dict>
+</plist>

--- a/FilterUpdateLoginItem/main.swift
+++ b/FilterUpdateLoginItem/main.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Darwin
+import os.log
+import wBlockCoreService
+
+let logger = Logger(subsystem: "skula.wBlock.FilterUpdateLoginItem", category: "AutoUpdate")
+
+if #available(macOS 13.0, *) {
+    logger.info("Legacy login item is not used on macOS 13 or newer")
+    exit(EXIT_SUCCESS)
+}
+
+Task {
+    logger.info("Legacy login item helper started")
+
+    while !Task.isCancelled {
+        _ = await FilterAutoUpdateRunner.run(trigger: "LegacyLoginItem", timeout: 180)
+        try? await TaskSleep.sleep(for: .seconds(15 * 60))
+    }
+
+    exit(EXIT_SUCCESS)
+}
+
+dispatchMain()

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -78,6 +78,19 @@ if [[ -n "${TEAM_ID}" ]]; then
       fi
     done
   fi
+
+  # Patch login item plists so shared app-group lookup sees the team prefix
+  if [[ -d "${APP_PATH}/Contents/Library/LoginItems" ]]; then
+    for login_item_plist in "${APP_PATH}/Contents/Library/LoginItems/"*.app/Contents/Info.plist; do
+      if [[ -f "${login_item_plist}" ]]; then
+        if ! /usr/libexec/PlistBuddy -c "Print :AppIdentifierPrefix" "${login_item_plist}" &>/dev/null; then
+          /usr/libexec/PlistBuddy -c "Add :AppIdentifierPrefix string ${TEAM_ID}." "${login_item_plist}"
+        else
+          /usr/libexec/PlistBuddy -c "Set :AppIdentifierPrefix ${TEAM_ID}." "${login_item_plist}"
+        fi
+      fi
+    done
+  fi
 fi
 
 if [[ -n "${SIGNING_IDENTITY}" ]]; then
@@ -191,6 +204,31 @@ if [[ -n "${SIGNING_IDENTITY}" ]]; then
         sign_item "${helper}"
       fi
     done < <(find "${APP_PATH}/Contents/MacOS" -maxdepth 1 -type f -perm -111 -print0)
+  fi
+
+  # Sign embedded login item apps before signing the outer app.
+  if [[ -d "${APP_PATH}/Contents/Library/LoginItems" ]]; then
+    while IFS= read -r -d '' login_item; do
+      if [[ -d "${login_item}/Contents/Frameworks" ]]; then
+        while IFS= read -r -d '' nested; do
+          sign_item "${nested}"
+        done < <(find "${login_item}/Contents/Frameworks" -maxdepth 1 \( -name "*.framework" -o -name "*.dylib" \) -print0)
+      fi
+
+      login_item_name="$(basename "${login_item}" .app)"
+      entitlements=""
+      case "${login_item_name}" in
+        "FilterUpdateLoginItem") entitlements="${ROOT_DIR}/FilterUpdateLoginItem/FilterUpdateLoginItem.entitlements" ;;
+      esac
+
+      if [[ -n "${entitlements}" && -f "${entitlements}" ]]; then
+        modified_ent="$(prepare_entitlements "${entitlements}")"
+        sign_item "${login_item}" "${modified_ent}"
+        rm -f "${modified_ent}"
+      else
+        sign_item "${login_item}"
+      fi
+    done < <(find "${APP_PATH}/Contents/Library/LoginItems" -maxdepth 1 -name "*.app" -print0)
   fi
 
   # Sign the main app last (outermost)

--- a/wBlock.xcodeproj/project.pbxproj
+++ b/wBlock.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		867CCA302F696EA200719EFE /* wBlock Scripts.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 867CCA182F696EA200719EFE /* wBlock Scripts.appex */; platformFilters = (macos, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		867CCA392F696F2200719EFE /* wBlockCoreService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A41C452DE089C50056F63D /* wBlockCoreService.framework */; };
 		867CCA3A2F696F2200719EFE /* wBlockCoreService.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C1A41C452DE089C50056F63D /* wBlockCoreService.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F00100000000000000000001 /* FilterUpdateLoginItem.app in Embed Login Items */ = {isa = PBXBuildFile; fileRef = F00100000000000000000003 /* FilterUpdateLoginItem.app */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F00100000000000000000002 /* wBlockCoreService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A41C452DE089C50056F63D /* wBlockCoreService.framework */; };
+		F00100000000000000000012 /* wBlockCoreService.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C1A41C452DE089C50056F63D /* wBlockCoreService.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8A39DAA348FC4B7F8774AFFD /* wBlockCoreService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A41C452DE089C50056F63D /* wBlockCoreService.framework */; };
 		C1A287482E73617D00F5B43D /* FilterUpdateService.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = C1A2873D2E73617D00F5B43D /* FilterUpdateService.xpc */; platformFilters = (macos, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		C1A2874F2E7361D000F5B43D /* wBlockCoreService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A41C452DE089C50056F63D /* wBlockCoreService.framework */; };
@@ -60,6 +63,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = A2F7A1E63BF14D97B6A86B9F;
 			remoteInfo = FilterUpdateAgent;
+		};
+		F0010000000000000000000B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C1A41C252DE0897C0056F63D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F00100000000000000000009;
+			remoteInfo = FilterUpdateLoginItem;
+		};
+		F0010000000000000000000F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C1A41C252DE0897C0056F63D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C1A41C442DE089C50056F63D;
+			remoteInfo = wBlockCoreService;
 		};
 		867CCA2E2F696EA200719EFE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -208,6 +225,17 @@
 			name = "Embed Launch Agents";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F00100000000000000000008 /* Embed Login Items */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Library/LoginItems";
+			dstSubfolderSpec = 16;
+			files = (
+				F00100000000000000000001 /* FilterUpdateLoginItem.app in Embed Login Items */,
+			);
+			name = "Embed Login Items";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		867CCA3D2F696F2200719EFE /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -215,6 +243,17 @@
 			dstSubfolderSpec = 10;
 			files = (
 				867CCA3A2F696F2200719EFE /* wBlockCoreService.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F00100000000000000000011 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				F00100000000000000000012 /* wBlockCoreService.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -283,6 +322,7 @@
 		867CCA182F696EA200719EFE /* wBlock Scripts.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "wBlock Scripts.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABB624B3E5C14E8CBFCA4484 /* skula.wBlock.FilterUpdateAgent.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = skula.wBlock.FilterUpdateAgent.plist; sourceTree = "<group>"; };
 		BB792A9EC0684311ACB5C861 /* FilterUpdateAgent */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = FilterUpdateAgent; sourceTree = BUILT_PRODUCTS_DIR; };
+		F00100000000000000000003 /* FilterUpdateLoginItem.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FilterUpdateLoginItem.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1A2873D2E73617D00F5B43D /* FilterUpdateService.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = FilterUpdateService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1A41C2D2DE0897C0056F63D /* wBlock.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = wBlock.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1A41C452DE089C50056F63D /* wBlockCoreService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = wBlockCoreService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -337,6 +377,14 @@
 				Info.plist,
 			);
 			target = C1A2873C2E73617D00F5B43D /* FilterUpdateService */;
+		};
+		F00100000000000000000013 /* Exceptions for "FilterUpdateLoginItem" folder in "FilterUpdateLoginItem" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				FilterUpdateLoginItem.entitlements,
+				Info.plist,
+			);
+			target = F00100000000000000000009 /* FilterUpdateLoginItem */;
 		};
 		C1A41C3A2DE0897D0056F63D /* Exceptions for "wBlock" folder in "wBlock" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
@@ -440,6 +488,14 @@
 				C1A2874C2E73617D00F5B43D /* Exceptions for "FilterUpdateService" folder in "FilterUpdateService" target */,
 			);
 			path = FilterUpdateService;
+			sourceTree = "<group>";
+		};
+		F00100000000000000000004 /* FilterUpdateLoginItem */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				F00100000000000000000013 /* Exceptions for "FilterUpdateLoginItem" folder in "FilterUpdateLoginItem" target */,
+			);
+			path = FilterUpdateLoginItem;
 			sourceTree = "<group>";
 		};
 		C1A41C2F2DE0897C0056F63D /* wBlock */ = {
@@ -570,6 +626,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A39DAA348FC4B7F8774AFFD /* wBlockCoreService.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F00100000000000000000006 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F00100000000000000000002 /* wBlockCoreService.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -763,6 +827,7 @@
 				C1F16CAC2DE355DE0031E7EF /* wBlock Custom (iOS) */,
 				C1A2873E2E73617D00F5B43D /* FilterUpdateService */,
 				19A5776A6FD74CF39C610F99 /* FilterUpdateAgent */,
+				F00100000000000000000004 /* FilterUpdateLoginItem */,
 				867CCA192F696EA200719EFE /* wBlock Scripts */,
 				C1A41C6A2DE08AD30056F63D /* Frameworks */,
 				C1A41C2E2DE0897C0056F63D /* Products */,
@@ -788,6 +853,7 @@
 				C1F16CAB2DE355DE0031E7EF /* wBlock Custom iOS.appex */,
 				C1A2873D2E73617D00F5B43D /* FilterUpdateService.xpc */,
 				BB792A9EC0684311ACB5C861 /* FilterUpdateAgent */,
+				F00100000000000000000003 /* FilterUpdateLoginItem.app */,
 				867CCA182F696EA200719EFE /* wBlock Scripts.appex */,
 			);
 			name = Products;
@@ -858,6 +924,30 @@
 			productReference = BB792A9EC0684311ACB5C861 /* FilterUpdateAgent */;
 			productType = "com.apple.product-type.tool";
 		};
+		F00100000000000000000009 /* FilterUpdateLoginItem */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F0010000000000000000000E /* Build configuration list for PBXNativeTarget "FilterUpdateLoginItem" */;
+			buildPhases = (
+				F00100000000000000000005 /* Sources */,
+				F00100000000000000000006 /* Frameworks */,
+				F00100000000000000000007 /* Resources */,
+				F00100000000000000000011 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F00100000000000000000010 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				F00100000000000000000004 /* FilterUpdateLoginItem */,
+			);
+			name = FilterUpdateLoginItem;
+			packageProductDependencies = (
+			);
+			productName = FilterUpdateLoginItem;
+			productReference = F00100000000000000000003 /* FilterUpdateLoginItem.app */;
+			productType = "com.apple.product-type.application";
+		};
 		C1A2873C2E73617D00F5B43D /* FilterUpdateService */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C1A287492E73617D00F5B43D /* Build configuration list for PBXNativeTarget "FilterUpdateService" */;
@@ -892,12 +982,14 @@
 				C1A2874D2E73617D00F5B43D /* Embed XPC Services */,
 				B48F1A766F504E9084FB6A9D /* Embed Helper Executables */,
 				093FF2B3D8FF427095202FE5 /* Embed Launch Agents */,
+				F00100000000000000000008 /* Embed Login Items */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				C1A41C4C2DE089C50056F63D /* PBXTargetDependency */,
 				D5FCECBF423348439B5AED9F /* PBXTargetDependency */,
+				F0010000000000000000000A /* PBXTargetDependency */,
 				C1A41C752DE08AD30056F63D /* PBXTargetDependency */,
 				C1A41C882DE08BDA0056F63D /* PBXTargetDependency */,
 				C1A41CCD2DE08CAB0056F63D /* PBXTargetDependency */,
@@ -1351,6 +1443,7 @@
 				C1A41C2C2DE0897C0056F63D /* wBlock */,
 				C1A41C442DE089C50056F63D /* wBlockCoreService */,
 				A2F7A1E63BF14D97B6A86B9F /* FilterUpdateAgent */,
+				F00100000000000000000009 /* FilterUpdateLoginItem */,
 				C1A41C682DE08AD30056F63D /* wBlock Ads */,
 				C1F16BEE2DE354C30031E7EF /* wBlock Security */,
 				C1F16C022DE354E40031E7EF /* wBlock Privacy */,
@@ -1370,6 +1463,13 @@
 
 /* Begin PBXResourcesBuildPhase section */
 		5F398FC94DF446C7A1A5A11F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F00100000000000000000007 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1527,6 +1627,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F00100000000000000000005 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C1A41C292DE0897C0056F63D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1646,6 +1753,19 @@
 			isa = PBXTargetDependency;
 			target = C1A41C442DE089C50056F63D /* wBlockCoreService */;
 			targetProxy = B975D9560C464A97B4EB33E4 /* PBXContainerItemProxy */;
+		};
+		F0010000000000000000000A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				macos,
+			);
+			target = F00100000000000000000009 /* FilterUpdateLoginItem */;
+			targetProxy = F0010000000000000000000B /* PBXContainerItemProxy */;
+		};
+		F00100000000000000000010 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C1A41C442DE089C50056F63D /* wBlockCoreService */;
+			targetProxy = F0010000000000000000000F /* PBXContainerItemProxy */;
 		};
 		867CCA2F2F696EA200719EFE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1802,6 +1922,76 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		F0010000000000000000000C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = FilterUpdateLoginItem/FilterUpdateLoginItem.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DNP7DGUB7B;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = FilterUpdateLoginItem/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = FilterUpdateLoginItem;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 2.0.4;
+				PRODUCT_BUNDLE_IDENTIFIER = skula.wBlock.FilterUpdateLoginItem;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				SUPPORTED_PLATFORMS = macosx;
+			};
+			name = Debug;
+		};
+		F0010000000000000000000D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = FilterUpdateLoginItem/FilterUpdateLoginItem.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DNP7DGUB7B;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = FilterUpdateLoginItem/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = FilterUpdateLoginItem;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 2.0.4;
+				PRODUCT_BUNDLE_IDENTIFIER = skula.wBlock.FilterUpdateLoginItem;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				SUPPORTED_PLATFORMS = macosx;
+			};
+			name = Release;
+		};
 		4A197C85937143978D7A5A52 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1830,7 +2020,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = skula.wBlock.FilterUpdateAgent;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1876,7 +2066,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -1932,7 +2122,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -1985,7 +2175,7 @@
 					"$(inherited)",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = skula.wBlock.FilterUpdateService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2028,7 +2218,7 @@
 					"$(inherited)",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = skula.wBlock.FilterUpdateService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2073,10 +2263,10 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = skula.wBlock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2121,10 +2311,10 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = skula.wBlock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2278,7 +2468,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
@@ -2287,7 +2477,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
@@ -2325,7 +2515,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
@@ -2334,7 +2524,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
@@ -2373,7 +2563,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "skula.wBlock.wBlock-Ads";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2403,7 +2593,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "skula.wBlock.wBlock-Ads";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2426,7 +2616,7 @@
 				INFOPLIST_FILE = "wBlock Ads (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 1";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2457,7 +2647,7 @@
 				INFOPLIST_FILE = "wBlock Ads (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 1";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2490,7 +2680,7 @@
 				INFOPLIST_FILE = "wBlock Scripts (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Scripts";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2526,7 +2716,7 @@
 				INFOPLIST_FILE = "wBlock Scripts (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Scripts";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2571,7 +2761,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "skula.wBlock.wBlock-Security";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2603,7 +2793,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "skula.wBlock.wBlock-Security";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2635,7 +2825,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "skula.wBlock.wBlock-Privacy";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2667,7 +2857,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "skula.wBlock.wBlock-Privacy";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2699,7 +2889,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "skula.wBlock.wBlock-Foreign";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2731,7 +2921,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "skula.wBlock.wBlock-Foreign";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2763,7 +2953,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "skula.wBlock.wBlock-Custom";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2795,7 +2985,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "skula.wBlock.wBlock-Custom";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2818,7 +3008,7 @@
 				INFOPLIST_FILE = "wBlock Privacy (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 2";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2849,7 +3039,7 @@
 				INFOPLIST_FILE = "wBlock Privacy (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 2";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2881,7 +3071,7 @@
 				INFOPLIST_FILE = "wBlock Security (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 3";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2912,7 +3102,7 @@
 				INFOPLIST_FILE = "wBlock Security (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 3";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2944,7 +3134,7 @@
 				INFOPLIST_FILE = "wBlock Privacy (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 2";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2975,7 +3165,7 @@
 				INFOPLIST_FILE = "wBlock Privacy (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 2";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3007,7 +3197,7 @@
 				INFOPLIST_FILE = "wBlock Multipurpose (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Multipurpose";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3038,7 +3228,7 @@
 				INFOPLIST_FILE = "wBlock Multipurpose (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Multipurpose";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3070,7 +3260,7 @@
 				INFOPLIST_FILE = "wBlock Foreign (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 4";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3101,7 +3291,7 @@
 				INFOPLIST_FILE = "wBlock Foreign (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 4";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3133,7 +3323,7 @@
 				INFOPLIST_FILE = "wBlock Experimental (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Experimental";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3164,7 +3354,7 @@
 				INFOPLIST_FILE = "wBlock Experimental (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock Experimental";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3196,7 +3386,7 @@
 				INFOPLIST_FILE = "wBlock Custom (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 5";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3227,7 +3417,7 @@
 				INFOPLIST_FILE = "wBlock Custom (iOS)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "wBlock 5";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3276,7 +3466,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = skula.wBlock.FilterUpdateAgent;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3470,6 +3660,15 @@
 			buildConfigurations = (
 				E7FEBCCE114E4D709B07336D /* Debug */,
 				4A197C85937143978D7A5A52 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F0010000000000000000000E /* Build configuration list for PBXNativeTarget "FilterUpdateLoginItem" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F0010000000000000000000C /* Debug */,
+				F0010000000000000000000D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/wBlock/AutoUpdateLaunchAgentManager.swift
+++ b/wBlock/AutoUpdateLaunchAgentManager.swift
@@ -2,11 +2,13 @@
 import Foundation
 import ServiceManagement
 import os.log
+import wBlockCoreService
 
 @MainActor
 final class AutoUpdateLaunchAgentManager {
     static let shared = AutoUpdateLaunchAgentManager()
     static let plistName = "skula.wBlock.FilterUpdateAgent.plist"
+    static let loginItemBundleIdentifier = "skula.wBlock.FilterUpdateLoginItem"
 
     struct RegistrationStatus: Equatable {
         enum State: Equatable {
@@ -33,16 +35,35 @@ final class AutoUpdateLaunchAgentManager {
 
     private init() {}
 
-    private var service: SMAppService {
-        SMAppService.agent(plistName: Self.plistName)
-    }
-
     func currentStatus() -> RegistrationStatus {
-        status(from: service.status)
+        if #available(macOS 13.0, *) {
+            return status(from: modernService.status)
+        }
+        return legacyStatus()
     }
 
     @discardableResult
     func reconcileWithAutoUpdateSetting(_ enabled: Bool) -> RegistrationStatus {
+        if #available(macOS 13.0, *) {
+            return reconcileModernService(enabled)
+        }
+        return reconcileLegacyLoginItem(enabled)
+    }
+
+    func openLoginItemsSettings() {
+        if #available(macOS 13.0, *) {
+            SMAppService.openSystemSettingsLoginItems()
+        }
+    }
+
+    @available(macOS 13.0, *)
+    private var modernService: SMAppService {
+        SMAppService.agent(plistName: Self.plistName)
+    }
+
+    @available(macOS 13.0, *)
+    private func reconcileModernService(_ enabled: Bool) -> RegistrationStatus {
+        let service = modernService
         let current = service.status
 
         do {
@@ -69,23 +90,45 @@ final class AutoUpdateLaunchAgentManager {
             )
         }
 
-        return currentStatus()
+        return status(from: service.status)
     }
 
-    func openLoginItemsSettings() {
-        SMAppService.openSystemSettingsLoginItems()
+    private func reconcileLegacyLoginItem(_ enabled: Bool) -> RegistrationStatus {
+        guard legacyLoginItemExists else {
+            return notFoundStatus()
+        }
+
+        let succeeded = SMLoginItemSetEnabled(Self.loginItemBundleIdentifier as CFString, enabled)
+        guard succeeded else {
+            logger.error("Legacy login item reconcile failed")
+            return unavailableStatus()
+        }
+
+        return enabled ? enabledStatus() : notRegisteredStatus()
     }
 
+    private func legacyStatus() -> RegistrationStatus {
+        guard legacyLoginItemExists else {
+            return notFoundStatus()
+        }
+
+        return ProtobufDataManager.shared.autoUpdateEnabled ? enabledStatus() : notRegisteredStatus()
+    }
+
+    private var legacyLoginItemExists: Bool {
+        let loginItemURL = Bundle.main.bundleURL
+            .appendingPathComponent("Contents")
+            .appendingPathComponent("Library")
+            .appendingPathComponent("LoginItems")
+            .appendingPathComponent("FilterUpdateLoginItem.app")
+        return FileManager.default.fileExists(atPath: loginItemURL.path)
+    }
+
+    @available(macOS 13.0, *)
     private func status(from serviceStatus: SMAppService.Status) -> RegistrationStatus {
         switch serviceStatus {
         case .enabled:
-            return RegistrationStatus(
-                state: .enabled,
-                detail: LocalizedStrings.text(
-                    "Background agent registered",
-                    comment: "Background auto-update agent status detail"
-                )
-            )
+            return enabledStatus()
         case .requiresApproval:
             return RegistrationStatus(
                 state: .requiresApproval,
@@ -95,30 +138,52 @@ final class AutoUpdateLaunchAgentManager {
                 )
             )
         case .notRegistered:
-            return RegistrationStatus(
-                state: .notRegistered,
-                detail: LocalizedStrings.text(
-                    "Background agent not registered",
-                    comment: "Background auto-update agent status detail"
-                )
-            )
+            return notRegisteredStatus()
         case .notFound:
-            return RegistrationStatus(
-                state: .notFound,
-                detail: LocalizedStrings.text(
-                    "Bundled background agent missing from app build",
-                    comment: "Background auto-update agent status detail"
-                )
-            )
+            return notFoundStatus()
         @unknown default:
-            return RegistrationStatus(
-                state: .unavailable,
-                detail: LocalizedStrings.text(
-                    "Background agent status unavailable",
-                    comment: "Background auto-update agent status detail"
-                )
-            )
+            return unavailableStatus()
         }
+    }
+
+    private func enabledStatus() -> RegistrationStatus {
+        RegistrationStatus(
+            state: .enabled,
+            detail: LocalizedStrings.text(
+                "Background agent registered",
+                comment: "Background auto-update agent status detail"
+            )
+        )
+    }
+
+    private func notRegisteredStatus() -> RegistrationStatus {
+        RegistrationStatus(
+            state: .notRegistered,
+            detail: LocalizedStrings.text(
+                "Background agent not registered",
+                comment: "Background auto-update agent status detail"
+            )
+        )
+    }
+
+    private func notFoundStatus() -> RegistrationStatus {
+        RegistrationStatus(
+            state: .notFound,
+            detail: LocalizedStrings.text(
+                "Bundled background agent missing from app build",
+                comment: "Background auto-update agent status detail"
+            )
+        )
+    }
+
+    private func unavailableStatus() -> RegistrationStatus {
+        RegistrationStatus(
+            state: .unavailable,
+            detail: LocalizedStrings.text(
+                "Background agent status unavailable",
+                comment: "Background auto-update agent status detail"
+            )
+        )
     }
 }
 #endif

--- a/wBlock/CloudSyncManager.swift
+++ b/wBlock/CloudSyncManager.swift
@@ -388,7 +388,7 @@ final class CloudSyncManager: ObservableObject {
                     }
                 }
                 guard let self else { return }
-                try? await Task.sleep(for: .seconds(2))
+                try? await TaskSleep.sleep(for: .seconds(2))
                 await self.uploadLatestPayload(trigger: immediateTrigger)
             }
             pendingUploadTask = task
@@ -448,7 +448,7 @@ final class CloudSyncManager: ObservableObject {
         }
     }
 
-    private func retryDelay(for error: CKError) -> Duration? {
+    private func retryDelay(for error: CKError) -> AsyncDelay? {
         if let retryAfter = error.userInfo[CKErrorRetryAfterKey] as? TimeInterval, retryAfter > 0 {
             return .milliseconds(max(250, Int(retryAfter * 1000)))
         }
@@ -1452,7 +1452,7 @@ final class CloudSyncManager: ObservableObject {
             logger.info(
                 "CloudKit save failed with retryable error \(ckError.code.rawValue, privacy: .public), retrying in \(String(describing: delay), privacy: .public)"
             )
-            try await Task.sleep(for: delay)
+            try await TaskSleep.sleep(for: delay)
             return try await saveRecord(
                 record,
                 retryPayload: retryPayload,

--- a/wBlock/ContentView.swift
+++ b/wBlock/ContentView.swift
@@ -136,11 +136,11 @@ struct ContentView: View {
                 EditCustomFilterNameView(filterManager: filterManager, filter: filter)
             }
         }
-        .onChange(of: dataManager.isForeignFiltersExpanded) { _, newValue in
+        .onChangeCompat(of: dataManager.isForeignFiltersExpanded) { _, newValue in
             guard isForeignFiltersExpanded != newValue else { return }
             isForeignFiltersExpanded = newValue
         }
-        .onChange(of: isForeignFiltersExpanded) { _, newValue in
+        .onChangeCompat(of: isForeignFiltersExpanded) { _, newValue in
             guard dataManager.isForeignFiltersExpanded != newValue else { return }
             Task {
                 await dataManager.setIsForeignFiltersExpanded(newValue)
@@ -179,7 +179,7 @@ struct ContentView: View {
     }
 
     private var filtersView: some View {
-        NavigationStack {
+        CompatibleNavigationStack {
             nativeFiltersListView
             #if os(iOS)
                 .navigationBarTitleDisplayMode(.inline)
@@ -213,7 +213,7 @@ struct ContentView: View {
             #endif
         }
         #if os(iOS)
-            .searchable(
+            .searchableCompat(
                 text: $filterSearchText,
                 isPresented: $showFilterSearch,
                 prompt: "Search filters"
@@ -314,7 +314,7 @@ struct ContentView: View {
     }
 
     private var userscriptsView: some View {
-        NavigationStack {
+        CompatibleNavigationStack {
             UserScriptManagerView(
                 userScriptManager: userScriptManager,
                 hasPendingChanges: hasPendingChanges,
@@ -718,7 +718,7 @@ struct ContentModifiers: ViewModifier {
                 }
             }
             // React to hasCompletedOnboarding changes
-            .onChange(of: dataManager.hasCompletedOnboarding) { oldValue, newValue in
+            .onChangeCompat(of: dataManager.hasCompletedOnboarding) { oldValue, newValue in
                 if newValue && !oldValue {
                     showOnboardingSheet = false
                 } else if !newValue && oldValue {
@@ -727,7 +727,7 @@ struct ContentModifiers: ViewModifier {
                 }
             }
             #if os(iOS)
-                .onChange(of: scenePhase) { oldPhase, newPhase in
+                .onChangeCompat(of: scenePhase) { _, newPhase in
                     if newPhase == .background && filterManager.hasUnappliedChanges {
                         scheduleNotification(delay: 1)
                     }
@@ -826,7 +826,7 @@ struct AddFilterListView: View {
 		var body: some View {
 		    Group {
 		        #if os(iOS)
-		            NavigationStack {
+		            CompatibleNavigationStack {
 		                addTabs
 		                    .navigationTitle("Add Filter List")
 		                    .navigationBarTitleDisplayMode(.inline)
@@ -848,8 +848,7 @@ struct AddFilterListView: View {
 		                    }
 		            }
 		            .interactiveDismissDisabled(isSaving)
-		            .presentationDetents([.large])
-		            .presentationDragIndicator(.visible)
+		            .largeSheetPresentationCompat()
 	        #elseif os(macOS)
 	            macosBody
 	        #endif
@@ -858,7 +857,7 @@ struct AddFilterListView: View {
 	    .onAppear {
 	        urlFieldIsFocused = addMode == .url
 	    }
-        .onChange(of: addMode) { _, newValue in
+        .onChangeCompat(of: addMode) { _, newValue in
             urlFieldIsFocused = newValue == .url
         }
         #endif
@@ -1101,7 +1100,7 @@ struct AddFilterListView: View {
 		                TextField(
 		                    text: $urlInput,
 		                    prompt: Text(verbatim: "https://example.com/filter.txt")
-		                        .foregroundStyle(.secondary)
+		                        .foregroundColor(.secondary)
 		                ) {
 		                    Text("URL")
 		                }
@@ -1378,7 +1377,7 @@ struct EditCustomFilterNameView: View {
     var body: some View {
         Group {
             #if os(iOS)
-                NavigationStack {
+                CompatibleNavigationStack {
                     Form {
                         Section {
                             TextField("Name", text: $name)
@@ -1531,7 +1530,7 @@ struct EditUserListView: View {
     var body: some View {
         Group {
             #if os(iOS)
-                NavigationStack {
+                CompatibleNavigationStack {
                     Form {
                         Section {
                             TextField("Title", text: $title)
@@ -1590,8 +1589,7 @@ struct EditUserListView: View {
                 } message: {
                     Text(errorMessage ?? "")
                 }
-                .presentationDetents([.large])
-                .presentationDragIndicator(.visible)
+                .largeSheetPresentationCompat()
             #else
                 SheetContainer {
                     SheetHeader(title: "Edit User List", isLoading: isLoadingContent) {

--- a/wBlock/LiquidGlassDesignSystem.swift
+++ b/wBlock/LiquidGlassDesignSystem.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import wBlockCoreService
 
 // MARK: - Liquid Glass (wBlock style)
 
@@ -143,9 +144,9 @@ struct ToolbarSearchField: View {
                 }
                 .padding(.horizontal, 8)
                 .frame(width: 220)
-                .transition(.blurReplace)
+                .transition(.blurReplaceCompat)
                 .task {
-                    try? await Task.sleep(for: .milliseconds(350))
+                    try? await TaskSleep.sleep(for: .milliseconds(350))
                     isFocused = true
                 }
             } else {
@@ -154,11 +155,11 @@ struct ToolbarSearchField: View {
                 } label: {
                     Label("Search", systemImage: "magnifyingglass")
                 }
-                .transition(.blurReplace)
+                .transition(.blurReplaceCompat)
             }
         }
         .animation(.smooth(duration: 0.3), value: isExpanded)
-        .onChange(of: isFocused) { _, focused in
+        .onChangeCompat(of: isFocused) { _, focused in
             if !focused && isExpanded {
                 collapse()
             }

--- a/wBlock/LogsView.swift
+++ b/wBlock/LogsView.swift
@@ -62,7 +62,7 @@ struct LogsView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        CompatibleNavigationStack {
             VStack(spacing: 0) {
                 // Filter toolbar
                 filterToolbar
@@ -136,16 +136,16 @@ struct LogsView: View {
             await loadLogs()
             updateFilteredEntries()
         }
-        .onChange(of: entries) { _, _ in
+        .onChangeCompat(of: entries) { _ in
             updateFilteredEntries()
         }
-        .onChange(of: selectedLevel) { _, _ in
+        .onChangeCompat(of: selectedLevel) { _ in
             updateFilteredEntries()
         }
-        .onChange(of: selectedCategory) { _, _ in
+        .onChangeCompat(of: selectedCategory) { _ in
             updateFilteredEntries()
         }
-        .onChange(of: searchText) { _, _ in
+        .onChangeCompat(of: searchText) { _ in
             updateFilteredEntries()
         }
         #if os(iOS)
@@ -369,7 +369,7 @@ struct LogEntryRow: View {
 
             if let metadata = entry.metadata, !metadata.isEmpty {
                 ForEach(metadata.keys.sorted(), id: \.self) { key in
-                    LabeledContent(key, value: metadata[key] ?? "")
+                    CompatibleLabeledContent(key, value: metadata[key] ?? "")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }

--- a/wBlock/OnboardingView.swift
+++ b/wBlock/OnboardingView.swift
@@ -94,7 +94,7 @@ struct OnboardingView: View {
         } else {
             // Auto-detect from system preferred languages
             let systemLangs = Locale.preferredLanguages.compactMap {
-                Locale(identifier: $0).language.languageCode?.identifier.lowercased()
+                Locale(identifier: $0).languageCode?.lowercased()
             }
             _selectedLanguages = State(initialValue: Set(systemLangs))
         }
@@ -219,21 +219,21 @@ struct OnboardingView: View {
             userScriptManager.prefetchDefaultUserScriptMetadataIfNeeded()
             await refreshScriptsExtensionState(retryingWhenDisabled: true)
         }
-        .onChange(of: scenePhase) { _, newValue in
+        .onChangeCompat(of: scenePhase) { _, newValue in
             guard newValue == .active else { return }
             Task {
                 await refreshScriptsExtensionState(retryingWhenDisabled: true)
             }
         }
-        .onChange(of: selectedLanguages) { _, newValue in
+        .onChangeCompat(of: selectedLanguages) { _, newValue in
             sharedDefaults.set(Array(newValue), forKey: Self.selectedLanguagesDefaultsKey)
             hasManuallyEditedRegionalSelection = false
             updateRegionalRecommendations(for: newValue)
         }
-        .onChange(of: filterManager.filterLists) { _ in
+        .onChangeCompat(of: filterManager.filterLists) { _ in
             updateRegionalRecommendations(for: selectedLanguages)
         }
-        .onChange(of: userScriptManager.userScripts) { _ in
+        .onChangeCompat(of: userScriptManager.userScripts) { _ in
             seedSelectedUserscriptsIfNeeded()
         }
         .confirmationDialog(
@@ -774,7 +774,7 @@ struct OnboardingView: View {
                 break
             }
             guard attempt < maxAttempts - 1 else { break }
-            try? await Task.sleep(for: .milliseconds(350))
+            try? await TaskSleep.sleep(for: .milliseconds(350))
         }
 
         detectedScriptsExtensionEnabled = state

--- a/wBlock/SettingsView.swift
+++ b/wBlock/SettingsView.swift
@@ -234,7 +234,7 @@ struct SettingsView: View {
     @ViewBuilder
     private var backupButtons: some View {
         #if os(macOS)
-        LabeledContent {
+        CompatibleLabeledContent {
             HStack(spacing: 8) {
                 Button {
                     exportBackup()
@@ -409,7 +409,7 @@ struct SettingsView: View {
     @ViewBuilder
     private var aboutSection: some View {
         Section("About") {
-            LabeledContent("wBlock Version") {
+            CompatibleLabeledContent("wBlock Version") {
                 Text(
                     Bundle.main.infoDictionary?["CFBundleShortVersionString"]
                         as? String ?? "Unknown"
@@ -444,7 +444,7 @@ struct SettingsView: View {
     @ViewBuilder
     private var settingsContent: some View {
         #if os(iOS)
-        NavigationStack {
+        CompatibleNavigationStack {
             List {
                 Section {
                     actionsSection
@@ -464,7 +464,7 @@ struct SettingsView: View {
             .navigationBarTitleDisplayMode(.inline)
         }
         #else
-        NavigationStack {
+        CompatibleNavigationStack {
             Form {
                 Section {
                     actionsSection
@@ -480,7 +480,7 @@ struct SettingsView: View {
                 aboutSection
                 dangerZoneSection
             }
-            .formStyle(.grouped)
+            .groupedFormStyleCompat()
         }
         #endif
     }

--- a/wBlock/SwiftUICompatibility.swift
+++ b/wBlock/SwiftUICompatibility.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+struct CompatibleNavigationStack<Content: View>: View {
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        if #available(iOS 16.0, macOS 13.0, *) {
+            NavigationStack(root: content)
+        } else {
+            #if os(iOS)
+            NavigationView(content: content)
+                .navigationViewStyle(StackNavigationViewStyle())
+            #else
+            NavigationView(content: content)
+            #endif
+        }
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func onChangeCompat<Value: Equatable>(
+        of value: Value,
+        perform action: @escaping (_ oldValue: Value, _ newValue: Value) -> Void
+    ) -> some View {
+        if #available(iOS 17.0, macOS 14.0, *) {
+            onChange(of: value, action)
+        } else {
+            onChange(of: value) { newValue in
+                action(value, newValue)
+            }
+        }
+    }
+
+    @ViewBuilder
+    func onChangeCompat<Value: Equatable>(
+        of value: Value,
+        perform action: @escaping (_ newValue: Value) -> Void
+    ) -> some View {
+        if #available(iOS 17.0, macOS 14.0, *) {
+            onChange(of: value) { _, newValue in
+                action(newValue)
+            }
+        } else {
+            onChange(of: value, perform: action)
+        }
+    }
+
+    @ViewBuilder
+    func searchableCompat(
+        text: Binding<String>,
+        isPresented: Binding<Bool>,
+        prompt: LocalizedStringKey
+    ) -> some View {
+        if #available(iOS 17.0, macOS 14.0, *) {
+            searchable(text: text, isPresented: isPresented, prompt: prompt)
+        } else {
+            searchable(text: text, prompt: prompt)
+        }
+    }
+
+    @ViewBuilder
+    func largeSheetPresentationCompat() -> some View {
+        if #available(iOS 16.0, macOS 13.0, *) {
+            presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func groupedFormStyleCompat() -> some View {
+        if #available(iOS 16.0, macOS 13.0, *) {
+            formStyle(.grouped)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func hiddenListRowSeparatorCompat() -> some View {
+        if #available(iOS 15.0, macOS 13.0, *) {
+            listRowSeparator(.hidden)
+        } else {
+            self
+        }
+    }
+}
+
+struct CompatibleLabeledContent<Label: View, Content: View>: View {
+    private let label: Label
+    private let content: Content
+
+    init(
+        @ViewBuilder content: () -> Content,
+        @ViewBuilder label: () -> Label
+    ) {
+        self.content = content()
+        self.label = label()
+    }
+
+    var body: some View {
+        if #available(iOS 16.0, macOS 13.0, *) {
+            LabeledContent {
+                content
+            } label: {
+                label
+            }
+        } else {
+            HStack(alignment: .firstTextBaseline) {
+                label
+                Spacer(minLength: 12)
+                content
+                    .multilineTextAlignment(.trailing)
+            }
+        }
+    }
+}
+
+extension CompatibleLabeledContent where Label == Text, Content == Text {
+    init(_ titleKey: LocalizedStringKey, value: String) {
+        self.init {
+            Text(value)
+        } label: {
+            Text(titleKey)
+        }
+    }
+
+    init(_ title: String, value: String) {
+        self.init {
+            Text(value)
+        } label: {
+            Text(title)
+        }
+    }
+}
+
+extension CompatibleLabeledContent where Label == Text {
+    init(
+        _ titleKey: LocalizedStringKey,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.init(content: content) {
+            Text(titleKey)
+        }
+    }
+}
+
+extension AnyTransition {
+    static var blurReplaceCompat: AnyTransition {
+        .opacity.combined(with: .scale(scale: 0.98))
+    }
+}

--- a/wBlock/SwiftUICompatibility.swift
+++ b/wBlock/SwiftUICompatibility.swift
@@ -17,6 +17,30 @@ struct CompatibleNavigationStack<Content: View>: View {
     }
 }
 
+private struct OnChangeCompatModifier<Value: Equatable>: ViewModifier {
+    let value: Value
+    let action: (_ oldValue: Value, _ newValue: Value) -> Void
+
+    @State private var previousValue: Value
+
+    init(
+        value: Value,
+        action: @escaping (_ oldValue: Value, _ newValue: Value) -> Void
+    ) {
+        self.value = value
+        self.action = action
+        _previousValue = State(initialValue: value)
+    }
+
+    func body(content: Content) -> some View {
+        content.onChange(of: value) { newValue in
+            let oldValue = previousValue
+            previousValue = newValue
+            action(oldValue, newValue)
+        }
+    }
+}
+
 extension View {
     @ViewBuilder
     func onChangeCompat<Value: Equatable>(
@@ -26,9 +50,7 @@ extension View {
         if #available(iOS 17.0, macOS 14.0, *) {
             onChange(of: value, action)
         } else {
-            onChange(of: value) { newValue in
-                action(value, newValue)
-            }
+            modifier(OnChangeCompatModifier(value: value, action: action))
         }
     }
 

--- a/wBlock/SyntaxHighlightingTextView.swift
+++ b/wBlock/SyntaxHighlightingTextView.swift
@@ -164,7 +164,12 @@ struct SyntaxHighlightingTextView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> UITextView {
-        let textView = UITextView(usingTextLayoutManager: true)
+        let textView: UITextView
+        if #available(iOS 16.0, *) {
+            textView = UITextView(usingTextLayoutManager: true)
+        } else {
+            textView = UITextView()
+        }
         textView.font = UIFont.monospacedSystemFont(ofSize: 13, weight: .regular)
         textView.autocapitalizationType = .none
         textView.autocorrectionType = .no

--- a/wBlock/UnifiedTabUI.swift
+++ b/wBlock/UnifiedTabUI.swift
@@ -43,7 +43,7 @@ struct UnifiedTabCardSectionRowModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
-            .listRowSeparator(.hidden)
+            .hiddenListRowSeparatorCompat()
             .listRowBackground(Color.clear)
     }
 }

--- a/wBlock/UpdatePopupView.swift
+++ b/wBlock/UpdatePopupView.swift
@@ -234,7 +234,7 @@ struct UpdatePopupView: View {
                             }
                         } label: {
                             Label("Update & Apply", systemImage: "arrow.triangle.2.circlepath.circle.fill")
-                                .fontWeight(.semibold)
+                                .font(.body.weight(.semibold))
                         }
                         .primaryActionButtonStyle()
                         .disabled(selectedFilters.isEmpty && selectedScripts.isEmpty)

--- a/wBlock/UserScriptManagerView.swift
+++ b/wBlock/UserScriptManagerView.swift
@@ -196,7 +196,7 @@ struct UserScriptManagerView: View {
                 }
             }
         }
-        .searchable(
+        .searchableCompat(
             text: $searchText,
             isPresented: $showSearch,
             prompt: "Search scripts"
@@ -1073,7 +1073,7 @@ private struct UserScriptSourceSheet: View {
 
     var body: some View {
         #if os(iOS)
-        NavigationStack {
+        CompatibleNavigationStack {
             sourceSheetBody
                 .background(Color(.systemGray6))
                 .navigationTitle("Script Content")
@@ -1225,11 +1225,11 @@ struct AddUserScriptView: View {
         .onAppear {
             urlFieldFocused = addMode == .url
         }
-        .onChange(of: addMode) { _, newValue in
+        .onChangeCompat(of: addMode) { _, newValue in
             urlFieldFocused = newValue == .url
         }
         #endif
-        .onChange(of: urlInput) { _, newValue in
+        .onChangeCompat(of: urlInput) { _, newValue in
             validateInput(newValue)
         }
         .fileImporter(isPresented: $showingFileImporter, allowedContentTypes: allowedImportTypes) { result in
@@ -1246,7 +1246,7 @@ struct AddUserScriptView: View {
 
     #if os(iOS)
     private var iosBody: some View {
-        NavigationStack {
+        CompatibleNavigationStack {
             addTabs
                 .navigationTitle("Add Userscript")
                 .navigationBarTitleDisplayMode(.inline)
@@ -1267,8 +1267,7 @@ struct AddUserScriptView: View {
                     }
                 }
         }
-        .presentationDetents([.large])
-        .presentationDragIndicator(.visible)
+        .largeSheetPresentationCompat()
     }
 
     private var addTabs: some View {
@@ -1290,7 +1289,7 @@ struct AddUserScriptView: View {
                     TextField(
                         text: $urlInput,
                         prompt: Text(verbatim: "https://example.com/script.user.js")
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     ) {
                         Text("Script URL")
                     }

--- a/wBlock/ZapperRuleManagerView.swift
+++ b/wBlock/ZapperRuleManagerView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import wBlockCoreService
 
 struct ZapperRuleManagerView: View {
     @ObservedObject private var ruleManager = ZapperRuleManager.shared
@@ -195,7 +196,7 @@ struct ZapperRuleManagerView: View {
         .shadow(color: .black.opacity(0.12), radius: 8, x: 0, y: 4)
         .task(id: pendingUndo?.rule) {
             guard pendingUndo != nil else { return }
-            try? await Task.sleep(for: .seconds(5))
+            try? await TaskSleep.sleep(for: .seconds(5))
             await MainActor.run {
                 pendingUndo = nil
             }

--- a/wBlock/wBlockApp.swift
+++ b/wBlock/wBlockApp.swift
@@ -62,7 +62,7 @@ struct wBlockApp: App {
 
                     startLaunchSetupIfNeeded()
                 }
-                .onChange(of: scenePhase) { newPhase in
+                .onChangeCompat(of: scenePhase) { newPhase in
                     guard newPhase == .active, hasCompletedLaunchSetup else { return }
                     Task { await CloudSyncManager.shared.syncNow(trigger: "AppActive") }
                 }

--- a/wBlockCoreService/AsyncDelay.swift
+++ b/wBlockCoreService/AsyncDelay.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public struct AsyncDelay: Sendable, Equatable, CustomStringConvertible {
+    public let nanoseconds: UInt64
+
+    public init(nanoseconds: UInt64) {
+        self.nanoseconds = nanoseconds
+    }
+
+    public static func seconds(_ seconds: Int) -> AsyncDelay {
+        AsyncDelay(nanoseconds: clampedNanoseconds(seconds, multiplier: 1_000_000_000))
+    }
+
+    public static func seconds(_ seconds: TimeInterval) -> AsyncDelay {
+        guard seconds > 0 else { return AsyncDelay(nanoseconds: 0) }
+        let nanoseconds = seconds * 1_000_000_000
+        return AsyncDelay(nanoseconds: nanoseconds >= Double(UInt64.max) ? UInt64.max : UInt64(nanoseconds))
+    }
+
+    public static func milliseconds(_ milliseconds: Int) -> AsyncDelay {
+        AsyncDelay(nanoseconds: clampedNanoseconds(milliseconds, multiplier: 1_000_000))
+    }
+
+    public var description: String {
+        if nanoseconds.isMultiple(of: 1_000_000_000) {
+            return "\(nanoseconds / 1_000_000_000)s"
+        }
+        if nanoseconds.isMultiple(of: 1_000_000) {
+            return "\(nanoseconds / 1_000_000)ms"
+        }
+        return "\(nanoseconds)ns"
+    }
+
+    private static func clampedNanoseconds(_ value: Int, multiplier: UInt64) -> UInt64 {
+        guard value > 0 else { return 0 }
+        let unsignedValue = UInt64(value)
+        guard unsignedValue <= UInt64.max / multiplier else { return UInt64.max }
+        return unsignedValue * multiplier
+    }
+}
+
+public enum TaskSleep {
+    public static func sleep(for delay: AsyncDelay) async throws {
+        try await Task.sleep(nanoseconds: delay.nanoseconds)
+    }
+}

--- a/wBlockCoreService/FilterAutoUpdateRunner.swift
+++ b/wBlockCoreService/FilterAutoUpdateRunner.swift
@@ -1,0 +1,19 @@
+import Foundation
+import os.log
+
+public enum FilterAutoUpdateRunner {
+    public static func run(trigger: String, timeout: TimeInterval = 180) async -> Bool {
+        let logger = Logger(subsystem: "wBlockCoreService", category: "FilterAutoUpdateRunner")
+        #if os(macOS)
+        if await FilterUpdateClient.shared.updateFilters(timeout: timeout) {
+            return true
+        }
+
+        logger.info("XPC update unavailable, running shared auto-update fallback for trigger=\(trigger, privacy: .public)")
+        #else
+        logger.info("Running shared auto-update for trigger=\(trigger, privacy: .public)")
+        #endif
+        await SharedAutoUpdateManager.shared.maybeRunAutoUpdate(trigger: trigger)
+        return true
+    }
+}

--- a/wBlockCoreService/ProtobufDataManager.swift
+++ b/wBlockCoreService/ProtobufDataManager.swift
@@ -1210,7 +1210,7 @@ public class ProtobufDataManager: ObservableObject {
     
     // MARK: - Data Saving (debounced)
     private var pendingSaveTask: Task<Void, Never>?
-    private let saveDebounceDelay: Duration = .milliseconds(500)
+    private let saveDebounceDelay: AsyncDelay = .milliseconds(500)
     private var lastSavedData: Data?
 
     public func saveData() {
@@ -1224,7 +1224,7 @@ public class ProtobufDataManager: ObservableObject {
                 }
             }
             do {
-                try await Task.sleep(for: delay)
+                try await TaskSleep.sleep(for: delay)
             } catch {
                 return
             }

--- a/wBlockCoreService/UserScript.swift
+++ b/wBlockCoreService/UserScript.swift
@@ -172,7 +172,7 @@ public struct UserScript: Identifiable, Codable, Hashable, Sendable {
         downloadURL = nil
 
         // Resolve the user's preferred language code for locale-aware metadata.
-        let preferredLang = Locale.current.language.languageCode?.identifier.lowercased() ?? "en"
+        let preferredLang = Locale.current.languageCode?.lowercased() ?? "en"
 
         var nameByLocale: [String: String] = [:]    // locale → name
         var descByLocale: [String: String] = [:]    // locale → description

--- a/wBlockCoreService/wBlockCoreService.swift
+++ b/wBlockCoreService/wBlockCoreService.swift
@@ -193,7 +193,7 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adPlacements', 'un
 
             let delayMs = min(200 * attempt, 1500)
             do {
-                try await Task.sleep(for: .milliseconds(delayMs))
+                try await TaskSleep.sleep(for: .milliseconds(delayMs))
             } catch {
                 return ReloadAttemptResult(
                     success: false,


### PR DESCRIPTION
Supports macOS 12.3 and iOS 15.4 by lowering targets, replacing newer SwiftUI/concurrency APIs, and adding a Monterey-only login item wrapper for background updates. Tested with the macOS build, both requested iOS simulator builds, and plist lint.