### PR TITLE
Hide unsupported iOS filter update

### DIFF
--- a/scripts/test_popup_filter_update_contract.mjs
+++ b/scripts/test_popup_filter_update_contract.mjs
@@ -23,6 +23,11 @@ const popupStatus = read('wBlockCoreService/FilterUpdatePopupStatus.swift');
 
 check(html.includes('id="update-filters"') && html.includes('id="filter-update-status"'),
   'popup must expose an accessible update action and live status');
+check(html.includes('data-i18n="popup_button_update_filters" hidden') &&
+  popup.includes('const isMac = await isMacPlatform()') &&
+  popup.includes('updateFiltersButton.hidden = !isMac') &&
+  /if \(isMac\) \{\s*refreshFilterUpdateStatus\(\)/.test(popup),
+  'popup filter updates must remain hidden and inactive outside macOS');
 check(html.includes('class="popup-actions"') && html.includes('class="popup-action-row"') &&
   !html.includes('class="section filter-update-section"') &&
   !html.includes('data-i18n="popup_filter_update_label"') &&

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.html
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.html
@@ -75,7 +75,7 @@
 
         <div class="popup-actions">
             <div class="popup-action-row">
-                <button id="update-filters" class="btn" type="button" data-i18n="popup_button_update_filters">Update Filters</button>
+                <button id="update-filters" class="btn" type="button" data-i18n="popup_button_update_filters" hidden>Update Filters</button>
                 <button id="resume-blocking" class="btn btn-primary" type="button" data-i18n="popup_button_resume_blocking" aria-live="polite" hidden>Resume Blocking</button>
             </div>
             <div id="filter-update-status" class="filter-update-status" role="status" aria-live="polite" hidden></div>

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.js
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.js
@@ -754,7 +754,7 @@ async function reloadActiveTab(tabId) {
     }
 }
 
-async function shouldShowOpenAppButton() {
+async function isMacPlatform() {
     try {
         const info = await browser.runtime.getPlatformInfo();
         return typeof info?.os === 'string' && info.os === 'mac';
@@ -1236,9 +1236,14 @@ function setupListeners() {
 
 async function refreshUi() {
     setError('');
-    refreshFilterUpdateStatus().catch((error) => {
-        console.warn('[wBlock] Failed to restore filter update status:', error);
-    });
+    const isMac = await isMacPlatform();
+    const updateFiltersButton = document.getElementById('update-filters');
+    if (updateFiltersButton) updateFiltersButton.hidden = !isMac;
+    if (isMac) {
+        refreshFilterUpdateStatus().catch((error) => {
+            console.warn('[wBlock] Failed to restore filter update status:', error);
+        });
+    }
     browser.runtime.sendMessage({ action: 'wblock:installRemoveParamDNRRules' }).catch((error) => {
         console.warn('[wBlock] Failed to refresh removeparam DNR rules:', error);
     });
@@ -1256,7 +1261,7 @@ async function refreshUi() {
     const resumeButton = document.getElementById('resume-blocking');
 
     if (openAppButton) {
-        openAppButton.hidden = !(await shouldShowOpenAppButton());
+        openAppButton.hidden = !isMac;
     }
     tab = await getActiveTabWithRetry();
     const pageSupport = getPageSupport(tab);


### PR DESCRIPTION
The Safari popup showed Update Filters on iPhone and iPad even though that action uses the macOS-only update path, which left testers with an unavailable-platform error. Keep the action hidden by default, reveal and restore its status only on macOS, and retain Resume Blocking as the available bottom action on iOS/iPadOS.

Verified with the four popup contract tests plus clean macOS and iOS Simulator builds.