### PR TITLE
fix: resolve redundant in-process updates by correcting XPC timeout and proxy error handling

### DIFF
--- a/wBlockCoreService/FilterUpdateXPC.swift
+++ b/wBlockCoreService/FilterUpdateXPC.swift
@@ -24,7 +24,7 @@ public final class FilterUpdateClient {
 
     /// Calls the XPC service to run an update, returning true on success.
     /// If the service is missing or fails to respond within the timeout, returns false.
-    public func updateFilters(timeout seconds: TimeInterval = 2.0) async -> Bool {
+    public func updateFilters(timeout seconds: TimeInterval = 180.0) async -> Bool {
         let log = OSLog(subsystem: "wBlockCoreService", category: "FilterUpdateXPC")
         guard seconds.isFinite, seconds >= 0 else {
             os_log("Invalid XPC timeout: %.2fs", log: log, type: .error, seconds)
@@ -78,8 +78,16 @@ public final class FilterUpdateClient {
                 }
             }
 
-            guard let proxy = connection.remoteObjectProxy as? FilterUpdateProtocol else {
-                os_log("Failed to obtain remoteObjectProxy for XPC service", log: log, type: .error)
+            let proxy = connection.remoteObjectProxyWithErrorHandler { error in
+                if markFinished() {
+                    os_log("Failed to obtain remoteObjectProxy for XPC service: %{public}@", log: log, type: .error, error.localizedDescription)
+                    connection.invalidate()
+                    cont.resume(returning: false)
+                }
+            }
+
+            guard let filterProxy = proxy as? FilterUpdateProtocol else {
+                os_log("Failed to cast remoteObjectProxy to FilterUpdateProtocol", log: log, type: .error)
                 if markFinished() {
                     connection.invalidate()
                     cont.resume(returning: false)
@@ -87,7 +95,7 @@ public final class FilterUpdateClient {
                 return
             }
 
-            proxy.updateFilters { success in
+            filterProxy.updateFilters { success in
                 if markFinished() {
                     connection.invalidate()
                     cont.resume(returning: success)


### PR DESCRIPTION
Corrects a logic bug in the macOS filter update flow where background updates are performed redundantly. The default timeout of 2.0 seconds in FilterUpdateClient.shared.updateFilters was too short for network-bound compilation and serialized write tasks. This caused AppDelegate's invocation to consistently time out and fall back to duplicate, concurrent in-process filter updates. Raising the default timeout to 180.0 seconds aligns client expectations with the actual background update workload. Furthermore, replacing connection.remoteObjectProxy with connection.remoteObjectProxyWithErrorHandler allows immediate connection failure propagation instead of silently failing or timing out on XPC configuration errors.