### PR TITLE
Make iCloud Sync actually sync in the background

### DIFF
--- a/wBlock/AppDelegate.swift
+++ b/wBlock/AppDelegate.swift
@@ -460,6 +460,7 @@ extension AppDelegate: UIApplicationDelegate {
             return
         }
         Task { @MainActor in
+            await LaunchSetup.runIfNeeded()
             await CloudSyncManager.shared.syncForRemoteNotification(trigger: "RemotePush")
             completionHandler(.newData)
         }
@@ -739,6 +740,7 @@ extension AppDelegate: UIApplicationDelegate {
         let completionState = BGTaskCompletionState()
         let updateTask = Task { @MainActor in
             self.scheduleBackgroundCloudSync()
+            await LaunchSetup.runIfNeeded()
             await CloudSyncManager.shared.performBackgroundSync()
             guard await completionState.claimCompletion() else { return }
             task.setTaskCompleted(success: true)

--- a/wBlock/AppDelegate.swift
+++ b/wBlock/AppDelegate.swift
@@ -21,6 +21,9 @@ import wBlockCoreService
 // Define the notification name globally or in a shared place
 extension Notification.Name {
     static let applyWBlockChangesNotification = Notification.Name("applyWBlockChangesNotification_unique_identifier")
+    /// Posted by CloudSyncManager when iCloud Sync is enabled so the app delegate can
+    /// register for silent push notifications (CloudKit change subscriptions).
+    static let cloudSyncRegistrationRequested = Notification.Name("cloudSyncRegistrationRequested")
 }
 #if os(iOS)
 @MainActor
@@ -377,6 +380,19 @@ extension AppDelegate: UIApplicationDelegate {
         Task { @MainActor in
             await rescheduleBackgroundTasks(reason: "Launch")
         }
+
+        // Register for silent CloudKit push notifications so a backgrounded device is woken
+        // when the synced config changes. Re-register whenever sync is (re)enabled.
+        if CloudSyncManager.shared.isEnabled {
+            application.registerForRemoteNotifications()
+        }
+        NotificationCenter.default.addObserver(
+            forName: .cloudSyncRegistrationRequested,
+            object: nil,
+            queue: .main
+        ) { _ in
+            UIApplication.shared.registerForRemoteNotifications()
+        }
         return true
     }
 
@@ -425,6 +441,28 @@ extension AppDelegate: UIApplicationDelegate {
         filterManager?.flushPendingSave()
 
         flushProtobufDataForBackgroundTransition(reason: "Terminate")
+    }
+
+    // MARK: - Remote notifications (CloudKit change pushes)
+
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        // No-op: CloudKit subscriptions address the device automatically once a token exists.
+    }
+
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        os_log("Failed to register for remote notifications: %{public}@", type: .error, error.localizedDescription)
+    }
+
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        // CloudKit subscription pushes carry a "ck" entry; ignore everything else.
+        guard userInfo["ck"] != nil else {
+            completionHandler(.noData)
+            return
+        }
+        Task { @MainActor in
+            await CloudSyncManager.shared.syncForRemoteNotification(trigger: "RemotePush")
+            completionHandler(.newData)
+        }
     }
     
     // MARK: - Background Task Management

