### PR TITLE
Remove stale onboarding test assertions

### DIFF
--- a/scripts/test_builtin_userscripts.swift
+++ b/scripts/test_builtin_userscripts.swift
@@ -111,22 +111,12 @@ else {
     exit(1)
 }
 
-guard onboardingSource.contains("Baseline userscripts are enabled by default. You can adjust them here.")
-    && onboardingSource.contains("isBaselineUserscriptEnabledByDefault")
+guard onboardingSource.contains("isBaselineUserscriptEnabledByDefault")
     && onboardingSource.contains("AdGuard Extra")
     && onboardingSource.contains("localizedCaseInsensitiveCompare(\"tinyShield\")")
     && onboardingSource.contains("visibleBaselineIDs")
 else {
     fputs("FAIL: onboarding should enable baseline userscripts by default\n", stderr)
-    exit(1)
-}
-
-guard onboardingSource.contains("regionalUserscriptGroups")
-    && onboardingSource.contains("languagesWithoutRegionalUserscripts")
-    && onboardingSource.contains("No regional userscripts needed. The default userscripts already cover English and international sites.")
-    && onboardingSource.contains("No regional userscripts available. However, the default userscripts already cover English and international sites.")
-else {
-    fputs("FAIL: onboarding should group regional userscripts by language with empty-language fallbacks\n", stderr)
     exit(1)
 }
 


### PR DESCRIPTION
The built-in userscript test still required onboarding copy and regional grouping views that were intentionally removed in 303c9bb. This drops only those stale source-presence assertions while retaining checks for baseline defaults and language-dependent userscript selection.

All 37 Swift script tests, five JavaScript tests, two shell tests, and the three Tube Cleaner suites now pass, including the Facebook Reel and leak safeguards.