### PR TITLE
zapper cancel button and status text fix

### DIFF
--- a/wBlock Scripts (iOS)/Resources/_locales/ar/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ar/messages.json
@@ -135,6 +135,10 @@
     "message": "إخفاء",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "إلغاء",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "أدخل محدد CSS.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/de/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/de/messages.json
@@ -135,6 +135,10 @@
     "message": "Ausblenden",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "Abbrechen",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "Gib einen CSS-Selektor ein.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/el/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/el/messages.json
@@ -135,6 +135,10 @@
     "message": "Απόκρυψη",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "Ακύρωση",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "Εισαγάγετε έναν επιλογέα CSS.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/en/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/en/messages.json
@@ -135,6 +135,10 @@
     "message": "Hide",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "Cancel",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "Enter a CSS selector.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/es/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/es/messages.json
@@ -135,6 +135,10 @@
     "message": "Ocultar",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "Cancelar",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "Introduce un selector CSS.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/fr/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/fr/messages.json
@@ -135,6 +135,10 @@
     "message": "Masquer",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "Annuler",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "Saisissez un sélecteur CSS.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/hu/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/hu/messages.json
@@ -135,6 +135,10 @@
     "message": "Elrejtés",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "Mégse",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "Adj meg egy CSS-szelektort.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/it/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/it/messages.json
@@ -135,6 +135,10 @@
     "message": "Nascondi",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "Cancella",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "Inserisci un selettore CSS.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/ja/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ja/messages.json
@@ -135,6 +135,10 @@
     "message": "非表示",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "キャンセル",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "CSS セレクタを入力してください。",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/ko/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ko/messages.json
@@ -135,6 +135,10 @@
     "message": "숨기기",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "취소",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "CSS 선택자를 입력하세요.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/pl/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/pl/messages.json
@@ -135,6 +135,10 @@
     "message": "Ukryj",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "Anuluj",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "Wprowadź selektor CSS.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/pt_BR/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/pt_BR/messages.json
@@ -135,6 +135,10 @@
     "message": "Ocultar",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "Cancelar",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "Digite um seletor CSS.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/ro/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ro/messages.json
@@ -135,6 +135,10 @@
     "message": "Ascunde",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "Renunță",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "Introdu un selector CSS.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/ru/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ru/messages.json
@@ -135,6 +135,10 @@
     "message": "Скрыть",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "Отмена",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "Введите CSS-селектор.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/tr/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/tr/messages.json
@@ -135,6 +135,10 @@
     "message": "Gizle",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "İptal",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "Bir CSS seçicisi gir.",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/zh_CN/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/zh_CN/messages.json
@@ -135,6 +135,10 @@
     "message": "隐藏",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "取消",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "请输入 CSS 选择器。",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/_locales/zh_TW/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/zh_TW/messages.json
@@ -135,6 +135,10 @@
     "message": "隱藏",
     "description": "Button label for confirming hide action in refine mode."
   },
+  "zapper_button_cancel": {
+    "message": "取消",
+    "description": "Button label to cancel element selection and exit refine mode without hiding."
+  },
   "zapper_error_enter_selector": {
     "message": "請輸入 CSS 選擇器。",
     "description": "Validation error shown when manual selector input is empty."

--- a/wBlock Scripts (iOS)/Resources/zapper-content.js
+++ b/wBlock Scripts (iOS)/Resources/zapper-content.js
@@ -412,6 +412,7 @@
         #${UI_ROOT_ID} .wblock-bar { flex-direction: column; align-items: stretch; }
         #${UI_ROOT_ID} .wblock-actions { width: 100%; }
         #${UI_ROOT_ID} .wblock-actions button { flex-grow: 1; min-height: 44px; }
+        #${UI_ROOT_ID} .wblock-overflow { left: 0; right: auto; }
       }
       #${HIGHLIGHT_ID} { position: fixed; pointer-events: none; z-index: 2147483646; border: 2px solid rgba(249,115,22,0.95); background: rgba(249,115,22,0.12); border-radius: 6px; transform: translate3d(0,0,0); }
       #${TOAST_ID} { position: absolute; left: 0; right: 0; bottom: 100%; margin-bottom: 8px; z-index: 2147483647; display: none; justify-content: center; pointer-events: none; }

