### PR TITLE
Accept userscript URLs with filename in query parameter

### DIFF
--- a/scripts/test_userscript_url_support.swift
+++ b/scripts/test_userscript_url_support.swift
@@ -21,6 +21,20 @@ struct UserScriptURLSupportTests {
             "ftp://example.com/script.js",
             "expected non-http(s) remote URLs to be rejected"
         )
+        expectValid(
+            "https://example.com/raw?file=script.user.js",
+            expectedPath: "/raw",
+            "expected userscript URLs with the filename in a query parameter to be accepted"
+        )
+        expectValid(
+            "https://gitflic.ru/project/magnolia1234/bypass-paywalls-clean-filters/blob/raw?file=userscript/bpc.en.user.js",
+            expectedPath: "/project/magnolia1234/bypass-paywalls-clean-filters/blob/raw",
+            "expected the gitflic BPC userscript URL (#455) to be accepted"
+        )
+        expectInvalid(
+            "https://example.com/raw?file=script.txt",
+            "expected query-parameter URLs without a supported extension to be rejected"
+        )
 
         let plainName = UserScriptURLSupport.displayName(forRemoteURL: URL(string: "https://example.com/foo.js")!)
         expectEqual(plainName, "foo", "expected .js suffix to be stripped from remote display names")

--- a/wBlockCoreService/UserScript.swift
+++ b/wBlockCoreService/UserScript.swift
@@ -55,13 +55,11 @@ public enum UserScriptURLSupport {
             return true
         }
         // Some hosts (e.g. gitflic.ru raw endpoints) carry the script filename in
-        // a query parameter rather than the path. Fall back to the basename of each
-        // query item value so those legitimate URLs are not rejected as invalid.
+        // a query parameter rather than the path. Fall back to the query item value
+        // so those legitimate URLs are not rejected as invalid.
         if let queryItems = components.queryItems {
             for item in queryItems {
-                guard let value = item.value, !value.isEmpty else { continue }
-                let basename = value.split(separator: "/").last.map(String.init) ?? value
-                if hasSupportedExtension(in: basename) {
+                if let value = item.value, hasSupportedExtension(in: value) {
                     return true
                 }
             }

--- a/wBlockCoreService/UserScript.swift
+++ b/wBlockCoreService/UserScript.swift
@@ -16,7 +16,7 @@ public enum UserScriptURLSupport {
               ["https", "http"].contains(scheme),
               let host = components.host,
               !host.isEmpty,
-              hasSupportedExtension(in: components.path),
+              hasSupportedExtension(in: components),
               let url = components.url else {
             return nil
         }
@@ -48,6 +48,25 @@ public enum UserScriptURLSupport {
         }
 
         return URL(fileURLWithPath: filename).deletingPathExtension().lastPathComponent
+    }
+
+    private static func hasSupportedExtension(in components: URLComponents) -> Bool {
+        if hasSupportedExtension(in: components.path) {
+            return true
+        }
+        // Some hosts (e.g. gitflic.ru raw endpoints) carry the script filename in
+        // a query parameter rather than the path. Fall back to the basename of each
+        // query item value so those legitimate URLs are not rejected as invalid.
+        if let queryItems = components.queryItems {
+            for item in queryItems {
+                guard let value = item.value, !value.isEmpty else { continue }
+                let basename = value.split(separator: "/").last.map(String.init) ?? value
+                if hasSupportedExtension(in: basename) {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     private static func hasSupportedExtension(in path: String) -> Bool {


### PR DESCRIPTION
Fixes #455.

The gitflic.ru BPC userscript URL was rejected as "invalid" because `UserScriptURLSupport.validatedRemoteURL` only checked the path component for a supported extension. gitflic carries the script filename in a query parameter (`?file=userscript/bpc.en.user.js`), not the path, so validation failed before any download was attempted.

The fix falls back to scanning query item values for a supported extension when the path has none. This also unblocks other hosts that use query-parameter filenames (some GitLab/Gitea raw routes, custom CDNs).

Added query-param test cases to `test_userscript_url_support.swift`, including the exact gitflic URL from the issue.