### PR TITLE
Keep never-synced local userscripts during Cloud Sync download

### DIFF
--- a/scripts/test_cloud_sync_local_user_scripts.swift
+++ b/scripts/test_cloud_sync_local_user_scripts.swift
@@ -12,6 +12,7 @@ struct CloudSyncLocalUserScriptTests {
     static func main() {
         let bypass = CloudSyncLocalUserScript(name: "Bypass Paywalls Clean", content: "// script A", isEnabled: true)
         let other = CloudSyncLocalUserScript(name: "Other Script", content: "// script B", isEnabled: false)
+        let foo = CloudSyncLocalUserScript(name: "Foo", content: "// script C", isEnabled: true)
 
         let missingAfterDelete = CloudSyncLocalUserScriptReconciler.missingRemoteScriptsToRestore(
             remoteScripts: [bypass],
@@ -36,11 +37,99 @@ struct CloudSyncLocalUserScriptTests {
         let namesToDelete = CloudSyncLocalUserScriptReconciler.localNamesToDeleteDuringRemoteApply(
             localNames: ["Bypass Paywalls Clean", "Local Only Script"],
             remoteScripts: [other],
-            deletedNames: ["bypass paywalls clean"]
+            deletedNames: ["bypass paywalls clean"],
+            lastSyncedNames: ["local only script"]
         )
         expect(
             namesToDelete == ["bypass paywalls clean", "local only script"],
-            "remote apply should remove deleted locals and locals absent from the winning payload"
+            "remote apply should remove tombstoned locals and previously-synced locals absent from the winning payload"
+        )
+
+        // #437: a brand-new local userscript that was never synced must NOT be deleted on the
+        // download path just because it is absent from a newer remote payload.
+        let neverSyncedKept = CloudSyncLocalUserScriptReconciler.localNamesToDeleteDuringRemoteApply(
+            localNames: ["Foo"],
+            remoteScripts: [],
+            deletedNames: [],
+            lastSyncedNames: []
+        )
+        expect(
+            neverSyncedKept.isEmpty,
+            "a never-synced, non-tombstoned local script must not be deleted on the download path (#437)"
+        )
+
+        // A local script that WAS previously synced and is now absent from remote (e.g. deleted on
+        // another device after its tombstone aged out) should still be removed.
+        let previouslySyncedRemoved =
+            CloudSyncLocalUserScriptReconciler.localNamesToDeleteDuringRemoteApply(
+                localNames: ["Foo"],
+                remoteScripts: [],
+                deletedNames: [],
+                lastSyncedNames: ["foo"]
+            )
+        expect(
+            previouslySyncedRemoved == ["foo"],
+            "a previously-synced local script absent from the winning remote payload should be removed"
+        )
+
+        // A tombstoned local script is removed even when it was never synced.
+        let tombstonedRemoved = CloudSyncLocalUserScriptReconciler.localNamesToDeleteDuringRemoteApply(
+            localNames: ["Foo"],
+            remoteScripts: [],
+            deletedNames: ["foo"],
+            lastSyncedNames: []
+        )
+        expect(
+            tombstonedRemoved == ["foo"],
+            "a tombstoned local script should be removed on the download path"
+        )
+
+        // A local script still present in the remote payload is always kept.
+        let presentInRemoteKept = CloudSyncLocalUserScriptReconciler.localNamesToDeleteDuringRemoteApply(
+            localNames: ["Foo"],
+            remoteScripts: [foo],
+            deletedNames: [],
+            lastSyncedNames: ["foo"]
+        )
+        expect(
+            presentInRemoteKept.isEmpty,
+            "a local script still present in the remote payload must be kept"
+        )
+
+        // Mixed case: only the tombstoned local is removed; the never-synced local is kept.
+        let namesToDeleteNeverSynced =
+            CloudSyncLocalUserScriptReconciler.localNamesToDeleteDuringRemoteApply(
+                localNames: ["Bypass Paywalls Clean", "Local Only Script"],
+                remoteScripts: [other],
+                deletedNames: ["bypass paywalls clean"],
+                lastSyncedNames: []
+            )
+        expect(
+            namesToDeleteNeverSynced == ["bypass paywalls clean"],
+            "a never-synced local absent from remote must be kept; only the tombstoned local is removed (#437)"
+        )
+
+        // localNamesNeverSyncedToUpload identifies kept scripts that still need uploading.
+        let neverSyncedToUpload = CloudSyncLocalUserScriptReconciler.localNamesNeverSyncedToUpload(
+            localNames: ["Foo", "Bar"],
+            remoteScripts: [other],
+            deletedNames: [],
+            lastSyncedNames: []
+        )
+        expect(
+            neverSyncedToUpload == ["foo", "bar"],
+            "never-synced, non-tombstoned locals absent from remote should be scheduled for upload (#437)"
+        )
+
+        let nothingToUpload = CloudSyncLocalUserScriptReconciler.localNamesNeverSyncedToUpload(
+            localNames: ["Foo", "Bar", "Other Script"],
+            remoteScripts: [other],
+            deletedNames: ["bar"],
+            lastSyncedNames: ["foo"]
+        )
+        expect(
+            nothingToUpload.isEmpty,
+            "synced, tombstoned, and remote-present locals should not be scheduled for upload"
         )
 
         let normalized = CloudSyncLocalUserScriptReconciler.normalizedName("  Bypass Paywalls Clean  ")

--- a/wBlock/CloudSyncManager.swift
+++ b/wBlock/CloudSyncManager.swift
@@ -524,6 +524,8 @@ final class CloudSyncManager: ObservableObject {
             let payloadHash = payload.contentHash
 
             if payloadHash == defaults.string(forKey: Keys.lastUploadedHash) {
+                // Already uploaded, so every current local script name is known-synced.
+                setLastSyncedLocalUserScriptNames(localUserScriptNames(in: payload))
                 defaults.set(Date().timeIntervalSince1970, forKey: Keys.lastSyncAt)
                 refreshStatusFromDefaults()
                 setStatus(.upToDate)
@@ -538,6 +540,8 @@ final class CloudSyncManager: ObservableObject {
             defaults.set(payloadHash, forKey: Keys.lastUploadedHash)
             defaults.set(Date().timeIntervalSince1970, forKey: Keys.lastUploadedAt)
             defaults.set(Date().timeIntervalSince1970, forKey: Keys.lastSyncAt)
+            // The uploaded payload's local script names are now known-synced.
+            setLastSyncedLocalUserScriptNames(localUserScriptNames(in: payload))
             lastErrorMessage = nil
             refreshStatusFromDefaults()
 
@@ -580,6 +584,8 @@ final class CloudSyncManager: ObservableObject {
             }
 
             if remotePayload.contentHash == localPayload.contentHash {
+                // Local and remote already match, so every local script name is known-synced.
+                setLastSyncedLocalUserScriptNames(localUserScriptNames(in: localPayload))
                 defaults.set(Date().timeIntervalSince1970, forKey: Keys.lastSyncAt)
                 refreshStatusFromDefaults()
                 setStatus(.upToDate)
@@ -634,7 +640,12 @@ final class CloudSyncManager: ObservableObject {
         await applyRemoteFilters(payload.filters, remoteUpdatedAt: payload.updatedAt)
 
         // User scripts (remote URLs + local imports)
-        await applyRemoteUserScripts(payload.userScripts)
+        let keptUnsyncedLocalScripts = await applyRemoteUserScripts(payload.userScripts)
+
+        // Record the local script names that are now known-synced (present in the cloud payload).
+        // Kept-but-never-synced local scripts are intentionally excluded here; they become synced
+        // only after the follow-up upload below pushes them to the cloud.
+        setLastSyncedLocalUserScriptNames(localUserScriptNames(in: payload))
 
         // Mark local state as matching the remote payload so we don't echo-upload.
         defaults.set(payload.contentHash, forKey: Keys.lastLocalHash)
@@ -644,6 +655,13 @@ final class CloudSyncManager: ObservableObject {
         defaults.set(payload.contentHash, forKey: Keys.lastUploadedHash)
         defaults.set(Date().timeIntervalSince1970, forKey: Keys.lastSyncAt)
         refreshStatusFromDefaults()
+
+        // A local userscript that was never synced and isn't in the winning remote payload was
+        // kept rather than deleted. Schedule an upload so it propagates to the cloud (#437). The
+        // request is deferred while syncing and picked up by finishSyncCycle().
+        if keptUnsyncedLocalScripts {
+            scheduleUpload(trigger: "\(trigger)-KeepUnsyncedLocal")
+        }
 
         // Rebuild blockers so the synced config takes effect.
         if let filterManager {
@@ -865,7 +883,8 @@ final class CloudSyncManager: ObservableObject {
         await dataManager.updateFilterLists(storedLists)
     }
 
-    private func applyRemoteUserScripts(_ scripts: SyncPayload.UserScripts) async {
+    @discardableResult
+    private func applyRemoteUserScripts(_ scripts: SyncPayload.UserScripts) async -> Bool {
         let remoteDeletedURLs = Set(scripts.deletedRemoteURLs ?? [])
         let remoteRemoteScriptURLs = Set(scripts.remote.map(\.url))
         let localRemoteScriptURLs = currentLocalRemoteUserScriptURLs()
@@ -960,10 +979,19 @@ final class CloudSyncManager: ObservableObject {
         // The newer remote payload is authoritative for synced local imports.
 
         let deletedLocalNames = deletedLocalUserScriptNameSet()
+        let lastSyncedNames = lastSyncedLocalUserScriptNameSet()
+        let currentLocalNames = userScriptManager.userScripts.filter(\.isLocal).map(\.name)
         let localNamesToDelete = CloudSyncLocalUserScriptReconciler.localNamesToDeleteDuringRemoteApply(
-            localNames: userScriptManager.userScripts.filter(\.isLocal).map(\.name),
+            localNames: currentLocalNames,
             remoteScripts: remoteLocalScripts,
-            deletedNames: deletedLocalNames
+            deletedNames: deletedLocalNames,
+            lastSyncedNames: lastSyncedNames
+        )
+        let keptUnsyncedLocalNames = CloudSyncLocalUserScriptReconciler.localNamesNeverSyncedToUpload(
+            localNames: currentLocalNames,
+            remoteScripts: remoteLocalScripts,
+            deletedNames: deletedLocalNames,
+            lastSyncedNames: lastSyncedNames
         )
 
         if !localNamesToDelete.isEmpty {
@@ -1029,6 +1057,10 @@ final class CloudSyncManager: ObservableObject {
             }
             await dataManager.setUserScriptDisabledHosts(disabledHosts, forScriptID: script.id.uuidString)
         }
+
+        // Report whether any never-synced local scripts were kept so the caller can schedule an
+        // upload to propagate them to the cloud (#437).
+        return !keptUnsyncedLocalNames.isEmpty
     }
 
     private func applyRemoteZapperRules(_ zapperRules: [String: [String]], disabledDomains: [String]?) async {
@@ -1616,6 +1648,7 @@ final class CloudSyncManager: ObservableObject {
         static let lastSyncAt = "cloudSyncLastSyncAt"
         static let deletedCustomURLs = "cloudSyncDeletedCustomURLs"
         static let deletedLocalUserScriptNames = "cloudSyncDeletedLocalUserScriptNames"
+        static let lastSyncedLocalUserScriptNames = "cloudSyncLastSyncedLocalUserScriptNames"
         static let deletedRemoteUserScriptURLs = "cloudSyncDeletedRemoteUserScriptURLs"
     }
 
@@ -1737,6 +1770,26 @@ final class CloudSyncManager: ObservableObject {
             }
         }
         saveDeletedCustomURLMarkers(markers)
+    }
+
+    private func localUserScriptNames(in payload: SyncPayload) -> Set<String> {
+        Set(
+            payload.userScripts.local
+                .map { CloudSyncLocalUserScriptReconciler.normalizedName($0.name) }
+                .filter { !$0.isEmpty }
+        )
+    }
+
+    private func lastSyncedLocalUserScriptNameSet() -> Set<String> {
+        let raw = defaults.array(forKey: Keys.lastSyncedLocalUserScriptNames) as? [String] ?? []
+        return Set(raw.map(CloudSyncLocalUserScriptReconciler.normalizedName).filter { !$0.isEmpty })
+    }
+
+    private func setLastSyncedLocalUserScriptNames(_ names: Set<String>) {
+        let normalized = Set(
+            names.map(CloudSyncLocalUserScriptReconciler.normalizedName).filter { !$0.isEmpty }
+        )
+        defaults.set(normalized.sorted(), forKey: Keys.lastSyncedLocalUserScriptNames)
     }
 
     private func deletedLocalUserScriptNameSet() -> Set<String> {

--- a/wBlock/CloudSyncUserScriptSync.swift
+++ b/wBlock/CloudSyncUserScriptSync.swift
@@ -42,14 +42,42 @@ enum CloudSyncLocalUserScriptReconciler {
     static func localNamesToDeleteDuringRemoteApply(
         localNames: [String],
         remoteScripts: [CloudSyncLocalUserScript],
-        deletedNames: Set<String>
+        deletedNames: Set<String>,
+        lastSyncedNames: Set<String>
     ) -> Set<String> {
         let localNormalized = Set(localNames.map(normalizedName))
         let desiredRemote = Set(remoteScripts.map { normalizedName($0.name) }).filter { !$0.isEmpty }
-        let deletedNormalized = Set(deletedNames.map(normalizedName))
+        let deletedNormalized = normalizedNames(deletedNames)
+        let syncedNormalized = normalizedNames(lastSyncedNames)
 
         return localNormalized.filter { normalizedLocal in
-            deletedNormalized.contains(normalizedLocal) || !desiredRemote.contains(normalizedLocal)
+            if deletedNormalized.contains(normalizedLocal) {
+                return true
+            }
+            // Only remove a local script the user previously had synced and that the winning
+            // remote payload no longer contains. A local script that was never synced (e.g. a
+            // brand-new import that has not uploaded yet) must be kept, not deleted — otherwise
+            // it is silently and unrecoverably lost (#437).
+            return syncedNormalized.contains(normalizedLocal) && !desiredRemote.contains(normalizedLocal)
+        }
+    }
+
+    /// Local scripts that should be kept and scheduled for upload during a remote apply: ones that
+    /// were never synced, are not tombstoned, and are absent from the winning remote payload.
+    static func localNamesNeverSyncedToUpload(
+        localNames: [String],
+        remoteScripts: [CloudSyncLocalUserScript],
+        deletedNames: Set<String>,
+        lastSyncedNames: Set<String>
+    ) -> Set<String> {
+        let desiredRemote = Set(remoteScripts.map { normalizedName($0.name) }).filter { !$0.isEmpty }
+        let deletedNormalized = normalizedNames(deletedNames)
+        let syncedNormalized = normalizedNames(lastSyncedNames)
+
+        return normalizedNames(localNames).filter { normalizedLocal in
+            !deletedNormalized.contains(normalizedLocal)
+                && !syncedNormalized.contains(normalizedLocal)
+                && !desiredRemote.contains(normalizedLocal)
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #437. A local (imported) userscript that hasn't uploaded yet could be silently and unrecoverably deleted the next time Cloud Sync pulled a newer remote payload.

The download path (`applyRemoteUserScripts` → `CloudSyncLocalUserScriptReconciler.localNamesToDeleteDuringRemoteApply`) treated the newer remote payload as authoritative for local imports and deleted any local script absent from it. It could not distinguish "never synced" from "deleted long ago," so a brand-new local script that simply hadn't synced yet was removed — and since it never reached the cloud, it was lost.

## Fix

- Persist a `lastSyncedLocalNames` snapshot (`cloudSyncLastSyncedLocalUserScriptNames`), updated on each successful apply and upload, plus the already-in-sync paths for migration on existing installs.
- On download, delete a local script only when it is **tombstoned**, or it was **previously synced and is now absent from remote**. This still removes legitimately deleted-elsewhere scripts even after their 90-day tombstone TTL prunes.
- A local script that was **never synced and isn't tombstoned** is **kept** and **scheduled for upload** (`localNamesNeverSyncedToUpload`) so it propagates to the cloud instead of being dropped.

## Tests

Extends the standalone reconciler test (`scripts/test_cloud_sync_local_user_scripts.swift`) to cover the never-synced case and the new behavior. Compile + run like the existing probe:

```
swiftc -parse-as-library wBlock/CloudSyncUserScriptSync.swift scripts/test_cloud_sync_local_user_scripts.swift -o /tmp/cstest && /tmp/cstest
# PASS
```

New/updated assertions:
- A never-synced, non-tombstoned local script is **not** deleted on download (#437).
- A previously-synced local script absent from remote **is** removed.
- A tombstoned local script **is** removed.
- A local script still present in remote is kept.
- `localNamesNeverSyncedToUpload` correctly selects kept-but-unsynced scripts for upload.
