### PR TITLE
Fix macOS 12 toolbar compilation

### DIFF
--- a/wBlock/ContentView.swift
+++ b/wBlock/ContentView.swift
@@ -290,8 +290,8 @@ struct ContentView: View {
                 minHeight: 550, idealHeight: 720, maxHeight: .infinity
             )
             .toolbar {
-                if !showFilterSearch {
-                    ToolbarItemGroup(placement: .automatic) {
+                ToolbarItemGroup(placement: .automatic) {
+                    if !showFilterSearch {
                         Button {
                             showingAddFilterSheet = true
                         } label: {
@@ -304,13 +304,7 @@ struct ContentView: View {
                                     ? String(localized: "Apply your pending changes")
                                     : String(localized: "Apply changes")
                             )
-                    }
 
-                    if #available(macOS 26.0, *) {
-                        ToolbarSpacer(.fixed, placement: .automatic)
-                    }
-
-                    ToolbarItem(placement: .automatic) {
                         Button {
                             showOnlyEnabledLists.toggle()
                         } label: {
@@ -320,10 +314,6 @@ struct ContentView: View {
                                     ? "line.3.horizontal.decrease.circle.fill"
                                     : "line.3.horizontal.decrease.circle")
                         }
-                    }
-
-                    if #available(macOS 26.0, *) {
-                        ToolbarSpacer(.fixed, placement: .automatic)
                     }
                 }
 

--- a/wBlock/UserScriptManagerView.swift
+++ b/wBlock/UserScriptManagerView.swift
@@ -364,8 +364,8 @@ struct UserScriptManagerView: View {
             }
         }
         .toolbar {
-            if !showSearch {
-                ToolbarItemGroup(placement: .automatic) {
+            ToolbarItemGroup(placement: .automatic) {
+                if !showSearch {
                     Button {
                         showingAddScriptSheet = true
                     } label: {
@@ -378,13 +378,7 @@ struct UserScriptManagerView: View {
                                 ? String(localized: "Apply your pending changes")
                                 : String(localized: "Apply changes")
                         )
-                }
 
-                if #available(macOS 26.0, *) {
-                    ToolbarSpacer(.fixed, placement: .automatic)
-                }
-
-                ToolbarItem(placement: .automatic) {
                     Button {
                         showOnlyEnabled.toggle()
                         ProtobufDataManager.shared.setUserScriptShowEnabledOnly(showOnlyEnabled)
@@ -395,10 +389,6 @@ struct UserScriptManagerView: View {
                                 ? "line.3.horizontal.decrease.circle.fill"
                                 : "line.3.horizontal.decrease.circle")
                     }
-                }
-
-                if #available(macOS 26.0, *) {
-                    ToolbarSpacer(.fixed, placement: .automatic)
                 }
             }
 


### PR DESCRIPTION
Fixes the macOS 12.3 Xcode Cloud archive failure by keeping conditional buttons inside `ToolbarItemGroup`, whose content uses the older `ViewBuilder` path, rather than conditionally emitting toolbar content that requires macOS 13. It also removes the macOS 26-only spacer branches that triggered the same unavailable toolbar-content builder path.

Verified with the focused UI contracts, a signed-off macOS Release archive at deployment target 12.3, and an iOS Simulator Debug build.