### PR TITLE
Block retired tinyShield cloud restores

### DIFF
--- a/scripts/test_cloud_sync_remote_user_scripts.swift
+++ b/scripts/test_cloud_sync_remote_user_scripts.swift
@@ -10,6 +10,19 @@ func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
 @main
 struct CloudSyncRemoteUserScriptTests {
     static func main() {
+        let retiredTinyShield =
+            "https://cdn.jsdelivr.net/npm/@filteringdev/tinyshield@latest/dist/grouped/a/tinyShield-ar.user.js"
+        expect(
+            CloudSyncRemoteUserScriptReconciler.normalizedURL("  \(retiredTinyShield)  ").isEmpty,
+            "retired regional tinyShield variants must not be restored from stale cloud payloads"
+        )
+        expect(
+            !CloudSyncRemoteUserScriptReconciler.normalizedURL(
+                "https://cdn.jsdelivr.net/npm/@filteringdev/tinyshield@latest/dist/tinyShield.user.js"
+            ).isEmpty,
+            "the supported global tinyShield userscript must remain syncable"
+        )
+
         let mergedWithLocalReAdd =
             CloudSyncRemoteUserScriptReconciler.deletedURLsToMergeDuringUploadReconciliation(
                 remoteDeletedURLs: ["https://example.com/foo.user.js"],

--- a/wBlock/CloudSyncRemoteUserScriptSync.swift
+++ b/wBlock/CloudSyncRemoteUserScriptSync.swift
@@ -1,8 +1,12 @@
 import Foundation
 
 enum CloudSyncRemoteUserScriptReconciler {
+    private static let retiredTinyShieldPrefix =
+        "https://cdn.jsdelivr.net/npm/@filteringdev/tinyshield@latest/dist/grouped/"
+
     static func normalizedURL(_ url: String) -> String {
-        url.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.hasPrefix(retiredTinyShieldPrefix) ? "" : normalized
     }
 
     static func deletedURLsToClearDuringUploadReconciliation(


### PR DESCRIPTION
The local startup migration removed obsolete regional tinyShield variants, but an older iCloud payload could restore and re-enable them immediately afterward. This is why it appeared on a long-lived account while other alpha testers without that stale cloud state did not reproduce it.

Retire those grouped URLs in the central remote-userscript reconciler so they are ignored during download, merge, and upload reconciliation while the supported global tinyShield script remains syncable. The focused sync and built-in migration tests pass, along with macOS and iOS Simulator builds.