### PR TITLE
Add filter update shortcut action

### DIFF
--- a/scripts/test_shortcut_filter_update_intent.swift
+++ b/scripts/test_shortcut_filter_update_intent.swift
@@ -24,6 +24,7 @@ let intent = try read("wBlock/FilterUpdateShortcuts.swift")
 let progressViewModel = try read("wBlock/ApplyChangesViewModel.swift")
 let progressView = try read("wBlock/ApplyChangesProgressView.swift")
 let contentView = try read("wBlock/ContentView.swift")
+let appFilterManager = try read("wBlock/AppFilterManager.swift")
 let project = try read("wBlock.xcodeproj/project.pbxproj")
 let fileManager = FileManager.default
 let localizationRoot = URL(fileURLWithPath: "wBlock")
@@ -94,10 +95,20 @@ assertContains(
     "applyFilterChangesFromExternalTrigger()",
     "Notification and shortcut triggers must share one apply path"
 )
+assertContains(
+    contentView,
+    "await filterManager.waitUntilReady()",
+    "Shortcut apply requests must wait until filter lists are loaded"
+)
 assertNotContains(
     contentView,
     "await filterManager.checkAndEnableFilters(forceReload: true)",
     "External triggers should call the synchronous apply entry point directly"
+)
+assertContains(
+    appFilterManager,
+    "func waitUntilReady() async",
+    "Filter manager must expose a readiness await point for cold-launch shortcut requests"
 )
 assertNotContains(
     progressViewModel,

--- a/scripts/test_shortcut_filter_update_intent.swift
+++ b/scripts/test_shortcut_filter_update_intent.swift
@@ -14,6 +14,9 @@ func assertContains(_ haystack: String, _ needle: String, _ message: String) {
 }
 
 let intent = try read("wBlock/FilterUpdateShortcuts.swift")
+let progressViewModel = try read("wBlock/ApplyChangesViewModel.swift")
+let progressView = try read("wBlock/ApplyChangesProgressView.swift")
+let contentView = try read("wBlock/ContentView.swift")
 let project = try read("wBlock.xcodeproj/project.pbxproj")
 let fileManager = FileManager.default
 let localizationRoot = URL(fileURLWithPath: "wBlock")
@@ -26,9 +29,16 @@ let localizationKeys = [
     "No filter updates found.",
     "wBlock filter update skipped because it is not due yet.",
     "wBlock filter update failed. Open wBlock for details.",
+    "Updating wBlock Filters",
+    "Checking for filter updates...",
+    "wBlock Filters Updated",
+    "No Filter Updates",
+    "Filter Update Skipped",
+    "Filter Update Deferred",
+    "Filter Update Failed",
+    "Filter Update Cancelled",
     "Update Filters",
 ]
-
 assertContains(
     intent,
     "struct UpdateWBlockFiltersIntent: AppIntent",
@@ -53,6 +63,36 @@ assertContains(
     intent,
     "struct WBlockShortcutsProvider: AppShortcutsProvider",
     "Shortcut must be discoverable in Shortcuts"
+)
+assertContains(
+    intent,
+    "ShortcutFilterUpdatePresentation.shared.start()",
+    "Shortcut must announce start so the opened app shows visible progress"
+)
+assertContains(
+    intent,
+    "ShortcutFilterUpdatePresentation.shared.finish(",
+    "Shortcut must announce completion so the progress sheet shows the result"
+)
+assertContains(
+    contentView,
+    "shortcutFilterUpdatePresentationChanged",
+    "Main view must listen for shortcut progress presentation changes"
+)
+assertContains(
+    contentView,
+    "prepareShortcutFilterUpdate()",
+    "Main view must show the apply-style sheet while shortcut updates run"
+)
+assertContains(
+    progressViewModel,
+    "func completeShortcutFilterUpdate(",
+    "Progress view model must support shortcut completion states"
+)
+assertContains(
+    progressView,
+    "completionCard(",
+    "Apply progress sheet must render shortcut completion results"
 )
 assertContains(
     project,

--- a/scripts/test_shortcut_filter_update_intent.swift
+++ b/scripts/test_shortcut_filter_update_intent.swift
@@ -13,6 +13,13 @@ func assertContains(_ haystack: String, _ needle: String, _ message: String) {
     }
 }
 
+func assertNotContains(_ haystack: String, _ needle: String, _ message: String) {
+    guard !haystack.contains(needle) else {
+        fputs("FAIL: \(message)\nUnexpected: \(needle)\n", stderr)
+        exit(1)
+    }
+}
+
 let intent = try read("wBlock/FilterUpdateShortcuts.swift")
 let progressViewModel = try read("wBlock/ApplyChangesViewModel.swift")
 let progressView = try read("wBlock/ApplyChangesProgressView.swift")
@@ -23,22 +30,10 @@ let localizationRoot = URL(fileURLWithPath: "wBlock")
 let localizationKeys = [
     "Update wBlock Filters",
     "Checks for wBlock filter updates and applies them when available.",
-    "Force Check",
-    "Check now even if automatic updates are not due yet.",
-    "wBlock filters updated.",
-    "No filter updates found.",
-    "wBlock filter update skipped because it is not due yet.",
-    "wBlock filter update failed. Open wBlock for details.",
-    "Updating wBlock Filters",
-    "Checking for filter updates...",
-    "wBlock Filters Updated",
-    "No Filter Updates",
-    "Filter Update Skipped",
-    "Filter Update Deferred",
-    "Filter Update Failed",
-    "Filter Update Cancelled",
+    "wBlock filter update started.",
     "Update Filters",
 ]
+
 assertContains(
     intent,
     "struct UpdateWBlockFiltersIntent: AppIntent",
@@ -47,17 +42,27 @@ assertContains(
 assertContains(
     intent,
     "static var openAppWhenRun: Bool { true }",
-    "Shortcut update must run with the app opened to avoid a silent long background job"
+    "Shortcut update must run with the app opened to show the normal apply flow"
+)
+assertNotContains(
+    intent,
+    "@Parameter",
+    "Shortcut update must not expose a force option"
+)
+assertNotContains(
+    intent,
+    "forceCheck",
+    "Shortcut update must always use the forced apply path"
 )
 assertContains(
+    intent,
+    "ShortcutFilterUpdateRequest.shared.requestUpdate()",
+    "Shortcut must request the app to run the normal apply flow"
+)
+assertNotContains(
     intent,
     "maybeRunAutoUpdate(",
-    "Shortcut update must use the shared auto-update pipeline"
-)
-assertContains(
-    intent,
-    "policy: .foreground(trigger: trigger)",
-    "Shortcut update must use the foreground auto-update policy"
+    "Shortcut must not use a separate shared auto-update UI path"
 )
 assertContains(
     intent,
@@ -65,34 +70,29 @@ assertContains(
     "Shortcut must be discoverable in Shortcuts"
 )
 assertContains(
-    intent,
-    "ShortcutFilterUpdatePresentation.shared.start()",
-    "Shortcut must announce start so the opened app shows visible progress"
-)
-assertContains(
-    intent,
-    "ShortcutFilterUpdatePresentation.shared.finish(",
-    "Shortcut must announce completion so the progress sheet shows the result"
+    contentView,
+    "shortcutFilterUpdateRequested",
+    "Main view must listen for shortcut update requests"
 )
 assertContains(
     contentView,
-    "shortcutFilterUpdatePresentationChanged",
-    "Main view must listen for shortcut progress presentation changes"
+    "checkAndEnableFilters(forceReload: true)",
+    "Shortcut must use the same forced apply entry point as Apply Changes"
 )
 assertContains(
     contentView,
-    "prepareShortcutFilterUpdate()",
-    "Main view must show the apply-style sheet while shortcut updates run"
+    "applyFilterChangesFromExternalTrigger()",
+    "Notification and shortcut triggers must share one apply path"
 )
-assertContains(
+assertNotContains(
     progressViewModel,
-    "func completeShortcutFilterUpdate(",
-    "Progress view model must support shortcut completion states"
+    "prepareShortcutFilterUpdate",
+    "Shortcut must not add a separate progress state"
 )
-assertContains(
+assertNotContains(
     progressView,
     "completionCard(",
-    "Apply progress sheet must render shortcut completion results"
+    "Shortcut must not add a separate completion UI"
 )
 assertContains(
     project,

--- a/scripts/test_shortcut_filter_update_intent.swift
+++ b/scripts/test_shortcut_filter_update_intent.swift
@@ -56,6 +56,16 @@ assertNotContains(
 )
 assertContains(
     intent,
+    "@MainActor\n    func perform()",
+    "Shortcut intent must run its request handoff on the main actor"
+)
+assertContains(
+    intent,
+    "IntentDialog(\"wBlock filter update started.\")",
+    "Shortcut intent dialog must be explicitly localized"
+)
+assertContains(
+    intent,
     "ShortcutFilterUpdateRequest.shared.requestUpdate()",
     "Shortcut must request the app to run the normal apply flow"
 )
@@ -83,6 +93,11 @@ assertContains(
     contentView,
     "applyFilterChangesFromExternalTrigger()",
     "Notification and shortcut triggers must share one apply path"
+)
+assertNotContains(
+    contentView,
+    "await filterManager.checkAndEnableFilters(forceReload: true)",
+    "External triggers should call the synchronous apply entry point directly"
 )
 assertNotContains(
     progressViewModel,

--- a/scripts/test_shortcut_filter_update_intent.swift
+++ b/scripts/test_shortcut_filter_update_intent.swift
@@ -1,0 +1,77 @@
+#!/usr/bin/env swift
+
+import Foundation
+
+func read(_ path: String) throws -> String {
+    try String(contentsOfFile: path, encoding: .utf8)
+}
+
+func assertContains(_ haystack: String, _ needle: String, _ message: String) {
+    guard haystack.contains(needle) else {
+        fputs("FAIL: \(message)\nMissing: \(needle)\n", stderr)
+        exit(1)
+    }
+}
+
+let intent = try read("wBlock/FilterUpdateShortcuts.swift")
+let project = try read("wBlock.xcodeproj/project.pbxproj")
+let fileManager = FileManager.default
+let localizationRoot = URL(fileURLWithPath: "wBlock")
+let localizationKeys = [
+    "Update wBlock Filters",
+    "Checks for wBlock filter updates and applies them when available.",
+    "Force Check",
+    "Check now even if automatic updates are not due yet.",
+    "wBlock filters updated.",
+    "No filter updates found.",
+    "wBlock filter update skipped because it is not due yet.",
+    "wBlock filter update failed. Open wBlock for details.",
+    "Update Filters",
+]
+
+assertContains(
+    intent,
+    "struct UpdateWBlockFiltersIntent: AppIntent",
+    "Shortcut intent must expose the update action through App Intents"
+)
+assertContains(
+    intent,
+    "static var openAppWhenRun: Bool { true }",
+    "Shortcut update must run with the app opened to avoid a silent long background job"
+)
+assertContains(
+    intent,
+    "maybeRunAutoUpdate(",
+    "Shortcut update must use the shared auto-update pipeline"
+)
+assertContains(
+    intent,
+    "policy: .foreground(trigger: trigger)",
+    "Shortcut update must use the foreground auto-update policy"
+)
+assertContains(
+    intent,
+    "struct WBlockShortcutsProvider: AppShortcutsProvider",
+    "Shortcut must be discoverable in Shortcuts"
+)
+assertContains(
+    project,
+    "PBXFileSystemSynchronizedRootGroup",
+    "Project must use synchronized groups so new app files are picked up automatically"
+)
+
+let localizationFiles = try fileManager.contentsOfDirectory(
+    at: localizationRoot,
+    includingPropertiesForKeys: nil
+).filter { $0.pathExtension == "lproj" }
+ .map { $0.appendingPathComponent("Localizable.strings") }
+ .filter { fileManager.fileExists(atPath: $0.path) }
+
+for file in localizationFiles {
+    let strings = try read(file.path)
+    for key in localizationKeys {
+        assertContains(strings, "\"\(key)\" =", "Missing shortcut localization key in \(file.path)")
+    }
+}
+
+print("PASS: shortcut filter update intent checks")

--- a/wBlock/AppDelegate.swift
+++ b/wBlock/AppDelegate.swift
@@ -602,7 +602,7 @@ extension AppDelegate: UIApplicationDelegate {
         for outcome: SharedAutoUpdateManager.AutoUpdateRunOutcome
     ) -> AutoUpdateDiagnosticResult {
         switch outcome {
-        case .completed, .skipped(_):
+        case .completed(_), .skipped(_):
             return .completed
         case .cancelled:
             return .timedOut
@@ -669,7 +669,7 @@ extension AppDelegate: UIApplicationDelegate {
             let result = diagnosticResult(for: outcome)
 
             switch outcome {
-            case .completed, .skipped(_):
+            case .completed(_), .skipped(_):
                 os_log("%{public}@ completed successfully", type: .info, taskLabel)
             case let .deferred(phase):
                 os_log("%{public}@ deferred at %{public}@", type: .info, taskLabel, phase)

--- a/wBlock/AppFilterManager.swift
+++ b/wBlock/AppFilterManager.swift
@@ -62,6 +62,7 @@ class AppFilterManager: ObservableObject {
     private(set) var filterUpdater: FilterListUpdater
     let logManager: ConcurrentLogManager
     let dataManager = ProtobufDataManager.shared
+    private var setupTask: Task<Void, Never>?
 
     // Per-site disable tracking
     var lastKnownDisabledSites: [String] = []
@@ -167,9 +168,9 @@ class AppFilterManager: ObservableObject {
             self.currentPlatform = .iOS
         #endif
 
-        // Wait for ProtobufDataManager to finish loading before setting up
-        Task {
-            await setupAsync()
+        // Wait for ProtobufDataManager to finish loading before setting up.
+        setupTask = Task { @MainActor [weak self] in
+            await self?.setupAsync()
         }
     }
 
@@ -224,9 +225,14 @@ class AppFilterManager: ObservableObject {
         isLoading = false
     }
 
-    func setupAsync() async {
+    func waitUntilReady() async {
+        await setupTask?.value
+    }
+
+    private func setupAsync() async {
         await dataManager.waitUntilLoaded()
         setup()
+        setupTask = nil
     }
 
     func setup() {

--- a/wBlock/ApplyChangesProgressView.swift
+++ b/wBlock/ApplyChangesProgressView.swift
@@ -27,9 +27,6 @@ struct ApplyChangesProgressView: View {
                             } else if let summary = viewModel.state.summary {
                                 summaryCard(summary)
                                     .transition(.opacity)
-                            } else if let completion = viewModel.state.completion {
-                                completionCard(completion)
-                                    .transition(.opacity)
                             }
                         }
                         .animation(.easeInOut(duration: 0.25), value: viewModel.state.isLoading)
@@ -107,35 +104,6 @@ struct ApplyChangesProgressView: View {
                     }
                 }
             }
-        }
-    }
-
-    private func completionCard(_ completion: ApplyChangesCompletion) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 10) {
-                Image(systemName: completion.style.systemImage)
-                    .foregroundStyle(completionColor(for: completion.style))
-
-                Text(completion.title)
-                    .font(.title3)
-                    .fontWeight(.semibold)
-            }
-
-            Text(completion.message)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(16)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
-    }
-
-    private func completionColor(for style: ApplyChangesCompletionStyle) -> Color {
-        switch style {
-        case .success: return .green
-        case .warning: return .orange
-        case .failure: return .red
         }
     }
 

--- a/wBlock/ApplyChangesProgressView.swift
+++ b/wBlock/ApplyChangesProgressView.swift
@@ -27,6 +27,9 @@ struct ApplyChangesProgressView: View {
                             } else if let summary = viewModel.state.summary {
                                 summaryCard(summary)
                                     .transition(.opacity)
+                            } else if let completion = viewModel.state.completion {
+                                completionCard(completion)
+                                    .transition(.opacity)
                             }
                         }
                         .animation(.easeInOut(duration: 0.25), value: viewModel.state.isLoading)
@@ -104,6 +107,35 @@ struct ApplyChangesProgressView: View {
                     }
                 }
             }
+        }
+    }
+
+    private func completionCard(_ completion: ApplyChangesCompletion) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                Image(systemName: completion.style.systemImage)
+                    .foregroundStyle(completionColor(for: completion.style))
+
+                Text(completion.title)
+                    .font(.title3)
+                    .fontWeight(.semibold)
+            }
+
+            Text(completion.message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+    }
+
+    private func completionColor(for style: ApplyChangesCompletionStyle) -> Color {
+        switch style {
+        case .success: return .green
+        case .warning: return .orange
+        case .failure: return .red
         }
     }
 

--- a/wBlock/ApplyChangesViewModel.swift
+++ b/wBlock/ApplyChangesViewModel.swift
@@ -67,6 +67,26 @@ struct ApplyChangesSummary: Equatable {
     var blockersApproachingLimit: Set<String>
 }
 
+enum ApplyChangesCompletionStyle: Equatable {
+    case success
+    case warning
+    case failure
+
+    var systemImage: String {
+        switch self {
+        case .success: return "checkmark.circle.fill"
+        case .warning: return "exclamationmark.triangle.fill"
+        case .failure: return "xmark.circle.fill"
+        }
+    }
+}
+
+struct ApplyChangesCompletion: Equatable {
+    var title: String
+    var message: String
+    var style: ApplyChangesCompletionStyle
+}
+
 /// Consolidated state for the apply progress presentation.
 struct ApplyChangesState: Equatable {
     var isLoading: Bool = false
@@ -83,13 +103,14 @@ struct ApplyChangesState: Equatable {
     var updatesFound: Int = 0
     var phases: [ApplyChangesPhaseProgress] = ApplyChangesPhase.allCases.map { ApplyChangesPhaseProgress(phase: $0, status: .pending) }
     var summary: ApplyChangesSummary? = nil
+    var completion: ApplyChangesCompletion? = nil
 
     var progressPercentage: Int {
         Int((0...1).clamp(progress) * 100)
     }
 
     var isComplete: Bool {
-        summary != nil
+        summary != nil || completion != nil
     }
 }
 
@@ -210,6 +231,38 @@ class ApplyChangesViewModel: ObservableObject {
             state.statusMessage = statusMessage
         } else if state.statusMessage.isEmpty || state.statusMessage.lowercased().contains("reloading") {
             state.statusMessage = String(localized: "Filters applied successfully.")
+        }
+    }
+
+    func prepareShortcutFilterUpdate() {
+        reset()
+        state.isLoading = true
+        state.statusMessage = String(localized: "Checking for filter updates...")
+        state.phases = ApplyChangesPhase.allCases.map { phase in
+            ApplyChangesPhaseProgress(phase: phase, status: phase == .updating ? .active : .pending)
+        }
+        state.progress = 0
+        resetProgressTracking()
+    }
+
+    func completeShortcutFilterUpdate(title: String, message: String, style: ApplyChangesCompletionStyle) {
+        state.isLoading = false
+        state.progress = 1
+        state.statusMessage = message
+        state.completion = ApplyChangesCompletion(title: title, message: message, style: style)
+        lastProgressValue = 1
+        lastProgressUpdate = Date()
+
+        let completedStatus: ApplyChangesPhaseStatus = style == .failure ? .failed : .complete
+        state.phases = state.phases.map { phase in
+            var updated = phase
+            switch phase.phase {
+            case .updating, .scripts:
+                updated.status = completedStatus
+            case .reading, .converting, .saving, .reloading:
+                updated.status = .pending
+            }
+            return updated
         }
     }
 

--- a/wBlock/ApplyChangesViewModel.swift
+++ b/wBlock/ApplyChangesViewModel.swift
@@ -67,26 +67,6 @@ struct ApplyChangesSummary: Equatable {
     var blockersApproachingLimit: Set<String>
 }
 
-enum ApplyChangesCompletionStyle: Equatable {
-    case success
-    case warning
-    case failure
-
-    var systemImage: String {
-        switch self {
-        case .success: return "checkmark.circle.fill"
-        case .warning: return "exclamationmark.triangle.fill"
-        case .failure: return "xmark.circle.fill"
-        }
-    }
-}
-
-struct ApplyChangesCompletion: Equatable {
-    var title: String
-    var message: String
-    var style: ApplyChangesCompletionStyle
-}
-
 /// Consolidated state for the apply progress presentation.
 struct ApplyChangesState: Equatable {
     var isLoading: Bool = false
@@ -103,14 +83,13 @@ struct ApplyChangesState: Equatable {
     var updatesFound: Int = 0
     var phases: [ApplyChangesPhaseProgress] = ApplyChangesPhase.allCases.map { ApplyChangesPhaseProgress(phase: $0, status: .pending) }
     var summary: ApplyChangesSummary? = nil
-    var completion: ApplyChangesCompletion? = nil
 
     var progressPercentage: Int {
         Int((0...1).clamp(progress) * 100)
     }
 
     var isComplete: Bool {
-        summary != nil || completion != nil
+        summary != nil
     }
 }
 
@@ -231,38 +210,6 @@ class ApplyChangesViewModel: ObservableObject {
             state.statusMessage = statusMessage
         } else if state.statusMessage.isEmpty || state.statusMessage.lowercased().contains("reloading") {
             state.statusMessage = String(localized: "Filters applied successfully.")
-        }
-    }
-
-    func prepareShortcutFilterUpdate() {
-        reset()
-        state.isLoading = true
-        state.statusMessage = String(localized: "Checking for filter updates...")
-        state.phases = ApplyChangesPhase.allCases.map { phase in
-            ApplyChangesPhaseProgress(phase: phase, status: phase == .updating ? .active : .pending)
-        }
-        state.progress = 0
-        resetProgressTracking()
-    }
-
-    func completeShortcutFilterUpdate(title: String, message: String, style: ApplyChangesCompletionStyle) {
-        state.isLoading = false
-        state.progress = 1
-        state.statusMessage = message
-        state.completion = ApplyChangesCompletion(title: title, message: message, style: style)
-        lastProgressValue = 1
-        lastProgressUpdate = Date()
-
-        let completedStatus: ApplyChangesPhaseStatus = style == .failure ? .failed : .complete
-        state.phases = state.phases.map { phase in
-            var updated = phase
-            switch phase.phase {
-            case .updating, .scripts:
-                updated.status = completedStatus
-            case .reading, .converting, .saving, .reloading:
-                updated.status = .pending
-            }
-            return updated
         }
     }
 

--- a/wBlock/ContentView.swift
+++ b/wBlock/ContentView.swift
@@ -731,7 +731,7 @@ struct ContentModifiers: ViewModifier {
                 }
                 filterManager.setUserScriptManager(userScriptManager)
                 #if canImport(AppIntents) && !os(visionOS)
-                applyShortcutFilterUpdatePresentation(ShortcutFilterUpdatePresentation.shared.state)
+                applyShortcutFilterUpdateIfNeeded()
                 #endif
             }
             // Show onboarding/setup sheets only on initial load
@@ -754,9 +754,9 @@ struct ContentModifiers: ViewModifier {
             }
             #if canImport(AppIntents) && !os(visionOS)
                 .onReceive(
-                    NotificationCenter.default.publisher(for: .shortcutFilterUpdatePresentationChanged)
+                    NotificationCenter.default.publisher(for: .shortcutFilterUpdateRequested)
                 ) { _ in
-                    applyShortcutFilterUpdatePresentation(ShortcutFilterUpdatePresentation.shared.state)
+                    applyShortcutFilterUpdateIfNeeded()
                 }
             #endif
             #if os(iOS)
@@ -768,10 +768,7 @@ struct ContentModifiers: ViewModifier {
                 .onReceive(
                     NotificationCenter.default.publisher(for: .applyWBlockChangesNotification)
                 ) { _ in
-                    filterManager.showingApplyProgressSheet = true
-                    Task {
-                        await filterManager.checkAndEnableFilters(forceReload: true)
-                    }
+                    applyFilterChangesFromExternalTrigger()
                 }
                 .fullScreenCover(isPresented: $showOnboardingSheet) {
                     OnboardingView(filterManager: filterManager)
@@ -791,36 +788,17 @@ struct ContentModifiers: ViewModifier {
         }
     }
 
-    #if canImport(AppIntents) && !os(visionOS)
-    private func applyShortcutFilterUpdatePresentation(_ state: ShortcutFilterUpdatePresentationState?) {
-        guard let state else { return }
-
-        switch state.style {
-        case .running:
-            filterManager.applyProgressViewModel.prepareShortcutFilterUpdate()
-            filterManager.showingApplyProgressSheet = true
-        case .success:
-            filterManager.applyProgressViewModel.completeShortcutFilterUpdate(
-                title: state.title,
-                message: state.message,
-                style: .success
-            )
-            filterManager.showingApplyProgressSheet = true
-        case .warning:
-            filterManager.applyProgressViewModel.completeShortcutFilterUpdate(
-                title: state.title,
-                message: state.message,
-                style: .warning
-            )
-            filterManager.showingApplyProgressSheet = true
-        case .failure:
-            filterManager.applyProgressViewModel.completeShortcutFilterUpdate(
-                title: state.title,
-                message: state.message,
-                style: .failure
-            )
-            filterManager.showingApplyProgressSheet = true
+    private func applyFilterChangesFromExternalTrigger() {
+        guard !filterManager.isLoading else { return }
+        Task {
+            await filterManager.checkAndEnableFilters(forceReload: true)
         }
+    }
+
+    #if canImport(AppIntents) && !os(visionOS)
+    private func applyShortcutFilterUpdateIfNeeded() {
+        guard ShortcutFilterUpdateRequest.shared.consumePendingRequest() else { return }
+        applyFilterChangesFromExternalTrigger()
     }
     #endif
     #if os(iOS)

--- a/wBlock/ContentView.swift
+++ b/wBlock/ContentView.swift
@@ -158,9 +158,7 @@ struct ContentView: View {
 
     private func applyPendingChanges() {
         guard !filterManager.isLoading else { return }
-        Task {
-            await filterManager.checkAndEnableFilters(forceReload: true)
-        }
+        filterManager.checkAndEnableFilters(forceReload: true)
     }
 
     private var applyChangesToolbarButton: some View {
@@ -790,9 +788,7 @@ struct ContentModifiers: ViewModifier {
 
     private func applyFilterChangesFromExternalTrigger() {
         guard !filterManager.isLoading else { return }
-        Task {
-            await filterManager.checkAndEnableFilters(forceReload: true)
-        }
+        filterManager.checkAndEnableFilters(forceReload: true)
     }
 
     #if canImport(AppIntents) && !os(visionOS)

--- a/wBlock/ContentView.swift
+++ b/wBlock/ContentView.swift
@@ -730,6 +730,9 @@ struct ContentModifiers: ViewModifier {
                         .startup, "wBlock application appeared", metadata: [:])
                 }
                 filterManager.setUserScriptManager(userScriptManager)
+                #if canImport(AppIntents) && !os(visionOS)
+                applyShortcutFilterUpdatePresentation(ShortcutFilterUpdatePresentation.shared.state)
+                #endif
             }
             // Show onboarding/setup sheets only on initial load
             .task {
@@ -749,6 +752,13 @@ struct ContentModifiers: ViewModifier {
                     showOnboardingSheet = true
                 }
             }
+            #if canImport(AppIntents) && !os(visionOS)
+                .onReceive(
+                    NotificationCenter.default.publisher(for: .shortcutFilterUpdatePresentationChanged)
+                ) { _ in
+                    applyShortcutFilterUpdatePresentation(ShortcutFilterUpdatePresentation.shared.state)
+                }
+            #endif
             #if os(iOS)
                 .onChangeCompat(of: scenePhase) { _, newPhase in
                     if newPhase == .background && filterManager.hasUnappliedChanges {
@@ -781,6 +791,38 @@ struct ContentModifiers: ViewModifier {
         }
     }
 
+    #if canImport(AppIntents) && !os(visionOS)
+    private func applyShortcutFilterUpdatePresentation(_ state: ShortcutFilterUpdatePresentationState?) {
+        guard let state else { return }
+
+        switch state.style {
+        case .running:
+            filterManager.applyProgressViewModel.prepareShortcutFilterUpdate()
+            filterManager.showingApplyProgressSheet = true
+        case .success:
+            filterManager.applyProgressViewModel.completeShortcutFilterUpdate(
+                title: state.title,
+                message: state.message,
+                style: .success
+            )
+            filterManager.showingApplyProgressSheet = true
+        case .warning:
+            filterManager.applyProgressViewModel.completeShortcutFilterUpdate(
+                title: state.title,
+                message: state.message,
+                style: .warning
+            )
+            filterManager.showingApplyProgressSheet = true
+        case .failure:
+            filterManager.applyProgressViewModel.completeShortcutFilterUpdate(
+                title: state.title,
+                message: state.message,
+                style: .failure
+            )
+            filterManager.showingApplyProgressSheet = true
+        }
+    }
+    #endif
     #if os(iOS)
         private func scheduleNotification(delay: TimeInterval = 1.0) {
             let content = UNMutableNotificationContent()

--- a/wBlock/ContentView.swift
+++ b/wBlock/ContentView.swift
@@ -793,8 +793,11 @@ struct ContentModifiers: ViewModifier {
 
     #if canImport(AppIntents) && !os(visionOS)
     private func applyShortcutFilterUpdateIfNeeded() {
-        guard ShortcutFilterUpdateRequest.shared.consumePendingRequest() else { return }
-        applyFilterChangesFromExternalTrigger()
+        Task { @MainActor in
+            await filterManager.waitUntilReady()
+            guard ShortcutFilterUpdateRequest.shared.consumePendingRequest() else { return }
+            applyFilterChangesFromExternalTrigger()
+        }
     }
     #endif
     #if os(iOS)

--- a/wBlock/FilterUpdateShortcuts.swift
+++ b/wBlock/FilterUpdateShortcuts.swift
@@ -3,6 +3,91 @@ import AppIntents
 import Foundation
 import wBlockCoreService
 
+extension Notification.Name {
+    static let shortcutFilterUpdatePresentationChanged = Notification.Name("shortcutFilterUpdatePresentationChanged")
+}
+
+enum ShortcutFilterUpdatePresentationResult {
+    case updated
+    case noUpdates
+    case skipped
+    case deferred
+    case failed
+    case cancelled
+}
+
+enum ShortcutFilterUpdatePresentationStyle: String {
+    case running
+    case success
+    case warning
+    case failure
+}
+
+struct ShortcutFilterUpdatePresentationState {
+    var title: String
+    var message: String
+    var style: ShortcutFilterUpdatePresentationStyle
+}
+
+@MainActor
+final class ShortcutFilterUpdatePresentation {
+    static let shared = ShortcutFilterUpdatePresentation()
+
+    private(set) var state: ShortcutFilterUpdatePresentationState?
+
+    private init() {}
+
+    func start() {
+        state = ShortcutFilterUpdatePresentationState(
+            title: String(localized: "Updating wBlock Filters"),
+            message: String(localized: "Checking for filter updates..."),
+            style: .running
+        )
+        postChange()
+    }
+
+    func finish(result: ShortcutFilterUpdatePresentationResult, message: String) {
+        state = ShortcutFilterUpdatePresentationState(
+            title: Self.title(for: result),
+            message: message,
+            style: Self.style(for: result)
+        )
+        postChange()
+    }
+
+    private func postChange() {
+        NotificationCenter.default.post(name: .shortcutFilterUpdatePresentationChanged, object: nil)
+    }
+
+    private static func title(for result: ShortcutFilterUpdatePresentationResult) -> String {
+        switch result {
+        case .updated:
+            return String(localized: "wBlock Filters Updated")
+        case .noUpdates:
+            return String(localized: "No Filter Updates")
+        case .skipped:
+            return String(localized: "Filter Update Skipped")
+        case .deferred:
+            return String(localized: "Filter Update Deferred")
+        case .failed:
+            return String(localized: "Filter Update Failed")
+        case .cancelled:
+            return String(localized: "Filter Update Cancelled")
+        }
+    }
+
+    private static func style(for result: ShortcutFilterUpdatePresentationResult) -> ShortcutFilterUpdatePresentationStyle {
+        switch result {
+        case .updated, .noUpdates:
+            return .success
+        case .skipped, .deferred, .cancelled:
+            return .warning
+        case .failed:
+            return .failure
+        }
+    }
+}
+
 @available(iOS 16.0, macOS 13.0, *)
 enum FilterUpdateShortcutResult: String, AppEnum {
     case updated
@@ -22,6 +107,26 @@ enum FilterUpdateShortcutResult: String, AppEnum {
         .failed: "Failed",
         .cancelled: "Cancelled",
     ]
+}
+
+@available(iOS 16.0, macOS 13.0, *)
+private extension ShortcutFilterUpdatePresentationResult {
+    init(_ result: FilterUpdateShortcutResult) {
+        switch result {
+        case .updated:
+            self = .updated
+        case .noUpdates:
+            self = .noUpdates
+        case .skipped:
+            self = .skipped
+        case .deferred:
+            self = .deferred
+        case .failed:
+            self = .failed
+        case .cancelled:
+            self = .cancelled
+        }
+    }
 }
 
 @available(iOS 16.0, macOS 13.0, *)
@@ -45,6 +150,8 @@ struct UpdateWBlockFiltersIntent: AppIntent {
     }
 
     func perform() async throws -> some ReturnsValue<FilterUpdateShortcutResult> & ProvidesDialog {
+        await ShortcutFilterUpdatePresentation.shared.start()
+
         let trigger = "Shortcut"
         let outcome = await SharedAutoUpdateManager.shared.maybeRunAutoUpdate(
             trigger: trigger,
@@ -52,57 +159,61 @@ struct UpdateWBlockFiltersIntent: AppIntent {
             policy: .foreground(trigger: trigger)
         )
         let response = Self.response(for: outcome)
-        return .result(value: response.result, dialog: response.dialog)
+        await ShortcutFilterUpdatePresentation.shared.finish(
+            result: ShortcutFilterUpdatePresentationResult(response.result),
+            message: response.message
+        )
+        return .result(value: response.result, dialog: IntentDialog(stringLiteral: response.message))
     }
 
     private static func response(
         for outcome: SharedAutoUpdateManager.AutoUpdateRunOutcome
-    ) -> (result: FilterUpdateShortcutResult, dialog: IntentDialog) {
+    ) -> (result: FilterUpdateShortcutResult, message: String) {
         switch outcome {
         case let .completed(completion):
             return completedResponse(for: completion)
         case let .skipped(reason):
             return (.skipped, skippedDialog(for: reason))
         case .cancelled:
-            return (.cancelled, "wBlock filter update was cancelled.")
+            return (.cancelled, String(localized: "wBlock filter update was cancelled."))
         case .deferred(_):
-            return (.deferred, "wBlock filter update was deferred. Open wBlock to finish updating.")
+            return (.deferred, String(localized: "wBlock filter update was deferred. Open wBlock to finish updating."))
         case .failed(_):
-            return (.failed, "wBlock filter update failed. Open wBlock for details.")
+            return (.failed, String(localized: "wBlock filter update failed. Open wBlock for details."))
         }
     }
 
     private static func completedResponse(
         for completion: SharedAutoUpdateManager.AutoUpdateCompletion
-    ) -> (result: FilterUpdateShortcutResult, dialog: IntentDialog) {
+    ) -> (result: FilterUpdateShortcutResult, message: String) {
         let didUpdate = completion.updatedFilters > 0 || completion.updatedScripts > 0
 
         switch completion.result {
         case .appliedUpdates:
-            return (.updated, "wBlock filters updated.")
+            return (.updated, String(localized: "wBlock filters updated."))
         case .noFilterUpdates where completion.updatedScripts > 0:
-            return (.updated, "No filter updates found. Userscripts updated.")
+            return (.updated, String(localized: "No filter updates found. Userscripts updated."))
         case .noFilterUpdates:
-            return (.noUpdates, "No filter updates found.")
+            return (.noUpdates, String(localized: "No filter updates found."))
         case .noSelectedFilters where didUpdate:
-            return (.updated, "No filters are selected. Userscripts updated.")
+            return (.updated, String(localized: "No filters are selected. Userscripts updated."))
         case .noSelectedFilters:
-            return (.noUpdates, "No filters are selected.")
+            return (.noUpdates, String(localized: "No filters are selected."))
         }
     }
 
-    private static func skippedDialog(for reason: String) -> IntentDialog {
+    private static func skippedDialog(for reason: String) -> String {
         switch reason {
         case "already_running":
-            return "wBlock filter update is already running."
+            return String(localized: "wBlock filter update is already running.")
         case "auto_update_disabled":
-            return "wBlock filter auto-update is disabled."
+            return String(localized: "wBlock filter auto-update is disabled.")
         case "throttled_not_eligible", "throttled_legacy_interval":
-            return "wBlock filter update skipped because it is not due yet."
+            return String(localized: "wBlock filter update skipped because it is not due yet.")
         case "extension_safe_mode":
-            return "Open wBlock to update filters."
+            return String(localized: "Open wBlock to update filters.")
         default:
-            return "wBlock filter update skipped."
+            return String(localized: "wBlock filter update skipped.")
         }
     }
 }

--- a/wBlock/FilterUpdateShortcuts.swift
+++ b/wBlock/FilterUpdateShortcuts.swift
@@ -1,131 +1,28 @@
 #if canImport(AppIntents) && !os(visionOS)
 import AppIntents
 import Foundation
-import wBlockCoreService
 
 extension Notification.Name {
-    static let shortcutFilterUpdatePresentationChanged = Notification.Name("shortcutFilterUpdatePresentationChanged")
-}
-
-enum ShortcutFilterUpdatePresentationResult {
-    case updated
-    case noUpdates
-    case skipped
-    case deferred
-    case failed
-    case cancelled
-}
-
-enum ShortcutFilterUpdatePresentationStyle: String {
-    case running
-    case success
-    case warning
-    case failure
-}
-
-struct ShortcutFilterUpdatePresentationState {
-    var title: String
-    var message: String
-    var style: ShortcutFilterUpdatePresentationStyle
+    static let shortcutFilterUpdateRequested = Notification.Name("shortcutFilterUpdateRequested")
 }
 
 @MainActor
-final class ShortcutFilterUpdatePresentation {
-    static let shared = ShortcutFilterUpdatePresentation()
+final class ShortcutFilterUpdateRequest {
+    static let shared = ShortcutFilterUpdateRequest()
 
-    private(set) var state: ShortcutFilterUpdatePresentationState?
+    private var isPending = false
 
     private init() {}
 
-    func start() {
-        state = ShortcutFilterUpdatePresentationState(
-            title: String(localized: "Updating wBlock Filters"),
-            message: String(localized: "Checking for filter updates..."),
-            style: .running
-        )
-        postChange()
+    func requestUpdate() {
+        isPending = true
+        NotificationCenter.default.post(name: .shortcutFilterUpdateRequested, object: nil)
     }
 
-    func finish(result: ShortcutFilterUpdatePresentationResult, message: String) {
-        state = ShortcutFilterUpdatePresentationState(
-            title: Self.title(for: result),
-            message: message,
-            style: Self.style(for: result)
-        )
-        postChange()
-    }
-
-    private func postChange() {
-        NotificationCenter.default.post(name: .shortcutFilterUpdatePresentationChanged, object: nil)
-    }
-
-    private static func title(for result: ShortcutFilterUpdatePresentationResult) -> String {
-        switch result {
-        case .updated:
-            return String(localized: "wBlock Filters Updated")
-        case .noUpdates:
-            return String(localized: "No Filter Updates")
-        case .skipped:
-            return String(localized: "Filter Update Skipped")
-        case .deferred:
-            return String(localized: "Filter Update Deferred")
-        case .failed:
-            return String(localized: "Filter Update Failed")
-        case .cancelled:
-            return String(localized: "Filter Update Cancelled")
-        }
-    }
-
-    private static func style(for result: ShortcutFilterUpdatePresentationResult) -> ShortcutFilterUpdatePresentationStyle {
-        switch result {
-        case .updated, .noUpdates:
-            return .success
-        case .skipped, .deferred, .cancelled:
-            return .warning
-        case .failed:
-            return .failure
-        }
-    }
-}
-
-@available(iOS 16.0, macOS 13.0, *)
-enum FilterUpdateShortcutResult: String, AppEnum {
-    case updated
-    case noUpdates
-    case skipped
-    case deferred
-    case failed
-    case cancelled
-
-    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Filter Update Result")
-
-    static var caseDisplayRepresentations: [FilterUpdateShortcutResult: DisplayRepresentation] = [
-        .updated: "Updated",
-        .noUpdates: "No Updates",
-        .skipped: "Skipped",
-        .deferred: "Deferred",
-        .failed: "Failed",
-        .cancelled: "Cancelled",
-    ]
-}
-
-@available(iOS 16.0, macOS 13.0, *)
-private extension ShortcutFilterUpdatePresentationResult {
-    init(_ result: FilterUpdateShortcutResult) {
-        switch result {
-        case .updated:
-            self = .updated
-        case .noUpdates:
-            self = .noUpdates
-        case .skipped:
-            self = .skipped
-        case .deferred:
-            self = .deferred
-        case .failed:
-            self = .failed
-        case .cancelled:
-            self = .cancelled
-        }
+    func consumePendingRequest() -> Bool {
+        guard isPending else { return false }
+        isPending = false
+        return true
     }
 }
 
@@ -135,86 +32,11 @@ struct UpdateWBlockFiltersIntent: AppIntent {
     static var description = IntentDescription("Checks for wBlock filter updates and applies them when available.")
     static var openAppWhenRun: Bool { true }
 
-    @Parameter(
-        title: "Force Check",
-        description: "Check now even if automatic updates are not due yet."
-    )
-    var forceCheck: Bool
+    init() {}
 
-    init() {
-        self.forceCheck = false
-    }
-
-    init(forceCheck: Bool) {
-        self.forceCheck = forceCheck
-    }
-
-    func perform() async throws -> some ReturnsValue<FilterUpdateShortcutResult> & ProvidesDialog {
-        await ShortcutFilterUpdatePresentation.shared.start()
-
-        let trigger = "Shortcut"
-        let outcome = await SharedAutoUpdateManager.shared.maybeRunAutoUpdate(
-            trigger: trigger,
-            force: forceCheck,
-            policy: .foreground(trigger: trigger)
-        )
-        let response = Self.response(for: outcome)
-        await ShortcutFilterUpdatePresentation.shared.finish(
-            result: ShortcutFilterUpdatePresentationResult(response.result),
-            message: response.message
-        )
-        return .result(value: response.result, dialog: IntentDialog(stringLiteral: response.message))
-    }
-
-    private static func response(
-        for outcome: SharedAutoUpdateManager.AutoUpdateRunOutcome
-    ) -> (result: FilterUpdateShortcutResult, message: String) {
-        switch outcome {
-        case let .completed(completion):
-            return completedResponse(for: completion)
-        case let .skipped(reason):
-            return (.skipped, skippedDialog(for: reason))
-        case .cancelled:
-            return (.cancelled, String(localized: "wBlock filter update was cancelled."))
-        case .deferred(_):
-            return (.deferred, String(localized: "wBlock filter update was deferred. Open wBlock to finish updating."))
-        case .failed(_):
-            return (.failed, String(localized: "wBlock filter update failed. Open wBlock for details."))
-        }
-    }
-
-    private static func completedResponse(
-        for completion: SharedAutoUpdateManager.AutoUpdateCompletion
-    ) -> (result: FilterUpdateShortcutResult, message: String) {
-        let didUpdate = completion.updatedFilters > 0 || completion.updatedScripts > 0
-
-        switch completion.result {
-        case .appliedUpdates:
-            return (.updated, String(localized: "wBlock filters updated."))
-        case .noFilterUpdates where completion.updatedScripts > 0:
-            return (.updated, String(localized: "No filter updates found. Userscripts updated."))
-        case .noFilterUpdates:
-            return (.noUpdates, String(localized: "No filter updates found."))
-        case .noSelectedFilters where didUpdate:
-            return (.updated, String(localized: "No filters are selected. Userscripts updated."))
-        case .noSelectedFilters:
-            return (.noUpdates, String(localized: "No filters are selected."))
-        }
-    }
-
-    private static func skippedDialog(for reason: String) -> String {
-        switch reason {
-        case "already_running":
-            return String(localized: "wBlock filter update is already running.")
-        case "auto_update_disabled":
-            return String(localized: "wBlock filter auto-update is disabled.")
-        case "throttled_not_eligible", "throttled_legacy_interval":
-            return String(localized: "wBlock filter update skipped because it is not due yet.")
-        case "extension_safe_mode":
-            return String(localized: "Open wBlock to update filters.")
-        default:
-            return String(localized: "wBlock filter update skipped.")
-        }
+    func perform() async throws -> some ProvidesDialog {
+        await ShortcutFilterUpdateRequest.shared.requestUpdate()
+        return .result(dialog: "wBlock filter update started.")
     }
 }
 

--- a/wBlock/FilterUpdateShortcuts.swift
+++ b/wBlock/FilterUpdateShortcuts.swift
@@ -1,0 +1,125 @@
+#if canImport(AppIntents) && !os(visionOS)
+import AppIntents
+import Foundation
+import wBlockCoreService
+
+@available(iOS 16.0, macOS 13.0, *)
+enum FilterUpdateShortcutResult: String, AppEnum {
+    case updated
+    case noUpdates
+    case skipped
+    case deferred
+    case failed
+    case cancelled
+
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Filter Update Result")
+
+    static var caseDisplayRepresentations: [FilterUpdateShortcutResult: DisplayRepresentation] = [
+        .updated: "Updated",
+        .noUpdates: "No Updates",
+        .skipped: "Skipped",
+        .deferred: "Deferred",
+        .failed: "Failed",
+        .cancelled: "Cancelled",
+    ]
+}
+
+@available(iOS 16.0, macOS 13.0, *)
+struct UpdateWBlockFiltersIntent: AppIntent {
+    static var title: LocalizedStringResource = "Update wBlock Filters"
+    static var description = IntentDescription("Checks for wBlock filter updates and applies them when available.")
+    static var openAppWhenRun: Bool { true }
+
+    @Parameter(
+        title: "Force Check",
+        description: "Check now even if automatic updates are not due yet."
+    )
+    var forceCheck: Bool
+
+    init() {
+        self.forceCheck = false
+    }
+
+    init(forceCheck: Bool) {
+        self.forceCheck = forceCheck
+    }
+
+    func perform() async throws -> some ReturnsValue<FilterUpdateShortcutResult> & ProvidesDialog {
+        let trigger = "Shortcut"
+        let outcome = await SharedAutoUpdateManager.shared.maybeRunAutoUpdate(
+            trigger: trigger,
+            force: forceCheck,
+            policy: .foreground(trigger: trigger)
+        )
+        let response = Self.response(for: outcome)
+        return .result(value: response.result, dialog: response.dialog)
+    }
+
+    private static func response(
+        for outcome: SharedAutoUpdateManager.AutoUpdateRunOutcome
+    ) -> (result: FilterUpdateShortcutResult, dialog: IntentDialog) {
+        switch outcome {
+        case let .completed(completion):
+            return completedResponse(for: completion)
+        case let .skipped(reason):
+            return (.skipped, skippedDialog(for: reason))
+        case .cancelled:
+            return (.cancelled, "wBlock filter update was cancelled.")
+        case .deferred(_):
+            return (.deferred, "wBlock filter update was deferred. Open wBlock to finish updating.")
+        case .failed(_):
+            return (.failed, "wBlock filter update failed. Open wBlock for details.")
+        }
+    }
+
+    private static func completedResponse(
+        for completion: SharedAutoUpdateManager.AutoUpdateCompletion
+    ) -> (result: FilterUpdateShortcutResult, dialog: IntentDialog) {
+        let didUpdate = completion.updatedFilters > 0 || completion.updatedScripts > 0
+
+        switch completion.result {
+        case .appliedUpdates:
+            return (.updated, "wBlock filters updated.")
+        case .noFilterUpdates where completion.updatedScripts > 0:
+            return (.updated, "No filter updates found. Userscripts updated.")
+        case .noFilterUpdates:
+            return (.noUpdates, "No filter updates found.")
+        case .noSelectedFilters where didUpdate:
+            return (.updated, "No filters are selected. Userscripts updated.")
+        case .noSelectedFilters:
+            return (.noUpdates, "No filters are selected.")
+        }
+    }
+
+    private static func skippedDialog(for reason: String) -> IntentDialog {
+        switch reason {
+        case "already_running":
+            return "wBlock filter update is already running."
+        case "auto_update_disabled":
+            return "wBlock filter auto-update is disabled."
+        case "throttled_not_eligible", "throttled_legacy_interval":
+            return "wBlock filter update skipped because it is not due yet."
+        case "extension_safe_mode":
+            return "Open wBlock to update filters."
+        default:
+            return "wBlock filter update skipped."
+        }
+    }
+}
+
+@available(iOS 16.0, macOS 13.0, *)
+struct WBlockShortcutsProvider: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: UpdateWBlockFiltersIntent(),
+            phrases: [
+                "Update \(.applicationName) filters",
+                "Check \(.applicationName) filters",
+                "Update filters in \(.applicationName)",
+            ],
+            shortTitle: "Update Filters",
+            systemImageName: "arrow.triangle.2.circlepath"
+        )
+    }
+}
+#endif

--- a/wBlock/FilterUpdateShortcuts.swift
+++ b/wBlock/FilterUpdateShortcuts.swift
@@ -34,9 +34,10 @@ struct UpdateWBlockFiltersIntent: AppIntent {
 
     init() {}
 
+    @MainActor
     func perform() async throws -> some ProvidesDialog {
-        await ShortcutFilterUpdateRequest.shared.requestUpdate()
-        return .result(dialog: "wBlock filter update started.")
+        ShortcutFilterUpdateRequest.shared.requestUpdate()
+        return .result(dialog: IntentDialog("wBlock filter update started."))
     }
 }
 

--- a/wBlock/ar.lproj/Localizable.strings
+++ b/wBlock/ar.lproj/Localizable.strings
@@ -701,3 +701,12 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/ar.lproj/Localizable.strings
+++ b/wBlock/ar.lproj/Localizable.strings
@@ -677,36 +677,8 @@ To re-enable these filters, disable other large filters and apply changes again.
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/ar.lproj/Localizable.strings
+++ b/wBlock/ar.lproj/Localizable.strings
@@ -676,3 +676,28 @@ To re-enable these filters, disable other large filters and apply changes again.
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/de.lproj/Localizable.strings
+++ b/wBlock/de.lproj/Localizable.strings
@@ -676,3 +676,28 @@ Um diese Filter wieder zu aktivieren, deaktiviere andere große Filter und wende
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/de.lproj/Localizable.strings
+++ b/wBlock/de.lproj/Localizable.strings
@@ -701,3 +701,12 @@ Um diese Filter wieder zu aktivieren, deaktiviere andere große Filter und wende
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/de.lproj/Localizable.strings
+++ b/wBlock/de.lproj/Localizable.strings
@@ -677,36 +677,8 @@ Um diese Filter wieder zu aktivieren, deaktiviere andere große Filter und wende
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/el.lproj/Localizable.strings
+++ b/wBlock/el.lproj/Localizable.strings
@@ -701,3 +701,12 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/el.lproj/Localizable.strings
+++ b/wBlock/el.lproj/Localizable.strings
@@ -677,36 +677,8 @@ To re-enable these filters, disable other large filters and apply changes again.
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/el.lproj/Localizable.strings
+++ b/wBlock/el.lproj/Localizable.strings
@@ -676,3 +676,28 @@ To re-enable these filters, disable other large filters and apply changes again.
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/en.lproj/Localizable.strings
+++ b/wBlock/en.lproj/Localizable.strings
@@ -701,3 +701,12 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/en.lproj/Localizable.strings
+++ b/wBlock/en.lproj/Localizable.strings
@@ -677,36 +677,8 @@ To re-enable these filters, disable other large filters and apply changes again.
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/en.lproj/Localizable.strings
+++ b/wBlock/en.lproj/Localizable.strings
@@ -676,3 +676,28 @@ To re-enable these filters, disable other large filters and apply changes again.
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/es.lproj/Localizable.strings
+++ b/wBlock/es.lproj/Localizable.strings
@@ -701,3 +701,12 @@ Para volver a activarlos, desactiva otros filtros grandes y aplica los cambios d
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/es.lproj/Localizable.strings
+++ b/wBlock/es.lproj/Localizable.strings
@@ -676,3 +676,28 @@ Para volver a activarlos, desactiva otros filtros grandes y aplica los cambios d
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/es.lproj/Localizable.strings
+++ b/wBlock/es.lproj/Localizable.strings
@@ -677,36 +677,8 @@ Para volver a activarlos, desactiva otros filtros grandes y aplica los cambios d
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/fr.lproj/Localizable.strings
+++ b/wBlock/fr.lproj/Localizable.strings
@@ -677,36 +677,8 @@ Pour les réactiver, désactivez d’autres gros filtres puis appliquez à nouve
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/fr.lproj/Localizable.strings
+++ b/wBlock/fr.lproj/Localizable.strings
@@ -676,3 +676,28 @@ Pour les réactiver, désactivez d’autres gros filtres puis appliquez à nouve
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/fr.lproj/Localizable.strings
+++ b/wBlock/fr.lproj/Localizable.strings
@@ -701,3 +701,12 @@ Pour les réactiver, désactivez d’autres gros filtres puis appliquez à nouve
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/hu.lproj/Localizable.strings
+++ b/wBlock/hu.lproj/Localizable.strings
@@ -678,36 +678,8 @@ Az újbóli engedélyezésükhöz tilts le más nagy szűrőket, majd alkalmazd 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/hu.lproj/Localizable.strings
+++ b/wBlock/hu.lproj/Localizable.strings
@@ -677,3 +677,28 @@ Az újbóli engedélyezésükhöz tilts le más nagy szűrőket, majd alkalmazd 
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/hu.lproj/Localizable.strings
+++ b/wBlock/hu.lproj/Localizable.strings
@@ -702,3 +702,12 @@ Az újbóli engedélyezésükhöz tilts le más nagy szűrőket, majd alkalmazd 
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/it.lproj/Localizable.strings
+++ b/wBlock/it.lproj/Localizable.strings
@@ -676,3 +676,28 @@ Per riattivarli, disattiva altri filtri grandi e applica di nuovo le modifiche."
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/it.lproj/Localizable.strings
+++ b/wBlock/it.lproj/Localizable.strings
@@ -701,3 +701,12 @@ Per riattivarli, disattiva altri filtri grandi e applica di nuovo le modifiche."
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/it.lproj/Localizable.strings
+++ b/wBlock/it.lproj/Localizable.strings
@@ -677,36 +677,8 @@ Per riattivarli, disattiva altri filtri grandi e applica di nuovo le modifiche."
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/ja.lproj/Localizable.strings
+++ b/wBlock/ja.lproj/Localizable.strings
@@ -701,3 +701,12 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/ja.lproj/Localizable.strings
+++ b/wBlock/ja.lproj/Localizable.strings
@@ -677,36 +677,8 @@ To re-enable these filters, disable other large filters and apply changes again.
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/ja.lproj/Localizable.strings
+++ b/wBlock/ja.lproj/Localizable.strings
@@ -676,3 +676,28 @@ To re-enable these filters, disable other large filters and apply changes again.
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/ko.lproj/Localizable.strings
+++ b/wBlock/ko.lproj/Localizable.strings
@@ -701,3 +701,12 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/ko.lproj/Localizable.strings
+++ b/wBlock/ko.lproj/Localizable.strings
@@ -677,36 +677,8 @@ To re-enable these filters, disable other large filters and apply changes again.
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/ko.lproj/Localizable.strings
+++ b/wBlock/ko.lproj/Localizable.strings
@@ -676,3 +676,28 @@ To re-enable these filters, disable other large filters and apply changes again.
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/pl.lproj/Localizable.strings
+++ b/wBlock/pl.lproj/Localizable.strings
@@ -701,3 +701,12 @@ Aby włączyć je ponownie, wyłącz inne duże filtry i ponownie zastosuj zmian
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/pl.lproj/Localizable.strings
+++ b/wBlock/pl.lproj/Localizable.strings
@@ -677,36 +677,8 @@ Aby włączyć je ponownie, wyłącz inne duże filtry i ponownie zastosuj zmian
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/pl.lproj/Localizable.strings
+++ b/wBlock/pl.lproj/Localizable.strings
@@ -676,3 +676,28 @@ Aby włączyć je ponownie, wyłącz inne duże filtry i ponownie zastosuj zmian
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/pt-BR.lproj/Localizable.strings
+++ b/wBlock/pt-BR.lproj/Localizable.strings
@@ -677,36 +677,8 @@ Para reativá-los, desative outros filtros grandes e aplique as alterações nov
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/pt-BR.lproj/Localizable.strings
+++ b/wBlock/pt-BR.lproj/Localizable.strings
@@ -701,3 +701,12 @@ Para reativá-los, desative outros filtros grandes e aplique as alterações nov
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/pt-BR.lproj/Localizable.strings
+++ b/wBlock/pt-BR.lproj/Localizable.strings
@@ -676,3 +676,28 @@ Para reativá-los, desative outros filtros grandes e aplique as alterações nov
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/ro.lproj/Localizable.strings
+++ b/wBlock/ro.lproj/Localizable.strings
@@ -676,3 +676,28 @@ Pentru a le reactiva, dezactivează alte filtre mari și aplică din nou modific
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/ro.lproj/Localizable.strings
+++ b/wBlock/ro.lproj/Localizable.strings
@@ -701,3 +701,12 @@ Pentru a le reactiva, dezactivează alte filtre mari și aplică din nou modific
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/ro.lproj/Localizable.strings
+++ b/wBlock/ro.lproj/Localizable.strings
@@ -677,36 +677,8 @@ Pentru a le reactiva, dezactivează alte filtre mari și aplică din nou modific
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/ru.lproj/Localizable.strings
+++ b/wBlock/ru.lproj/Localizable.strings
@@ -701,3 +701,12 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/ru.lproj/Localizable.strings
+++ b/wBlock/ru.lproj/Localizable.strings
@@ -677,36 +677,8 @@ To re-enable these filters, disable other large filters and apply changes again.
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/ru.lproj/Localizable.strings
+++ b/wBlock/ru.lproj/Localizable.strings
@@ -676,3 +676,28 @@ To re-enable these filters, disable other large filters and apply changes again.
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/tr.lproj/Localizable.strings
+++ b/wBlock/tr.lproj/Localizable.strings
@@ -701,3 +701,12 @@ Bu filtreleri yeniden etkinleştirmek için diğer büyük filtreleri kapatıp d
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/tr.lproj/Localizable.strings
+++ b/wBlock/tr.lproj/Localizable.strings
@@ -676,3 +676,28 @@ Bu filtreleri yeniden etkinleştirmek için diğer büyük filtreleri kapatıp d
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/tr.lproj/Localizable.strings
+++ b/wBlock/tr.lproj/Localizable.strings
@@ -677,36 +677,8 @@ Bu filtreleri yeniden etkinleştirmek için diğer büyük filtreleri kapatıp d
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/zh-Hans.lproj/Localizable.strings
+++ b/wBlock/zh-Hans.lproj/Localizable.strings
@@ -701,3 +701,12 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/zh-Hans.lproj/Localizable.strings
+++ b/wBlock/zh-Hans.lproj/Localizable.strings
@@ -677,36 +677,8 @@ To re-enable these filters, disable other large filters and apply changes again.
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/zh-Hans.lproj/Localizable.strings
+++ b/wBlock/zh-Hans.lproj/Localizable.strings
@@ -676,3 +676,28 @@ To re-enable these filters, disable other large filters and apply changes again.
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlock/zh-Hant.lproj/Localizable.strings
+++ b/wBlock/zh-Hant.lproj/Localizable.strings
@@ -701,3 +701,12 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Open wBlock to update filters." = "Open wBlock to update filters.";
 "wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
+
+"Updating wBlock Filters" = "Updating wBlock Filters";
+"Checking for filter updates..." = "Checking for filter updates...";
+"wBlock Filters Updated" = "wBlock Filters Updated";
+"No Filter Updates" = "No Filter Updates";
+"Filter Update Skipped" = "Filter Update Skipped";
+"Filter Update Deferred" = "Filter Update Deferred";
+"Filter Update Failed" = "Filter Update Failed";
+"Filter Update Cancelled" = "Filter Update Cancelled";

--- a/wBlock/zh-Hant.lproj/Localizable.strings
+++ b/wBlock/zh-Hant.lproj/Localizable.strings
@@ -677,36 +677,8 @@ To re-enable these filters, disable other large filters and apply changes again.
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
 
-"Filter Update Result" = "Filter Update Result";
-"Updated" = "Updated";
-"No Updates" = "No Updates";
-"Skipped" = "Skipped";
-"Deferred" = "Deferred";
-"Cancelled" = "Cancelled";
 "Update wBlock Filters" = "Update wBlock Filters";
 "Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
-"Force Check" = "Force Check";
-"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
-"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
-"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
-"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
-"wBlock filters updated." = "wBlock filters updated.";
-"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
-"No filter updates found." = "No filter updates found.";
-"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
-"No filters are selected." = "No filters are selected.";
-"wBlock filter update is already running." = "wBlock filter update is already running.";
-"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
-"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
-"Open wBlock to update filters." = "Open wBlock to update filters.";
-"wBlock filter update skipped." = "wBlock filter update skipped.";
 "Update Filters" = "Update Filters";
 
-"Updating wBlock Filters" = "Updating wBlock Filters";
-"Checking for filter updates..." = "Checking for filter updates...";
-"wBlock Filters Updated" = "wBlock Filters Updated";
-"No Filter Updates" = "No Filter Updates";
-"Filter Update Skipped" = "Filter Update Skipped";
-"Filter Update Deferred" = "Filter Update Deferred";
-"Filter Update Failed" = "Filter Update Failed";
-"Filter Update Cancelled" = "Filter Update Cancelled";
+"wBlock filter update started." = "wBlock filter update started.";

--- a/wBlock/zh-Hant.lproj/Localizable.strings
+++ b/wBlock/zh-Hant.lproj/Localizable.strings
@@ -676,3 +676,28 @@ To re-enable these filters, disable other large filters and apply changes again.
 
 "HaGeZi Referral Allowlist" = "HaGeZi Referral Allowlist";
 "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects." = "Unblocks affiliate and tracking referral links that otherwise break in emails, search results, and redirects.";
+
+"Filter Update Result" = "Filter Update Result";
+"Updated" = "Updated";
+"No Updates" = "No Updates";
+"Skipped" = "Skipped";
+"Deferred" = "Deferred";
+"Cancelled" = "Cancelled";
+"Update wBlock Filters" = "Update wBlock Filters";
+"Checks for wBlock filter updates and applies them when available." = "Checks for wBlock filter updates and applies them when available.";
+"Force Check" = "Force Check";
+"Check now even if automatic updates are not due yet." = "Check now even if automatic updates are not due yet.";
+"wBlock filter update was cancelled." = "wBlock filter update was cancelled.";
+"wBlock filter update was deferred. Open wBlock to finish updating." = "wBlock filter update was deferred. Open wBlock to finish updating.";
+"wBlock filter update failed. Open wBlock for details." = "wBlock filter update failed. Open wBlock for details.";
+"wBlock filters updated." = "wBlock filters updated.";
+"No filter updates found. Userscripts updated." = "No filter updates found. Userscripts updated.";
+"No filter updates found." = "No filter updates found.";
+"No filters are selected. Userscripts updated." = "No filters are selected. Userscripts updated.";
+"No filters are selected." = "No filters are selected.";
+"wBlock filter update is already running." = "wBlock filter update is already running.";
+"wBlock filter auto-update is disabled." = "wBlock filter auto-update is disabled.";
+"wBlock filter update skipped because it is not due yet." = "wBlock filter update skipped because it is not due yet.";
+"Open wBlock to update filters." = "Open wBlock to update filters.";
+"wBlock filter update skipped." = "wBlock filter update skipped.";
+"Update Filters" = "Update Filters";

--- a/wBlockCoreService/SharedAutoUpdateManager.swift
+++ b/wBlockCoreService/SharedAutoUpdateManager.swift
@@ -113,8 +113,36 @@ public actor SharedAutoUpdateManager {
         }
     }
 
-    public enum AutoUpdateRunOutcome: Sendable {
-        case completed
+    public enum AutoUpdateCompletionResult: Sendable, Equatable {
+        case appliedUpdates
+        case noFilterUpdates
+        case noSelectedFilters
+    }
+
+    public struct AutoUpdateCompletion: Sendable, Equatable {
+        public let result: AutoUpdateCompletionResult
+        public let checkedFilters: Int
+        public let updatedFilters: Int
+        public let updatedScripts: Int
+        public let failedScripts: Int
+
+        public init(
+            result: AutoUpdateCompletionResult,
+            checkedFilters: Int,
+            updatedFilters: Int,
+            updatedScripts: Int,
+            failedScripts: Int
+        ) {
+            self.result = result
+            self.checkedFilters = checkedFilters
+            self.updatedFilters = updatedFilters
+            self.updatedScripts = updatedScripts
+            self.failedScripts = failedScripts
+        }
+    }
+
+    public enum AutoUpdateRunOutcome: Sendable, Equatable {
+        case completed(AutoUpdateCompletion)
         case skipped(reason: String)
         case cancelled
         case deferred(phase: String)
@@ -122,7 +150,7 @@ public actor SharedAutoUpdateManager {
 
         public var isSuccessfulForBackgroundTask: Bool {
             switch self {
-            case .completed, .skipped(_):
+            case .completed(_), .skipped(_):
                 return true
             case .cancelled, .deferred(_), .failed(_):
                 return false
@@ -789,7 +817,15 @@ public actor SharedAutoUpdateManager {
                     ]
                 )
 
-                return await finishStartedRun(.completed)
+                return await finishStartedRun(.completed(
+                    AutoUpdateCompletion(
+                        result: .noSelectedFilters,
+                        checkedFilters: 0,
+                        updatedFilters: 0,
+                        updatedScripts: scriptsResult.updated,
+                        failedScripts: scriptsResult.failed
+                    )
+                ))
             }
 
             try checkBudget(
@@ -859,7 +895,15 @@ public actor SharedAutoUpdateManager {
                     ]
                 )
 
-                return await finishStartedRun(.completed)
+                return await finishStartedRun(.completed(
+                    AutoUpdateCompletion(
+                        result: .noFilterUpdates,
+                        checkedFilters: updateResult.checkedCount,
+                        updatedFilters: 0,
+                        updatedScripts: scriptsResult.updated,
+                        failedScripts: scriptsResult.failed
+                    )
+                ))
             }
 
             try requireFullRebuildAllowed(policy, phase: AutoUpdateBudgetPhase.fullRebuild)
@@ -934,7 +978,15 @@ public actor SharedAutoUpdateManager {
                 ]
             )
 
-            return await finishStartedRun(.completed)
+            return await finishStartedRun(.completed(
+                AutoUpdateCompletion(
+                    result: .appliedUpdates,
+                    checkedFilters: updateResult.checkedCount,
+                    updatedFilters: updatedFilterSet.count,
+                    updatedScripts: scriptsResult.updated,
+                    failedScripts: scriptsResult.failed
+                )
+            ))
         } catch is CancellationError {
             os_log("Auto-update cancelled (trigger: %{public}@)", log: log, type: .info, trigger)
             appendSharedLog("Auto-update cancelled: trigger=\(trigger)")


### PR DESCRIPTION
Adds an App Shortcuts action for updating wBlock filters. The shortcut opens wBlock and runs the same Apply Changes flow as the normal app path, so progress and completion UI stay consistent instead of duplicating update logic.

Covers the structured auto-update outcome changes, localized Shortcut text, and a focused regression script for the intent wiring. Checked with `swift scripts/test_auto_update_helper_safety.swift`, `swift scripts/test_shortcut_filter_update_intent.swift`, and `xcodebuild -project wBlock.xcodeproj -scheme wBlock -configuration Debug -destination 'platform=macOS,arch=arm64' build`.

Closes #399