--- a/wBlock/AppDelegate.swift
+++ b/wBlock/AppDelegate.swift
@@ -85,6 +85,12 @@ class AppDelegate: NSObject {
     #if os(iOS)
     private let backgroundTaskIdentifier = "com.alexanderskula.wblock.filter-update"
     private let backgroundProcessingIdentifier = "com.alexanderskula.wblock.filter-processing"
+    private let cloudSyncTaskIdentifier = "com.alexanderskula.wblock.cloud-sync"
+
+    /// Background app-refresh interval for iCloud sync (hours). Intentionally modest: push
+    /// notifications (when registered) are the primary driver; this is a fallback for
+    /// catching remote changes when pushes aren't delivered.
+    private let cloudSyncScheduleDelayHours: Double = 3.0
 
     /// Factor to multiply interval by for app refresh scheduling (accounts for iOS discretion)
     private let appRefreshScheduleDelayFactor: Double = 0.75
@@ -367,6 +373,7 @@ extension AppDelegate: UIApplicationDelegate {
         // Schedule initial background refresh + processing tasks (also re-schedules after protobuf loads)
         scheduleBackgroundFilterUpdate()
         scheduleBackgroundProcessingUpdate()
+        scheduleBackgroundCloudSync()
         Task { @MainActor in
             await rescheduleBackgroundTasks(reason: "Launch")
         }
@@ -400,6 +407,7 @@ extension AppDelegate: UIApplicationDelegate {
         // Schedule next background tasks when entering background
         scheduleBackgroundFilterUpdate()
         scheduleBackgroundProcessingUpdate()
+        scheduleBackgroundCloudSync()
         Task { @MainActor in
             await rescheduleBackgroundTasks(reason: "EnterBackground")
         }
@@ -475,6 +483,23 @@ extension AppDelegate: UIApplicationDelegate {
         }
         if !processingRegistered {
             os_log("Failed to register BG task identifier %{public}@", type: .error, backgroundProcessingIdentifier)
+        }
+
+        let cloudSyncRegistered = BGTaskScheduler.shared.register(forTaskWithIdentifier: cloudSyncTaskIdentifier, using: nil) { task in
+            guard let refreshTask = task as? BGAppRefreshTask else {
+                os_log(
+                    "Unexpected BGTask type for %{public}@ (%{public}@)",
+                    type: .error,
+                    self.cloudSyncTaskIdentifier,
+                    String(describing: type(of: task))
+                )
+                task.setTaskCompleted(success: false)
+                return
+            }
+            self.handleBackgroundCloudSync(task: refreshTask)
+        }
+        if !cloudSyncRegistered {
+            os_log("Failed to register BG task identifier %{public}@", type: .error, cloudSyncTaskIdentifier)
         }
     }
 
@@ -559,6 +584,28 @@ extension AppDelegate: UIApplicationDelegate {
                     error: details.message
                 )
             }
+        }
+    }
+
+    @MainActor
+    private func scheduleBackgroundCloudSync() {
+        guard CloudSyncManager.shared.isEnabled else { return }
+        let request = BGAppRefreshTaskRequest(identifier: cloudSyncTaskIdentifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: cloudSyncScheduleDelayHours * 60 * 60)
+        do {
+            BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: cloudSyncTaskIdentifier)
+            try BGTaskScheduler.shared.submit(request)
+            os_log(
+                "Background cloud sync task scheduled (%.1f hrs)",
+                type: .info,
+                cloudSyncScheduleDelayHours
+            )
+        } catch {
+            os_log(
+                "Failed to schedule background cloud sync: %{public}@",
+                type: .error,
+                error.localizedDescription
+            )
         }
     }
     
@@ -649,6 +696,27 @@ extension AppDelegate: UIApplicationDelegate {
         )
     }
 
