### PR TITLE
Consolidate selection lists onto shared SelectableRow

### DIFF
--- a/scripts/test_selection_indicator_contract.swift
+++ b/scripts/test_selection_indicator_contract.swift
@@ -22,11 +22,13 @@ require(indicator.contains("Circle()\n                .fill"), "selected state m
 require(indicator.contains(".strokeBorder("), "unselected state must use a shape stroke")
 require(indicator.contains("Image(systemName: \"checkmark\")"), "selected state must contain an explicit checkmark")
 require(indicator.contains(".accessibilityHidden(true)"), "decorative indicator must not duplicate its button label")
-require(onboarding.components(separatedBy: "SelectionIndicator(isSelected: isSelected)").count - 1 == 3, "all onboarding selection cards must use the shared indicator")
-require(apply.contains("SelectionIndicator(isSelected: isSelected, size: 18)"), "apply selection row must use the shared indicator")
+require(indicator.contains("struct SelectableRow: View"), "missing shared selection row")
+require(indicator.contains(".accessibilityAddTraits(isSelected ? .isSelected : [])"), "shared row must expose selected state")
+require(onboarding.components(separatedBy: "SelectableRow(").count - 1 == 3, "all onboarding selection cards must use the shared row")
+require(apply.components(separatedBy: "SelectableRow(").count - 1 == 2, "apply selection rows must use the shared row")
 for source in [onboarding, apply] {
+    require(!source.contains("SelectionIndicator("), "selection rows must go through SelectableRow, not bespoke indicator layouts")
     require(!source.contains("isSelected ? \"checkmark.circle.fill\" : \"circle\""), "outlined SF Symbol selection pair must be removed")
 }
-require(onboarding.components(separatedBy: ".accessibilityAddTraits(isSelected ? .isSelected : [])").count - 1 >= 3, "onboarding cards must expose selected state")
 
-print("PASS: shape-rendered selection indicators")
+print("PASS: shared shape-rendered selection rows")

--- a/wBlock/ApplyChangesProgressView.swift
+++ b/wBlock/ApplyChangesProgressView.swift
@@ -158,8 +158,8 @@ struct ApplyChangesProgressView: View {
                     Section {
                         if let filters = filtersByCategory[category] {
                             ForEach(filters, id: \.id) { filter in
-                                selectionRow(
-                                    title: filter.localizedDisplayName,
+                                SelectableRow(
+                                    title: Text(filter.localizedDisplayName),
                                     subtitle: filter.localizedDisplayDescription,
                                     isSelected: selectedFilters.contains(filter.id)
                                 ) {
@@ -170,8 +170,8 @@ struct ApplyChangesProgressView: View {
 
                         if category == .scripts {
                             ForEach(filterManager.availableScriptUpdates, id: \.id) { script in
-                                selectionRow(
-                                    title: script.localizedDisplayName,
+                                SelectableRow(
+                                    title: Text(script.localizedDisplayName),
                                     subtitle: script.localizedDisplayDescription,
                                     isSelected: selectedScripts.contains(script.id)
                                 ) {
@@ -207,40 +207,6 @@ struct ApplyChangesProgressView: View {
             .toggleStyle(.switch)
             .labelsHidden()
         }
-    }
-
-    private func selectionRow(
-        title: String,
-        subtitle: String,
-        isSelected: Bool,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            HStack(spacing: 12) {
-                SelectionIndicator(isSelected: isSelected, size: 18)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
-                        .font(.body)
-                        .foregroundStyle(.primary)
-                        .multilineTextAlignment(.leading)
-
-                    if !subtitle.isEmpty {
-                        Text(subtitle)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(2)
-                            .multilineTextAlignment(.leading)
-                    }
-                }
-
-                Spacer(minLength: 0)
-            }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(title)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
     // MARK: - Progress

--- a/wBlock/OnboardingView.swift
+++ b/wBlock/OnboardingView.swift
@@ -454,35 +454,14 @@ struct OnboardingView: View {
             selectedBlockingLevel.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             == level.rawValue.lowercased()
 
-        return Button {
+        return SelectableRow(
+            title: Text(LocalizedStringKey(level.rawValue)),
+            subtitle: blockingLevelDescription(level),
+            isSelected: isSelected,
+            style: .card
+        ) {
             selectedBlockingLevel = level.rawValue
-        } label: {
-            HStack(alignment: .top, spacing: 12) {
-                SelectionIndicator(isSelected: isSelected)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 8) {
-                        Text(LocalizedStringKey(level.rawValue))
-                            .font(.headline)
-                    }
-
-                    Text(blockingLevelDescription(level))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer(minLength: 0)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(14)
-            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-        .liquidGlassCompat(
-            cornerRadius: 16,
-            material: isSelected ? .thickMaterial : .regularMaterial
-        )
     }
 
     func blockingLevelDescription(_ level: BlockingLevel) -> String {
@@ -724,41 +703,19 @@ struct OnboardingView: View {
     private func regionalToggle(for filter: FilterList) -> some View {
         let isSelected = selectedRegionalFilters.contains(filter.id)
 
-        return Button {
+        return SelectableRow(
+            title: Text(filter.localizedDisplayName),
+            subtitle: filter.localizedDisplayDescription,
+            isSelected: isSelected,
+            style: .card
+        ) {
             if isSelected {
                 selectedRegionalFilters.remove(filter.id)
             } else {
                 selectedRegionalFilters.insert(filter.id)
             }
             hasManuallyEditedRegionalSelection = true
-        } label: {
-            HStack(alignment: .top, spacing: 12) {
-                SelectionIndicator(isSelected: isSelected)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(filter.localizedDisplayName)
-                        .font(.headline)
-
-                    if !filter.localizedDisplayDescription.isEmpty {
-                        Text(filter.localizedDisplayDescription)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(2)
-                    }
-                }
-
-                Spacer(minLength: 0)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(14)
-            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-        .liquidGlassCompat(
-            cornerRadius: 16,
-            material: isSelected ? .thickMaterial : .regularMaterial
-        )
     }
 
     private var syncStep: some View {
@@ -973,7 +930,13 @@ struct OnboardingView: View {
     private func userscriptCard(for script: OnboardingUserScriptItem) -> some View {
         let isSelected = selectedUserscripts.contains(script.id)
 
-        return Button {
+        return SelectableRow(
+            title: Text(script.name),
+            subtitle: script.description,
+            badge: script.isBeta ? Text("Beta") : nil,
+            isSelected: isSelected,
+            style: .groupedRow
+        ) {
             if isSelected {
                 selectedUserscripts.remove(script.id)
                 manuallySelectedUserscripts.remove(script.id)
@@ -987,40 +950,7 @@ struct OnboardingView: View {
                     manuallySelectedUserscripts.insert(script.id)
                 }
             }
-        } label: {
-            HStack(alignment: .top, spacing: 10) {
-                SelectionIndicator(isSelected: isSelected)
-
-                VStack(alignment: .leading, spacing: 3) {
-                    HStack(spacing: 6) {
-                        Text(script.name)
-                            .font(.headline)
-                        if script.isBeta {
-                            Text("Beta")
-                                .font(.caption2)
-                                .fontWeight(.medium)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .background(Color.orange.opacity(0.15))
-                                .foregroundStyle(.orange)
-                                .cornerRadius(4)
-                        }
-                    }
-                    Text(script.description)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                }
-
-                Spacer(minLength: 0)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
     private func resolvedUserscriptDescription(for script: UserScript) -> String {

--- a/wBlock/SelectionIndicator.swift
+++ b/wBlock/SelectionIndicator.swift
@@ -26,3 +26,104 @@ struct SelectionIndicator: View {
         .accessibilityHidden(true)
     }
 }
+
+/// Shared tappable selection row used by onboarding pick lists and the
+/// apply-updates review sheet. Every selection list renders through this row
+/// so spacing, typography, and accessibility stay consistent.
+struct SelectableRow: View {
+    enum Style {
+        /// Bare row for use inside a `List` section.
+        case listRow
+        /// Row inside a shared grouped material container.
+        case groupedRow
+        /// Standalone material card.
+        case card
+    }
+
+    let title: Text
+    var subtitle: String = ""
+    var badge: Text? = nil
+    let isSelected: Bool
+    var style: Style = .listRow
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: 12) {
+                SelectionIndicator(isSelected: isSelected, size: indicatorSize)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 6) {
+                        title
+                            .font(titleFont)
+                            .foregroundStyle(.primary)
+                            .multilineTextAlignment(.leading)
+
+                        if let badge {
+                            badge
+                                .font(.caption2)
+                                .fontWeight(.medium)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Color.orange.opacity(0.15))
+                                .foregroundStyle(.orange)
+                                .cornerRadius(4)
+                        }
+                    }
+
+                    if !subtitle.isEmpty {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(contentPadding)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .modifier(SelectableRowBackground(style: style, isSelected: isSelected))
+    }
+
+    private var indicatorSize: CGFloat {
+        style == .listRow ? 18 : 20
+    }
+
+    private var titleFont: Font {
+        style == .listRow ? .body : .headline
+    }
+
+    private var contentPadding: EdgeInsets {
+        switch style {
+        case .listRow:
+            return EdgeInsets()
+        case .groupedRow:
+            return EdgeInsets(top: 10, leading: 12, bottom: 10, trailing: 12)
+        case .card:
+            return EdgeInsets(top: 14, leading: 14, bottom: 14, trailing: 14)
+        }
+    }
+}
+
+private struct SelectableRowBackground: ViewModifier {
+    let style: SelectableRow.Style
+    let isSelected: Bool
+
+    func body(content: Content) -> some View {
+        if style == .card {
+            content.liquidGlassCompat(
+                cornerRadius: 16,
+                material: isSelected ? .thickMaterial : .regularMaterial
+            )
+        } else {
+            content
+        }
+    }
+}
+


### PR DESCRIPTION
Adds a shared SelectableRow component and migrates all four bespoke selection rows onto it: the onboarding blocking-level cards, regional filter toggles, and userscript rows, plus the apply-updates review sheet's selectionRow helper (now deleted). Net -102 lines in the views.

The selection indicator contract test now enforces the shared row: three SelectableRow usages in onboarding, two in the apply sheet, and no bespoke SelectionIndicator layouts in either view.

Verified with the contract test (PASS) and a full xcodebuild of the macOS wBlock scheme.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4fbf3575f3c74dd5562cfe0238e62803ce84803b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->