--- a/wBlock Scripts (iOS)/Resources/zapper-content.js
+++ b/wBlock Scripts (iOS)/Resources/zapper-content.js
@@ -45,6 +45,7 @@
       parentButton: null,
       childButton: null,
       hideButton: null,
+      cancelButton: null,
       navGroup: null,
       defaultGroup: null,
     },
@@ -393,7 +394,7 @@
       #${UI_ROOT_ID} .wblock-bar { display: flex; gap: 10px; align-items: center; justify-content: space-between; padding: 12px 14px; border-radius: 16px; backdrop-filter: blur(16px); background: rgba(20, 20, 22, 0.78); color: #fff; box-shadow: 0 10px 30px rgba(0,0,0,0.35); cursor: grab; }
       #${UI_ROOT_ID} .wblock-bar.wblock-dragging { cursor: grabbing; }
       #${UI_ROOT_ID} .wblock-drag-hint { width: 36px; height: 4px; border-radius: 2px; background: rgba(255,255,255,0.3); margin: 0 auto 6px; }
-      #${UI_ROOT_ID} .wblock-status { font-size: 13px; line-height: 1.35; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      #${UI_ROOT_ID} .wblock-status { font-size: 13px; line-height: 1.35; flex: 1; min-width: 0; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
       #${UI_ROOT_ID} .wblock-actions { display: flex; gap: 10px; }
       #${UI_ROOT_ID} button { appearance: none; display: inline-flex; align-items: center; justify-content: center; border: 0; border-radius: 11px; padding: 10px 12px; min-height: 40px; line-height: 1.1; font-size: 13px; font-weight: 650; color: #fff; background: rgba(255,255,255,0.14); touch-action: manipulation; -webkit-tap-highlight-color: transparent; white-space: nowrap; flex-shrink: 0; }
       #${UI_ROOT_ID} button:disabled { opacity: 0.5; }
@@ -409,7 +410,6 @@
       #${UI_ROOT_ID} .wblock-overflow button:active { background: rgba(255,255,255,0.1); }
       @media (max-width: 430px) {
         #${UI_ROOT_ID} .wblock-bar { flex-direction: column; align-items: stretch; }
-        #${UI_ROOT_ID} .wblock-status { font-size: 14px; }
         #${UI_ROOT_ID} .wblock-actions { width: 100%; }
         #${UI_ROOT_ID} .wblock-actions button { flex-grow: 1; min-height: 44px; }
       }
@@ -546,6 +546,15 @@
     };
     childButton.addEventListener('click', onChild);
 
+    const cancelButton = document.createElement('button');
+    cancelButton.type = 'button';
+    cancelButton.textContent = t('zapper_button_cancel', undefined, 'Cancel');
+    const onCancel = (e) => {
+      if (e) { e.preventDefault(); e.stopPropagation(); if (typeof e.stopImmediatePropagation === 'function') e.stopImmediatePropagation(); }
+      exitRefineMode();
+    };
+    cancelButton.addEventListener('click', onCancel);
+
     const hideButton = document.createElement('button');
     hideButton.type = 'button';
     hideButton.className = 'wblock-hide-btn';
@@ -556,6 +565,7 @@
     };
     hideButton.addEventListener('click', onHide);
 
+    navGroup.appendChild(cancelButton);
     navGroup.appendChild(parentButton);
     navGroup.appendChild(childButton);
     navGroup.appendChild(hideButton);
@@ -588,6 +598,7 @@
     state.ui.parentButton = parentButton;
     state.ui.childButton = childButton;
     state.ui.hideButton = hideButton;
+    state.ui.cancelButton = cancelButton;
     state.ui.navGroup = navGroup;
     state.ui.defaultGroup = defaultGroup;
 
@@ -845,6 +856,7 @@
     state.ui.parentButton = null;
     state.ui.childButton = null;
     state.ui.hideButton = null;
+    state.ui.cancelButton = null;
     state.ui.navGroup = null;
     state.ui.defaultGroup = null;
   }


### PR DESCRIPTION
Two usability fixes for the element zapper reported by cameren.

- Adds a Cancel button as the first item in the refine-mode nav group, so users can exit element selection on mobile without having to hide and then undo. Escape still works on desktop.
- Switches `.wblock-status` from `white-space: nowrap` + single-line ellipsis to `-webkit-line-clamp: 2`, so long refine-mode status text wraps instead of getting cut off on narrow screens.
- Adds `zapper_button_cancel` to all 17 locale files.