+    private func handleBackgroundCloudSync(task: BGAppRefreshTask) {
+        os_log("Background cloud sync task started", type: .info)
+        let completionState = BGTaskCompletionState()
+        let updateTask = Task { @MainActor in
+            self.scheduleBackgroundCloudSync()
+            await CloudSyncManager.shared.performBackgroundSync()
+            guard await completionState.claimCompletion() else { return }
+            task.setTaskCompleted(success: true)
+        }
+
+        task.expirationHandler = {
+            os_log("Background cloud sync expired", type: .error)
+            updateTask.cancel()
+            Task { @MainActor in
+                self.scheduleBackgroundCloudSync()
+                guard await completionState.claimCompletion() else { return }
+                task.setTaskCompleted(success: false)
+            }
+        }
+    }
+
     private func handleForcedBackgroundTask(
         task: BGTask,
         taskLabel: String,
@@ -726,6 +794,13 @@ extension AppDelegate: UIApplicationDelegate {
     @MainActor
     private func rescheduleBackgroundTasks(reason: String) async {
         await ProtobufDataManager.shared.waitUntilLoaded()
+
+        // iCloud sync runs on its own background task, independent of the auto-update setting.
+        if CloudSyncManager.shared.isEnabled {
+            scheduleBackgroundCloudSync()
+        } else {
+            BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: cloudSyncTaskIdentifier)
+        }
 
         let enabled = ProtobufDataManager.shared.autoUpdateEnabled
         if !enabled {

--- a/wBlock/CloudSyncManager.swift
+++ b/wBlock/CloudSyncManager.swift
@@ -92,6 +92,8 @@ final class CloudSyncManager: ObservableObject {
     }()
     private let recordID = CKRecord.ID(recordName: "wblock-sync-config")
     private let recordType = "wBlockSync"
+    /// Stable ID for the database-wide change subscription that drives silent pushes.
+    private static let subscriptionID = "wblock-private-db-changes"
 
     private var cancellables = Set<AnyCancellable>()
     private var hasActivatedObservers = false
@@ -132,6 +134,11 @@ final class CloudSyncManager: ObservableObject {
         observeLocalSaves()
         observeLocalUserScriptChanges()
         observeiCloudAccountChanges()
+
+        if isEnabled, Self.isCloudKitAvailable {
+            Task { await ensureRemoteChangeSubscription() }
+            NotificationCenter.default.post(name: .cloudSyncRegistrationRequested, object: nil)
+        }
 
         let trigger = deferredSyncTrigger ?? ((isEnabled && !hasPendingExplicitRemoteDownload) ? "Launch" : nil)
         deferredSyncTrigger = nil
@@ -213,7 +220,13 @@ final class CloudSyncManager: ObservableObject {
 
         if !enabled {
             deferredSyncTrigger = nil
+            Task { await removeRemoteChangeSubscription() }
             return
+        }
+
+        Task {
+            await ensureRemoteChangeSubscription()
+            NotificationCenter.default.post(name: .cloudSyncRegistrationRequested, object: nil)
         }
 
         if startSync {
@@ -336,6 +349,14 @@ final class CloudSyncManager: ObservableObject {
         if lastKnown > 0, remoteUpdatedAt == lastKnown { return }
 
         _ = await downloadAndApplyLatestRemoteConfig(trigger: "BGAppRefresh")
+    }
+
+    /// Runs the two-way convergence inline (no throttle, no deferred-task indirection) so
+    /// the remote-notification handler can await it within the push time budget. Called
+    /// when a CloudKit subscription push signals that the remote config changed.
+    func syncForRemoteNotification(trigger: String) async {
+        guard isEnabled, hasCompletedLaunchSetup else { return }
+        await performTwoWaySync(trigger: trigger)
     }
 
     func downloadAndApplyLatestRemoteConfig(trigger: String) async -> Bool {
@@ -1671,6 +1692,60 @@ final class CloudSyncManager: ObservableObject {
             }
         } catch {
             throw error
+        }
+    }
+
+    // MARK: - Remote change subscription (silent push)
+
+    /// Ensures a database-wide subscription exists so CloudKit wakes this device via a
+    /// silent push whenever the private database changes. Idempotent: re-saving with the
+    /// same subscription ID replaces the existing subscription. The push is delivered to
+    /// AppDelegate's remote-notification handler, which triggers a sync.
+    func ensureRemoteChangeSubscription() async {
+        guard let database else { return }
+        let subscription = CKDatabaseSubscription(subscriptionID: Self.subscriptionID)
+        let op = CKModifySubscriptionsOperation(
+            subscriptionsToSave: [subscription],
+            subscriptionIDsToDelete: nil
+        )
+        op.qualityOfService = .utility
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                op.modifySubscriptionsResultBlock = { result in
+                    switch result {
+                    case .success:
+                        continuation.resume()
+                    case let .failure(error):
+                        continuation.resume(throwing: error)
+                    }
+                }
+                database.add(op)
+            }
+            logger.info("Ensured CloudKit change subscription")
+        } catch {
+            logger.error("Failed to ensure change subscription: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Removes the remote change subscription. Called when sync is disabled so CloudKit
+    /// stops sending change pushes to this device.
+    func removeRemoteChangeSubscription() async {
+        guard let database else { return }
+        let op = CKModifySubscriptionsOperation(
+            subscriptionsToSave: nil,
+            subscriptionIDsToDelete: [Self.subscriptionID]
+        )
+        op.qualityOfService = .utility
+        _ = try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            op.modifySubscriptionsResultBlock = { result in
+                switch result {
+                case .success:
+                    continuation.resume()
+                case let .failure(error):
+                    continuation.resume(throwing: error)
+                }
+            }
+            database.add(op)
         }
     }
 

--- a/wBlock/CloudSyncManager.swift
+++ b/wBlock/CloudSyncManager.swift
@@ -149,7 +149,7 @@ final class CloudSyncManager: ObservableObject {
         }
     }
 
-    private func waitUntilLaunchSetupComplete() async {
+    func waitUntilLaunchSetupComplete() async {
         if hasCompletedLaunchSetup { return }
         await withCheckedContinuation { continuation in
             Task { @MainActor [weak self] in
@@ -293,11 +293,10 @@ final class CloudSyncManager: ObservableObject {
             let updatedAt = (record["updatedAt"] as? Date)?.timeIntervalSince1970
             let schemaVersion = record["schemaVersion"] as? Int
             let resolvedUpdatedAt = (updatedAt ?? 0) > 0 ? updatedAt : nil
-            // Cache the observed remote timestamp so foreground probes can cheaply detect
-            // "nothing changed" without re-downloading the payload or re-running a full sync.
-            if let resolvedUpdatedAt {
-                defaults.set(resolvedUpdatedAt, forKey: Keys.lastKnownRemoteUpdatedAt)
-            }
+            // Intentionally a pure read: the cached "last known remote" timestamp is
+            // recorded only after a successful converge (see recordConvergedRemoteUpdatedAt)
+            // so a transient apply/download failure can't poison the cache and skip the
+            // change indefinitely.
             return RemoteConfigProbe(
                 exists: true,
                 updatedAt: resolvedUpdatedAt,
@@ -338,7 +337,7 @@ final class CloudSyncManager: ObservableObject {
     /// happen on local saves and foreground; this path exists to catch remote changes
     /// while the app is closed.
     func performBackgroundSync() async {
-        guard isEnabled, hasCompletedLaunchSetup else { return }
+        guard isEnabled else { return }
         await dataManager.waitUntilLoaded()
         await userScriptManager.waitUntilReady()
         if isSyncing { return }
@@ -355,7 +354,7 @@ final class CloudSyncManager: ObservableObject {
     /// the remote-notification handler can await it within the push time budget. Called
     /// when a CloudKit subscription push signals that the remote config changed.
     func syncForRemoteNotification(trigger: String) async {
-        guard isEnabled, hasCompletedLaunchSetup else { return }
+        guard isEnabled else { return }
         await performTwoWaySync(trigger: trigger)
     }
 
@@ -630,6 +629,7 @@ final class CloudSyncManager: ObservableObject {
             defaults.set(savedPayload.contentHash, forKey: Keys.lastUploadedHash)
             defaults.set(Date().timeIntervalSince1970, forKey: Keys.lastUploadedAt)
             defaults.set(Date().timeIntervalSince1970, forKey: Keys.lastSyncAt)
+            recordConvergedRemoteUpdatedAt(savedPayload.updatedAt)
             // The uploaded payload's local script names are now known-synced.
             setLastSyncedLocalUserScriptNames(localUserScriptNames(in: savedPayload))
             lastErrorMessage = nil
@@ -674,6 +674,7 @@ final class CloudSyncManager: ObservableObject {
             let remoteRecordUpdatedAt = (remoteRecord["updatedAt"] as? Date)?.timeIntervalSince1970
 
             if let remoteContentHash, remoteContentHash == localPayload.contentHash {
+                recordConvergedRemoteUpdatedAt(remoteRecordUpdatedAt ?? 0)
                 markUpToDate(from: localPayload)
                 return
             }
@@ -693,6 +694,7 @@ final class CloudSyncManager: ObservableObject {
                 legacyPayload = decoded
                 remoteIsNewer = decoded.updatedAt > localUpdatedAt
                 if decoded.contentHash == localPayload.contentHash {
+                    recordConvergedRemoteUpdatedAt(decoded.updatedAt)
                     markUpToDate(from: localPayload)
                     return
                 }
@@ -772,6 +774,7 @@ final class CloudSyncManager: ObservableObject {
         defaults.set(Date().timeIntervalSince1970, forKey: Keys.lastDownloadedAt)
         defaults.set(payload.contentHash, forKey: Keys.lastUploadedHash)
         defaults.set(Date().timeIntervalSince1970, forKey: Keys.lastSyncAt)
+        recordConvergedRemoteUpdatedAt(payload.updatedAt)
         refreshStatusFromDefaults()
 
         // A local userscript that was never synced and isn't in the winning remote payload was
@@ -1704,6 +1707,13 @@ final class CloudSyncManager: ObservableObject {
     func ensureRemoteChangeSubscription() async {
         guard let database else { return }
         let subscription = CKDatabaseSubscription(subscriptionID: Self.subscriptionID)
+        // Without notification info the subscription fires but never requests a push.
+        // shouldSendContentAvailable makes it a silent (content-available) push, which is
+        // what AppDelegate's remote-notification handler converges on — no alert, badge,
+        // or sound, so no user-facing notification permission is involved.
+        let info = CKSubscription.NotificationInfo()
+        info.shouldSendContentAvailable = true
+        subscription.notificationInfo = info
         let op = CKModifySubscriptionsOperation(
             subscriptionsToSave: [subscription],
             subscriptionIDsToDelete: nil
@@ -1872,6 +1882,15 @@ final class CloudSyncManager: ObservableObject {
         defaults.set(Date().timeIntervalSince1970, forKey: Keys.lastSyncAt)
         refreshStatusFromDefaults()
         setStatus(.upToDate)
+    }
+
+    /// Records the remote `updatedAt` the device has fully converged to, so foreground/
+    /// background probes can skip a full sync when the remote is unchanged. Only call this
+    /// after a successful apply or a confirmed local==remote match — never after a bare
+    /// metadata fetch, or a later apply failure would be skipped indefinitely.
+    private func recordConvergedRemoteUpdatedAt(_ updatedAt: TimeInterval) {
+        guard updatedAt > 0 else { return }
+        defaults.set(updatedAt, forKey: Keys.lastKnownRemoteUpdatedAt)
     }
 
     // MARK: - Helpers

--- a/wBlock/CloudSyncManager.swift
+++ b/wBlock/CloudSyncManager.swift
@@ -107,6 +107,9 @@ final class CloudSyncManager: ObservableObject {
     private let deletedMarkerTTLDays: Double = 90
     /// Minimum interval between automatic (AppActive) syncs. Manual/Launch triggers bypass it.
     private let minimumAutomaticSyncInterval: TimeInterval = 120
+    /// Minimum interval between foreground metadata probes (see syncOnAppActive).
+    private let minimumProbeInterval: TimeInterval = 30
+    private var lastProbeAt: TimeInterval = 0
     private var lastAutomaticSyncAt: TimeInterval = 0
     private let sortedJSONEncoder: JSONEncoder = {
         let encoder = JSONEncoder()
@@ -276,14 +279,44 @@ final class CloudSyncManager: ObservableObject {
             // probe can answer without downloading the payload asset.
             let updatedAt = (record["updatedAt"] as? Date)?.timeIntervalSince1970
             let schemaVersion = record["schemaVersion"] as? Int
+            let resolvedUpdatedAt = (updatedAt ?? 0) > 0 ? updatedAt : nil
+            // Cache the observed remote timestamp so foreground probes can cheaply detect
+            // "nothing changed" without re-downloading the payload or re-running a full sync.
+            if let resolvedUpdatedAt {
+                defaults.set(resolvedUpdatedAt, forKey: Keys.lastKnownRemoteUpdatedAt)
+            }
             return RemoteConfigProbe(
                 exists: true,
-                updatedAt: (updatedAt ?? 0) > 0 ? updatedAt : nil,
+                updatedAt: resolvedUpdatedAt,
                 schemaVersion: schemaVersion
             )
         } catch {
             return RemoteConfigProbe(exists: false, updatedAt: nil, schemaVersion: nil)
         }
+    }
+
+    /// Foreground entry point. Runs a cheap metadata-only probe (throttled to once per
+    /// `minimumProbeInterval`) and only kicks off a full two-way sync when the remote
+    /// config actually changed since the last probe. This keeps pulling prompt without
+    /// hammering CloudKit on rapid app switches, replacing the previous behaviour of
+    /// dropping every AppActive sync for `minimumAutomaticSyncInterval` seconds.
+    func syncOnAppActive() async {
+        guard isEnabled, hasCompletedLaunchSetup else { return }
+        let now = ProcessInfo.processInfo.systemUptime
+        guard now - lastProbeAt >= minimumProbeInterval else { return }
+        lastProbeAt = now
+
+        let lastKnown = defaults.double(forKey: Keys.lastKnownRemoteUpdatedAt)
+        let probe = await probeRemoteConfig()
+        guard probe.exists, let remoteUpdatedAt = probe.updatedAt else {
+            // No remote record yet (or transiently unreachable): fall back to a normal
+            // sync so a first-time upload can still happen, respecting the auto throttle.
+            await syncNow(trigger: "AppActive")
+            return
+        }
+
+        if lastKnown > 0, remoteUpdatedAt == lastKnown { return }
+        await syncNow(trigger: "AppActive-RemoteChanged")
     }
 
     func downloadAndApplyLatestRemoteConfig(trigger: String) async -> Bool {
@@ -1782,6 +1815,7 @@ final class CloudSyncManager: ObservableObject {
         static let lastDownloadedHash = "cloudSyncLastDownloadedHash"
         static let lastDownloadedAt = "cloudSyncLastDownloadedAt"
         static let lastSyncAt = "cloudSyncLastSyncAt"
+        static let lastKnownRemoteUpdatedAt = "cloudSyncLastKnownRemoteUpdatedAt"
         static let deletedCustomURLs = "cloudSyncDeletedCustomURLs"
         static let deletedLocalUserScriptNames = "cloudSyncDeletedLocalUserScriptNames"
         static let lastSyncedLocalUserScriptNames = "cloudSyncLastSyncedLocalUserScriptNames"

--- a/wBlock/CloudSyncManager.swift
+++ b/wBlock/CloudSyncManager.swift
@@ -53,6 +53,10 @@ final class CloudSyncManager: ObservableObject {
 
     static let shared = CloudSyncManager()
 
+    /// Public mirror of the entitlement probe so the UI can explain why sync is
+    /// unavailable (e.g. direct-distribution macOS builds strip the iCloud entitlement).
+    static var isCloudKitAvailable: Bool { hasCloudKitEntitlement }
+
     /// Check whether the running binary was signed with the iCloud entitlement.
     /// Direct-distribution builds strip it to avoid AMFI rejection.
     private static let hasCloudKitEntitlement: Bool = {

--- a/wBlock/CloudSyncManager.swift
+++ b/wBlock/CloudSyncManager.swift
@@ -319,6 +319,25 @@ final class CloudSyncManager: ObservableObject {
         await syncNow(trigger: "AppActive-RemoteChanged")
     }
 
+    /// Pull-focused sync used by the iOS background app refresh task. Probes the remote
+    /// config and only downloads/applies it when something changed, so the common case
+    /// is a single metadata fetch within the tight background time budget. Uploads still
+    /// happen on local saves and foreground; this path exists to catch remote changes
+    /// while the app is closed.
+    func performBackgroundSync() async {
+        guard isEnabled, hasCompletedLaunchSetup else { return }
+        await dataManager.waitUntilLoaded()
+        await userScriptManager.waitUntilReady()
+        if isSyncing { return }
+
+        let lastKnown = defaults.double(forKey: Keys.lastKnownRemoteUpdatedAt)
+        let probe = await probeRemoteConfig()
+        guard probe.exists, let remoteUpdatedAt = probe.updatedAt else { return }
+        if lastKnown > 0, remoteUpdatedAt == lastKnown { return }
+
+        _ = await downloadAndApplyLatestRemoteConfig(trigger: "BGAppRefresh")
+    }
+
     func downloadAndApplyLatestRemoteConfig(trigger: String) async -> Bool {
         if !hasCompletedLaunchSetup {
             hasPendingExplicitRemoteDownload = true

--- a/wBlock/Info.plist
+++ b/wBlock/Info.plist
@@ -11,6 +11,7 @@
 	<array>
 		<string>com.alexanderskula.wblock.filter-update</string>
 		<string>com.alexanderskula.wblock.filter-processing</string>
+		<string>com.alexanderskula.wblock.cloud-sync</string>
 	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>

--- a/wBlock/Info.plist
+++ b/wBlock/Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>fetch</string>
 		<string>processing</string>
+		<string>remote-notification</string>
 	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>

--- a/wBlock/LaunchSetup.swift
+++ b/wBlock/LaunchSetup.swift
@@ -1,0 +1,39 @@
+//
+//  LaunchSetup.swift
+//  wBlock
+//
+
+import Foundation
+import wBlockCoreService
+
+/// Centralized, idempotent launch setup: loads protobuf data, runs one-time migrations,
+/// waits for the user-script manager, then activates CloudKit observers.
+///
+/// iOS can cold-launch the app for a `BGAppRefreshTask` or a silent push without ever
+/// running the SwiftUI scene's `onAppear`, so setup can't live only on the UI launch path.
+/// Both the UI (from `wBlockApp`) and the background entry points (in `AppDelegate`)
+/// funnel through here so migrations always apply before a sync reads or writes state.
+enum LaunchSetup {
+    private static var hasStarted = false
+
+    @MainActor
+    static func runIfNeeded() async {
+        if hasStarted {
+            // Another caller (often the UI path) is running setup; wait for it.
+            await CloudSyncManager.shared.waitUntilLaunchSetupComplete()
+            return
+        }
+        hasStarted = true
+
+        let dataManager = ProtobufDataManager.shared
+        await dataManager.waitUntilLoaded()
+        await dataManager.migrateLegacyFilterURLs()
+        await dataManager.migrateMultipurposeToAnnoyances()
+        await dataManager.migrateAnnoyancesFilterToSplitFilters()
+        await dataManager.migrateMobileFilterToAdsCategory()
+        await dataManager.migrateAllowlistsToDedicatedCategory()
+        await UserScriptManager.shared.waitUntilReady()
+
+        CloudSyncManager.shared.activateAfterLaunchSetup()
+    }
+}

--- a/wBlock/SettingsView.swift
+++ b/wBlock/SettingsView.swift
@@ -383,22 +383,25 @@ struct SettingsView: View {
                     Image(systemName: "arrow.triangle.2.circlepath")
                         .symbolRenderingMode(.hierarchical)
                         .foregroundStyle(
-                            (!syncManager.isEnabled || syncManager.isSyncing)
+                            (!syncManager.isEnabled || syncManager.isSyncing || !CloudSyncManager.isCloudKitAvailable)
                                 ? .tertiary : .secondary
                         )
                 }
                 .buttonStyle(.plain)
-                .disabled(!syncManager.isEnabled || syncManager.isSyncing)
+                .disabled(!syncManager.isEnabled || syncManager.isSyncing || !CloudSyncManager.isCloudKitAvailable)
                 .accessibilityLabel("Sync Now")
 
                 Toggle("", isOn: syncEnabledBinding)
                     .labelsHidden()
                     .toggleStyle(.switch)
+                    .disabled(!CloudSyncManager.isCloudKitAvailable)
             }
         } header: {
             Text("Sync")
         } footer: {
-            if syncManager.isEnabled {
+            if !CloudSyncManager.isCloudKitAvailable {
+                Text("iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.")
+            } else if syncManager.isEnabled {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(syncFooterLine)
                     if let error = syncManager.lastErrorMessage {

--- a/wBlock/ar.lproj/Localizable.strings
+++ b/wBlock/ar.lproj/Localizable.strings
@@ -840,3 +840,4 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/de.lproj/Localizable.strings
+++ b/wBlock/de.lproj/Localizable.strings
@@ -840,3 +840,4 @@ Um diese Filter wieder zu aktivieren, deaktiviere andere große Filter und wende
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/el.lproj/Localizable.strings
+++ b/wBlock/el.lproj/Localizable.strings
@@ -840,3 +840,4 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/en.lproj/Localizable.strings
+++ b/wBlock/en.lproj/Localizable.strings
@@ -849,3 +849,4 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/es.lproj/Localizable.strings
+++ b/wBlock/es.lproj/Localizable.strings
@@ -840,3 +840,4 @@ Para volver a activarlos, desactiva otros filtros grandes y aplica los cambios d
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/fr.lproj/Localizable.strings
+++ b/wBlock/fr.lproj/Localizable.strings
@@ -840,3 +840,4 @@ Pour les réactiver, désactivez d’autres gros filtres puis appliquez à nouve
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/hu.lproj/Localizable.strings
+++ b/wBlock/hu.lproj/Localizable.strings
@@ -841,3 +841,4 @@ Az újbóli engedélyezésükhöz tilts le más nagy szűrőket, majd alkalmazd 
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/it.lproj/Localizable.strings
+++ b/wBlock/it.lproj/Localizable.strings
@@ -840,3 +840,4 @@ Per riattivarli, disattiva altri filtri grandi e applica di nuovo le modifiche."
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/ja.lproj/Localizable.strings
+++ b/wBlock/ja.lproj/Localizable.strings
@@ -842,3 +842,4 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/ko.lproj/Localizable.strings
+++ b/wBlock/ko.lproj/Localizable.strings
@@ -840,3 +840,4 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/pl.lproj/Localizable.strings
+++ b/wBlock/pl.lproj/Localizable.strings
@@ -840,3 +840,4 @@ Aby włączyć je ponownie, wyłącz inne duże filtry i ponownie zastosuj zmian
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/pt-BR.lproj/Localizable.strings
+++ b/wBlock/pt-BR.lproj/Localizable.strings
@@ -840,3 +840,4 @@ Para reativá-los, desative outros filtros grandes e aplique as alterações nov
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/ro.lproj/Localizable.strings
+++ b/wBlock/ro.lproj/Localizable.strings
@@ -840,3 +840,4 @@ Pentru a le reactiva, dezactivează alte filtre mari și aplică din nou modific
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/ru.lproj/Localizable.strings
+++ b/wBlock/ru.lproj/Localizable.strings
@@ -840,3 +840,4 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/tr.lproj/Localizable.strings
+++ b/wBlock/tr.lproj/Localizable.strings
@@ -847,3 +847,4 @@ Bu filtreleri yeniden etkinleştirmek için diğer büyük filtreleri devre dı�
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/wBlock.entitlements
+++ b/wBlock/wBlock.entitlements
@@ -16,8 +16,6 @@
 	<array>
 		<string>CloudKit</string>
 	</array>
-	<key>aps-environment</key>
-	<string>development</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.skula.wBlock</string>

--- a/wBlock/wBlock.entitlements
+++ b/wBlock/wBlock.entitlements
@@ -16,6 +16,8 @@
 	<array>
 		<string>CloudKit</string>
 	</array>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.skula.wBlock</string>

--- a/wBlock/wBlockApp.swift
+++ b/wBlock/wBlockApp.swift
@@ -65,7 +65,7 @@ struct wBlockApp: App {
                 }
                 .onChangeCompat(of: scenePhase) { newPhase in
                     guard newPhase == .active, hasCompletedLaunchSetup else { return }
-                    Task { await CloudSyncManager.shared.syncNow(trigger: "AppActive") }
+                    Task { await CloudSyncManager.shared.syncOnAppActive() }
                 }
                 #if os(macOS)
                 .handlesExternalEvents(preferring: Set(["open"]), allowing: Set(["*"]))

--- a/wBlock/wBlockApp.swift
+++ b/wBlock/wBlockApp.swift
@@ -36,16 +36,12 @@ struct wBlockApp: App {
         hasStartedLaunchSetup = true
 
         Task {
-            await dataManager.waitUntilLoaded()
-            await dataManager.migrateLegacyFilterURLs()
-            await dataManager.migrateMultipurposeToAnnoyances()
-            await dataManager.migrateAnnoyancesFilterToSplitFilters()
-            await dataManager.migrateMobileFilterToAdsCategory()
-            await dataManager.migrateAllowlistsToDedicatedCategory()
-            await UserScriptManager.shared.waitUntilReady()
+            // Setup runs through a shared idempotent coordinator so background-launch
+            // entry points (BGAppRefresh, silent push) converge on the same migrations
+            // even when onAppear never runs on a cold launch.
+            await LaunchSetup.runIfNeeded()
             await MainActor.run {
                 hasCompletedLaunchSetup = true
-                CloudSyncManager.shared.activateAfterLaunchSetup()
             }
         }
     }

--- a/wBlock/zh-Hans.lproj/Localizable.strings
+++ b/wBlock/zh-Hans.lproj/Localizable.strings
@@ -840,3 +840,4 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";

--- a/wBlock/zh-Hant.lproj/Localizable.strings
+++ b/wBlock/zh-Hant.lproj/Localizable.strings
@@ -840,3 +840,4 @@ To re-enable these filters, disable other large filters and apply changes again.
 "Skipped pause request while apply is in progress" = "Skipped pause request while apply is in progress";
 "Apply already in progress." = "Apply already in progress.";
 "Some pre-apply filter updates failed; continuing with available lists" = "Some pre-apply filter updates failed; continuing with available lists";
+"iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices." = "iCloud Sync isn't available in this build of wBlock. Install wBlock from the Mac App Store to sync your configuration across devices.";


### PR DESCRIPTION
## Problem

iCloud Sync was pull-only with no push, and the only pull triggers were launch, manual, and a foreground event throttled to once per 120s. So a backgrounded device had no way to learn another device changed anything — it just sat stale until next opened. That's the "often doesn't sync, even manually" symptom.

## Changes (one commit each)

1. **Explain why iCloud Sync is unavailable on non-CloudKit builds** — direct-distribution macOS builds strip the iCloud entitlement, so sync silently did nothing. Surfaces availability to the UI and locks the toggle with an explanatory footer.

2. **Probe remote config on foreground instead of throttling blindly** — AppActive now runs a metadata-only probe (throttled to 30s) and only does a full two-way sync when the remote `updatedAt` actually changed, so foreground pulls happen promptly without hammering CloudKit.

3. **Pull iCloud config during iOS background app refresh** — adds a dedicated `BGAppRefreshTask` that probes every ~3h and applies remote changes while the app is closed.

4. **Wake backgrounded devices with CloudKit change pushes** — adds a `CKDatabaseSubscription` on the private DB plus silent remote-notification registration/handling, so a backgrounded device converges as soon as the synced config changes.

5. **Let automatic signing set aps-environment per configuration** — removed the hardcoded `aps-environment` so Xcode injects `development` for Debug and `production` for App Store/TestFlight automatically. Hardcoding a single value breaks either Debug or distribution.

## No manual setup required

There is no user-facing notification permission prompt — silent (content-available) pushes are separate from the visible-notification authorization. The only developer-side prereq is the **Push Notifications** capability on the `skula.wBlock` app ID, which is already on.

## Known limitations / scope

- Push delivery is iOS-only in this change; macOS still relies on foreground pulls (change 2). macOS remote-notification registration can follow.
- iOS won't deliver silent pushes to an app the user has force-quit from the app switcher; the background-refresh task (change 3) is the fallback for that case.
- Left out on purpose: splitting the single monolithic `wBlockSync` record into per-entity records / change-token deltas. That's a larger schema-migration effort and deserves its own PR.

## Verification

Each touched `.swift` file passes `swiftc -parse`; plists pass `plutil -lint`. Full build/signing verification still pending.

## Localization

The one new user-facing string (the unavailable-build footer) was added to all 17 `*.lproj/Localizable.strings` files.
