### PR TITLE
Add built-in No Autoplay to the Scripts extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ A Safari content blocker for macOS, iOS, iPadOS, and visionOS.<br>
 
 ### Content modification
 - **Element Zapper** (macOS, iOS, iPadOS, visionOS) — visually select and hide page elements in Safari
+- **No Autoplay** (macOS, iOS, iPadOS, visionOS) — keeps videos and audio paused until you tap or click them, stopping muted feed/scroll autoplay; enable it globally from the Safari toolbar popup and allow autoplay per site when a page needs it
 - **Tube Cleaner & Player Cleaner** — optional remote userscript defaults downloaded from the wBlock-userscripts repository; they turn existing media elements into native Safari players before first paint, restoring Picture-in-Picture and background playback. They update independently of the app version; wBlock's content-blocking rules handle ads separately
 - **Userscript engine** with Greasemonkey API (GM_getValue, GM_setValue, GM_xmlhttpRequest)
 - **Userstyle support** — install UserCSS themes (.user.css) applied natively as CSS, no JS wrapper needed

--- a/scripts/test_no_autoplay.mjs
+++ b/scripts/test_no_autoplay.mjs
@@ -100,8 +100,15 @@ function createEnvironment(options = {}) {
     },
   });
 
+  const bodyElement = attrsMixin({
+    localName: "body",
+    querySelectorAll: (selector) => (selector === "video, audio" ? env.mediaInDom : []),
+    parentElement: documentElement,
+  });
+
   const documentStub = {
     documentElement: options.deferRoot ? null : documentElement,
+    body: bodyElement,
     head: null,
     addEventListener(type, fn) {
       if (!env.documentListeners.has(type)) env.documentListeners.set(type, []);
@@ -124,6 +131,7 @@ function createEnvironment(options = {}) {
     event.type = type;
     documentStub.dispatchEvent(event);
   };
+  env.body = bodyElement;
 
   function MutationObserver(callback) {
     this.callback = callback;
@@ -267,6 +275,32 @@ async function playResult(media) {
   const arrowVideo = env.makeMedia("video");
   env.dispatch("keydown", { key: "ArrowDown", target: arrowVideo, composedPath: () => [arrowVideo] });
   check("non-playback key does not unlock media", (await playResult(arrowVideo)) === "NotAllowedError");
+}
+
+// --- 2b. Page-level gestures never unlock a page's only video ---
+{
+  const env = createEnvironment({ hint: true, storage: { [ENABLED_KEY]: true } });
+  env.run();
+  const only = env.makeMedia("video");
+  only.parentElement = env.body;
+  env.mediaInDom.push(only);
+
+  env.dispatch("click", { target: env.body, composedPath: () => [env.body] });
+  check("a click on the body does not unlock the page's only video",
+    (await playResult(only)) === "NotAllowedError");
+
+  env.dispatch("keydown", { key: " ", target: env.body, composedPath: () => [env.body] });
+  check("pressing space on the page does not unlock the only video",
+    (await playResult(only)) === "NotAllowedError");
+
+  const unrelated = { localName: "div", querySelectorAll: () => [], parentElement: env.body };
+  env.dispatch("pointerdown", { target: unrelated, composedPath: () => [unrelated, env.body] });
+  check("a gesture in unrelated UI walks up but stops before the body",
+    (await playResult(only)) === "NotAllowedError");
+
+  env.dispatch("click", { target: only, composedPath: () => [only, env.body] });
+  check("a direct gesture on the only video still unlocks it",
+    (await playResult(only)) === "ok");
 }
 
 // --- 3. Boot scan and mutation observer disarm autoplaying media ---

--- a/scripts/test_no_autoplay.mjs
+++ b/scripts/test_no_autoplay.mjs
@@ -1,0 +1,433 @@
+// Behavioral test for the No Autoplay content script
+// ("wBlock Scripts (iOS)/Resources/no-autoplay.js").
+//
+// Runs the shipped script in a vm sandbox with stubbed DOM and WebExtension
+// APIs and verifies the controller/gate contract:
+// - the warm hint arms the gate synchronously at document_start;
+// - extension storage is authoritative and corrects the hint both ways;
+// - locked media rejects play() with NotAllowedError and loses autoplay;
+// - user gestures (direct or via a single-media player) unlock media;
+// - per-site allow, the native disabled-sites state, and live storage
+//   changes stand the gate down (and re-arm it) without a reload;
+// - a CSP that blocks inline scripts falls back to the isolated world where
+//   DOM-level enforcement (autoplay stripping, pause-on-play) still works.
+//
+// Run: node scripts/test_no_autoplay.mjs [path/to/no-autoplay.js]
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const scriptPath = process.argv[2]
+  ?? path.join(repoRoot, "wBlock Scripts (iOS)", "Resources", "no-autoplay.js");
+const source = readFileSync(scriptPath, "utf8");
+
+const ENABLED_KEY = "wblock.noAutoplay.enabled.v1";
+const ALLOW_PREFIX = "wblock.noAutoplayAllow.v1:";
+const HINT_KEY = "__wblock_no_autoplay_arm_v1";
+const HOST = "example.com";
+
+let failures = 0;
+const check = (name, cond) => {
+  console.log(`${cond ? "PASS" : "FAIL"}: ${name}`);
+  if (!cond) failures += 1;
+};
+const settle = () => new Promise((resolve) => setTimeout(resolve, 25));
+
+function createEnvironment(options = {}) {
+  const env = {
+    inlineExecutions: 0,
+    observers: [],
+    storageListeners: [],
+    documentListeners: new Map(),
+    mediaInDom: [],
+    localStore: new Map(),
+    nativeCalls: [],
+  };
+
+  if (options.hint) env.localStore.set(HINT_KEY, "1");
+  const storageData = options.storage || {};
+
+  function attrsMixin(target) {
+    const attrs = new Map();
+    target.getAttribute = (k) => (attrs.has(k) ? attrs.get(k) : null);
+    target.setAttribute = (k, v) => { attrs.set(k, String(v)); };
+    target.removeAttribute = (k) => { attrs.delete(k); };
+    target.hasAttribute = (k) => attrs.has(k);
+    return target;
+  }
+
+  function HTMLMediaElement() {}
+  HTMLMediaElement.prototype.play = function () {
+    this.playedNatively = true;
+    this.paused = false;
+    return Promise.resolve();
+  };
+  Object.defineProperty(HTMLMediaElement.prototype, "autoplay", {
+    configurable: true,
+    enumerable: true,
+    get() { return this._autoplay === true; },
+    set(value) {
+      this._autoplay = value === true;
+      if (this._autoplay) this.setAttribute("autoplay", "");
+      else this.removeAttribute("autoplay");
+    },
+  });
+
+  env.makeMedia = (localName = "video") => {
+    const media = Object.create(HTMLMediaElement.prototype);
+    attrsMixin(media);
+    media.localName = localName;
+    media.paused = true;
+    media.pauseCalls = 0;
+    media.playedNatively = false;
+    media.pause = () => { media.pauseCalls += 1; media.paused = true; };
+    media.querySelectorAll = () => [];
+    media.addEventListener = () => {};
+    return media;
+  };
+
+  const documentElement = attrsMixin({
+    querySelectorAll: (selector) => (selector === "video, audio" ? env.mediaInDom : []),
+    appendChild(el) {
+      if (typeof el.textContent === "string" && el.textContent.length > 0 && !options.cspBlocksInline) {
+        env.inlineExecutions += 1;
+        vm.runInContext(el.textContent, context);
+      }
+      return el;
+    },
+  });
+
+  const documentStub = {
+    documentElement: options.deferRoot ? null : documentElement,
+    head: null,
+    addEventListener(type, fn) {
+      if (!env.documentListeners.has(type)) env.documentListeners.set(type, []);
+      env.documentListeners.get(type).push(fn);
+    },
+    removeEventListener() {},
+    dispatchEvent(event) {
+      for (const fn of env.documentListeners.get(event.type) || []) fn(event);
+      return true;
+    },
+    createElement(tag) {
+      const el = attrsMixin({ tagName: String(tag).toUpperCase(), textContent: "", remove() {} });
+      return el;
+    },
+    querySelector: () => null,
+    querySelectorAll: () => [],
+  };
+
+  env.dispatch = (type, event) => {
+    event.type = type;
+    documentStub.dispatchEvent(event);
+  };
+
+  function MutationObserver(callback) {
+    this.callback = callback;
+    this.roots = [];
+    env.observers.push(this);
+  }
+  MutationObserver.prototype.observe = function (root) { this.roots.push(root); };
+  MutationObserver.prototype.disconnect = function () {};
+  env.triggerMutations = (mutations) => {
+    for (const observer of env.observers) observer.callback(mutations);
+  };
+
+  class DOMExceptionStub extends Error {
+    constructor(message, name) {
+      super(message);
+      this.name = name || "Error";
+    }
+  }
+
+  class EventStub {
+    constructor(type) { this.type = type; }
+  }
+
+  function DocumentStubCtor() {}
+  DocumentStubCtor.prototype.createElement = documentStub.createElement;
+  function ElementStubCtor() {}
+
+  const sandbox = {
+    console,
+    setTimeout,
+    clearTimeout,
+    HTMLMediaElement,
+    Document: DocumentStubCtor,
+    Element: ElementStubCtor,
+    MutationObserver,
+    DOMException: DOMExceptionStub,
+    Event: EventStub,
+    document: documentStub,
+    location: { hostname: options.hostname ?? HOST },
+    localStorage: {
+      getItem: (k) => (env.localStore.has(k) ? env.localStore.get(k) : null),
+      setItem: (k, v) => { env.localStore.set(k, String(v)); },
+      removeItem: (k) => { env.localStore.delete(k); },
+    },
+    crypto: {
+      getRandomValues(arr) {
+        for (let i = 0; i < arr.length; i += 1) arr[i] = (i * 37 + 11) % 256;
+        return arr;
+      },
+    },
+    browser: {
+      runtime: {
+        sendNativeMessage(_id, message) {
+          env.nativeCalls.push(message);
+          if (message && message.action === "getSiteDisabledState") {
+            return Promise.resolve({ disabled: options.nativeDisabled === true });
+          }
+          return Promise.resolve({});
+        },
+      },
+      storage: {
+        local: {
+          get: async (keys) => {
+            const out = {};
+            for (const key of Array.isArray(keys) ? keys : [keys]) {
+              if (key in storageData) out[key] = storageData[key];
+            }
+            return out;
+          },
+        },
+        onChanged: {
+          addListener: (fn) => { env.storageListeners.push(fn); },
+        },
+      },
+    },
+  };
+  sandbox.window = sandbox;
+  const context = vm.createContext(sandbox);
+  env.sandbox = sandbox;
+  env.storage = storageData;
+  env.run = () => vm.runInContext(source, context);
+  env.gateMarker = () => documentElement.getAttribute("data-wblock-no-autoplay-gate") === "1";
+  env.notifyStorageChange = (changes) => {
+    for (const fn of env.storageListeners) fn(changes, "local");
+  };
+  env.attachRoot = () => {
+    documentStub.documentElement = documentElement;
+    env.triggerMutations([{ type: "childList", addedNodes: [] }]);
+  };
+  return env;
+}
+
+async function playResult(media) {
+  try {
+    await media.play();
+    return "ok";
+  } catch (error) {
+    return error && error.name ? error.name : "error";
+  }
+}
+
+// --- 1. Warm hint arms the gate synchronously at document_start ---
+{
+  const env = createEnvironment({ hint: true, storage: { [ENABLED_KEY]: true } });
+  env.run();
+  check("warm hint injects the page gate synchronously (before any await)", env.gateMarker());
+  check("page-world injection used the inline script path", env.inlineExecutions === 1);
+
+  const video = env.makeMedia("video");
+  const blocked = await playResult(video);
+  check("locked media rejects play() with NotAllowedError", blocked === "NotAllowedError");
+  check("blocked media is marked and stays paused", video.getAttribute("data-wblock-no-autoplay") === "1" && video.paused);
+
+  video.autoplay = true;
+  check("autoplay setter is ignored while locked", video.autoplay === false && !video.hasAttribute("autoplay"));
+
+  env.dispatch("click", { target: video, composedPath: () => [video] });
+  check("a direct click unlocks that media", video.getAttribute("data-wblock-no-autoplay-unlocked") === "1");
+  check("unlocked media plays natively", (await playResult(video)) === "ok" && video.playedNatively);
+
+  const other = env.makeMedia("video");
+  check("unlocking one media does not unlock others", (await playResult(other)) === "NotAllowedError");
+
+  await settle();
+  check("authoritative check keeps the hint set while enabled", env.localStore.get(HINT_KEY) === "1");
+}
+
+// --- 2. A play button beside a single video unlocks that player ---
+{
+  const env = createEnvironment({ hint: true, storage: { [ENABLED_KEY]: true } });
+  env.run();
+  const video = env.makeMedia("video");
+  const player = { querySelectorAll: (sel) => (sel === "video, audio" ? [video] : []) };
+  const button = { querySelectorAll: () => [], parentElement: player };
+  env.dispatch("click", { target: button, composedPath: () => [button, player] });
+  check("sibling play button unlocks the only video in the player", (await playResult(video)) === "ok");
+
+  const keyedVideo = env.makeMedia("video");
+  env.dispatch("keydown", { key: "k", target: keyedVideo, composedPath: () => [keyedVideo] });
+  check("playback key unlocks the focused media", (await playResult(keyedVideo)) === "ok");
+  const arrowVideo = env.makeMedia("video");
+  env.dispatch("keydown", { key: "ArrowDown", target: arrowVideo, composedPath: () => [arrowVideo] });
+  check("non-playback key does not unlock media", (await playResult(arrowVideo)) === "NotAllowedError");
+}
+
+// --- 3. Boot scan and mutation observer disarm autoplaying media ---
+{
+  const env = createEnvironment({ hint: true, storage: { [ENABLED_KEY]: true } });
+  const preexisting = env.makeMedia("video");
+  preexisting._autoplay = true;
+  preexisting.setAttribute("autoplay", "");
+  preexisting.paused = false;
+  env.mediaInDom.push(preexisting);
+  env.run();
+  check("boot scan pauses and disarms media that was already autoplaying",
+    preexisting.pauseCalls > 0 && preexisting.paused && !preexisting.hasAttribute("autoplay"));
+
+  const late = env.makeMedia("audio");
+  late._autoplay = true;
+  late.setAttribute("autoplay", "");
+  late.paused = false;
+  env.triggerMutations([{ type: "childList", addedNodes: [late] }]);
+  check("mutation observer disarms media added later",
+    late.pauseCalls > 0 && !late.hasAttribute("autoplay") && late.getAttribute("data-wblock-no-autoplay") === "1");
+
+  const rearmed = env.makeMedia("video");
+  rearmed.setAttribute("autoplay", "");
+  env.triggerMutations([{ type: "attributes", addedNodes: [], target: rearmed }]);
+  check("mutation observer strips a re-added autoplay attribute", !rearmed.hasAttribute("autoplay"));
+
+  check("pause-on-play event catches media that slipped through", (() => {
+    const slipped = env.makeMedia("video");
+    slipped.paused = false;
+    env.dispatch("play", { target: slipped });
+    return slipped.pauseCalls > 0 && slipped.paused;
+  })());
+}
+
+// --- 4. Authoritative state corrects a stale hint (per-site allow) ---
+{
+  const env = createEnvironment({
+    hint: true,
+    storage: { [ENABLED_KEY]: true, [ALLOW_PREFIX + HOST]: true },
+  });
+  env.run();
+  check("stale hint still arms synchronously", env.gateMarker());
+  await settle();
+  check("per-site allow clears the hint", !env.localStore.has(HINT_KEY));
+  const video = env.makeMedia("video");
+  check("per-site allow stands the gate down (play passes through)", (await playResult(video)) === "ok");
+  video.autoplay = true;
+  check("per-site allow restores the autoplay setter", video.autoplay === true && video.hasAttribute("autoplay"));
+}
+
+// --- 5. Global toggle off: nothing arms ---
+{
+  const env = createEnvironment({ storage: {} });
+  env.run();
+  await settle();
+  check("disabled feature never injects the gate", !env.gateMarker() && env.inlineExecutions === 0);
+  check("disabled feature leaves no hint behind", !env.localStore.has(HINT_KEY));
+  const video = env.makeMedia("video");
+  check("disabled feature leaves play() untouched", (await playResult(video)) === "ok");
+}
+
+// --- 6. First visit with the feature enabled arms after the async check ---
+{
+  const env = createEnvironment({ storage: { [ENABLED_KEY]: true } });
+  env.run();
+  check("no hint means no synchronous arming", !env.gateMarker());
+  await settle();
+  check("authoritative check arms the gate on first visit", env.gateMarker());
+  check("authoritative check records the hint for the next visit", env.localStore.get(HINT_KEY) === "1");
+  check("native disabled-sites state was consulted",
+    env.nativeCalls.some((m) => m && m.action === "getSiteDisabledState" && m.host === HOST));
+}
+
+// --- 7. wBlock disabled on this site: gate stands down ---
+{
+  const env = createEnvironment({ hint: true, storage: { [ENABLED_KEY]: true }, nativeDisabled: true });
+  env.run();
+  await settle();
+  check("site-disabled state clears the hint", !env.localStore.has(HINT_KEY));
+  const video = env.makeMedia("video");
+  check("site-disabled state stands the gate down", (await playResult(video)) === "ok");
+}
+
+// --- 8. Live storage changes disarm and re-arm without a reload ---
+{
+  const env = createEnvironment({ hint: true, storage: { [ENABLED_KEY]: true } });
+  env.run();
+  await settle();
+  const video = env.makeMedia("video");
+  check("gate is armed before the live change", (await playResult(video)) === "NotAllowedError");
+
+  env.storage[ENABLED_KEY] = false;
+  env.notifyStorageChange({ [ENABLED_KEY]: { newValue: false } });
+  await settle();
+  check("turning the global toggle off disarms live", (await playResult(video)) === "ok");
+  check("live disarm clears the hint", !env.localStore.has(HINT_KEY));
+
+  env.storage[ENABLED_KEY] = true;
+  env.notifyStorageChange({ [ENABLED_KEY]: { newValue: true } });
+  await settle();
+  const fresh = env.makeMedia("video");
+  check("turning the global toggle back on re-arms live", (await playResult(fresh)) === "NotAllowedError");
+  check("re-arming does not inject a second gate", env.inlineExecutions === 1);
+}
+
+// --- 9. CSP fallback: gate runs in the isolated world ---
+{
+  const env = createEnvironment({ hint: true, storage: { [ENABLED_KEY]: true }, cspBlocksInline: true });
+  env.run();
+  check("CSP fallback does not execute inline scripts", env.inlineExecutions === 0);
+  check("CSP fallback still activates the gate", env.gateMarker());
+
+  const video = env.makeMedia("video");
+  video.paused = false;
+  env.dispatch("play", { target: video });
+  check("CSP fallback pauses locked media on play events", video.pauseCalls > 0 && video.paused);
+
+  const late = env.makeMedia("video");
+  late._autoplay = true;
+  late.setAttribute("autoplay", "");
+  env.triggerMutations([{ type: "childList", addedNodes: [late] }]);
+  check("CSP fallback strips autoplay from added media", !late.hasAttribute("autoplay"));
+
+  env.dispatch("click", { target: video, composedPath: () => [video] });
+  check("CSP fallback records unlocks in the shared DOM",
+    video.getAttribute("data-wblock-no-autoplay-unlocked") === "1");
+}
+
+// --- 10. document_start before the document element exists ---
+{
+  const env = createEnvironment({ hint: true, storage: { [ENABLED_KEY]: true }, deferRoot: true });
+  env.run();
+  check("arming defers while the document element is missing", !env.gateMarker() && env.inlineExecutions === 0);
+  env.attachRoot();
+  check("gate arms as soon as the document element appears", env.gateMarker() && env.inlineExecutions === 1);
+  const video = env.makeMedia("video");
+  check("deferred gate still blocks play()", (await playResult(video)) === "NotAllowedError");
+}
+
+// --- 11. Deferred arm is cancelled if the authoritative check says off ---
+{
+  const env = createEnvironment({ hint: true, storage: {}, deferRoot: true });
+  env.run();
+  await settle();
+  env.attachRoot();
+  check("deferred arm is cancelled when the feature turns out to be off",
+    !env.gateMarker() && env.inlineExecutions === 0);
+  check("cancelled deferred arm clears the hint", !env.localStore.has(HINT_KEY));
+}
+
+// --- 12. Frames without a hostname never arm ---
+{
+  const env = createEnvironment({ hint: true, storage: { [ENABLED_KEY]: true }, hostname: "" });
+  env.run();
+  await settle();
+  check("hostname-less frames stand down after the authoritative check", !env.localStore.has(HINT_KEY));
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nAll No Autoplay checks passed");

--- a/scripts/test_no_autoplay.sh
+++ b/scripts/test_no_autoplay.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# CI wrapper for the No Autoplay content script behavioral test.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+node scripts/test_no_autoplay.mjs

--- a/wBlock Scripts (iOS)/Resources/_locales/ar/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ar/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "تعذر بدء تحديث الفلاتر.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "إيقاف التشغيل التلقائي",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "السماح بالتشغيل التلقائي على هذا الموقع",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "تبقى الوسائط متوقفة مؤقتًا حتى تضغط أو تنقر عليها.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/de/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/de/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "Filteraktualisierung konnte nicht gestartet werden.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "Keine automatische Wiedergabe",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "Autoplay auf dieser Website erlauben",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "Medien bleiben pausiert, bis du sie antippst oder anklickst.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/el/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/el/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "Δεν ήταν δυνατή η έναρξη της ενημέρωσης φίλτρων.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "Χωρίς αυτόματη αναπαραγωγή",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "Να επιτρέπεται η αυτόματη αναπαραγωγή σε αυτόν τον ιστότοπο",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "Τα πολυμέσα παραμένουν σε παύση μέχρι να τα πατήσετε ή να κάνετε κλικ.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/en/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/en/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "Could not start filter update.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "No Autoplay",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "Allow autoplay on this site",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "Media stays paused until you tap or click it.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/es/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/es/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "No se pudo iniciar la actualización de filtros.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "Sin reproducción automática",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "Permitir reproducción automática en este sitio",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "El contenido permanece en pausa hasta que lo toques o hagas clic.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/fr/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/fr/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "Impossible de démarrer la mise à jour des filtres.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "Pas de lecture automatique",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "Autoriser la lecture automatique sur ce site",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "Les médias restent en pause jusqu’à ce que vous les touchiez ou cliquiez.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/hu/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/hu/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "A szűrőfrissítés nem indítható el.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "Automatikus lejátszás tiltása",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "Automatikus lejátszás engedélyezése ezen az oldalon",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "A média szüneteltetve marad, amíg rá nem koppint vagy kattint.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/it/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/it/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "Impossibile avviare l’aggiornamento dei filtri.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "Nessuna riproduzione automatica",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "Consenti la riproduzione automatica su questo sito",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "I contenuti restano in pausa finché non li tocchi o fai clic.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/ja/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ja/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "フィルターの更新を開始できません。",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "自動再生をブロック",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "このサイトで自動再生を許可",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "タップまたはクリックするまでメディアは一時停止のままです。",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/ko/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ko/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "필터 업데이트를 시작할 수 없습니다.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "자동 재생 차단",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "이 사이트에서 자동 재생 허용",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "탭하거나 클릭하기 전에는 미디어가 일시 정지된 상태로 유지됩니다.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/pl/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/pl/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "Nie można rozpocząć aktualizacji filtrów.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "Bez autoodtwarzania",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "Zezwól na autoodtwarzanie w tej witrynie",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "Multimedia pozostają wstrzymane, dopóki ich nie dotkniesz lub nie klikniesz.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/pt_BR/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/pt_BR/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "Não foi possível iniciar a atualização dos filtros.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "Sem reprodução automática",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "Permitir reprodução automática neste site",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "A mídia fica pausada até você tocar ou clicar nela.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/ro/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ro/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "Actualizarea filtrelor nu a putut fi pornită.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "Fără redare automată",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "Permite redarea automată pe acest site",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "Conținutul rămâne în pauză până când îl atingi sau dai clic.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/ru/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ru/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "Не удалось начать обновление фильтров.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "Без автовоспроизведения",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "Разрешить автовоспроизведение на этом сайте",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "Медиа остаётся на паузе, пока вы не нажмёте на него.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/tr/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/tr/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "Filtre güncellemesi başlatılamadı.",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "Otomatik oynatma yok",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "Bu sitede otomatik oynatmaya izin ver",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "Siz dokunana veya tıklayana kadar medya duraklatılmış kalır.",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/zh_CN/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/zh_CN/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "无法开始更新过滤器。",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "禁止自动播放",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "允许此网站自动播放",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "媒体将保持暂停，直到你点按或点击它。",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/_locales/zh_TW/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/zh_TW/messages.json
@@ -282,5 +282,17 @@
   "popup_error_filter_update_start": {
     "message": "無法開始更新過濾器。",
     "description": "Error shown when the background filter update cannot be started."
+  },
+  "popup_no_autoplay": {
+    "message": "停止自動播放",
+    "description": "Section title for the No Autoplay controls in the popup."
+  },
+  "popup_no_autoplay_allow_site": {
+    "message": "允許此網站自動播放",
+    "description": "Label for the per-site toggle that allows autoplay on the current site."
+  },
+  "popup_no_autoplay_hint": {
+    "message": "媒體會保持暫停，直到你點按或按一下它。",
+    "description": "Hint explaining what No Autoplay does."
   }
 }

--- a/wBlock Scripts (iOS)/Resources/manifest.json
+++ b/wBlock Scripts (iOS)/Resources/manifest.json
@@ -21,6 +21,7 @@
     "content_scripts": [
         {
             "js": [
+                "no-autoplay.js",
                 "zapper-content.js",
                 "content.js"
             ],

--- a/wBlock Scripts (iOS)/Resources/no-autoplay.js
+++ b/wBlock Scripts (iOS)/Resources/no-autoplay.js
@@ -151,8 +151,13 @@
                     return;
                 }
             }
+            // Walk up from the target looking for player chrome that wraps
+            // exactly one media element. Stop before page-level containers:
+            // treating body/html as a "player" would let a gesture anywhere
+            // on the page unlock its only video.
             var el = event.target;
             for (i = 0; i < 8 && el; i++) {
+                if (el === doc.body || el === doc.documentElement || el === doc) return;
                 if (el.querySelectorAll) {
                     var list = el.querySelectorAll('video, audio');
                     if (list.length === 1) {

--- a/wBlock Scripts (iOS)/Resources/no-autoplay.js
+++ b/wBlock Scripts (iOS)/Resources/no-autoplay.js
@@ -1,0 +1,479 @@
+// wBlock No Autoplay (WebExtension content script)
+//
+// Keeps media paused until the user taps, clicks, or key-activates it, which
+// stops muted feed/scroll autoplay. The enforcement gate has to patch
+// HTMLMediaElement.prototype.play before page scripts call it, so it is
+// injected into the page world via an inline <script> tag; when a strict CSP
+// blocks that, the same gate runs in this isolated world, where its DOM-level
+// protections (autoplay stripping, pause-on-play, unlock on interaction)
+// still apply to the shared document.
+//
+// State model:
+// - Global toggle:  browser.storage.local["wblock.noAutoplay.enabled.v1"]
+// - Per-site allow: browser.storage.local["wblock.noAutoplayAllow.v1:<host>"]
+// - Sites where wBlock is disabled ("Enable on this site" off) stand down.
+// - Warm hint: page localStorage["__wblock_no_autoplay_arm_v1"] mirrors the
+//   last authoritative decision so repeat visits arm synchronously at
+//   document_start. The hint is page-writable by design (the same trust model
+//   as the userscript injector's warm-start cache): the worst a page can do is
+//   toggle its own first-paint arming, and the async authoritative check
+//   corrects it. Autoplay blocking is a convenience, not a security boundary.
+
+(function () {
+    'use strict';
+
+    var ENABLED_KEY = 'wblock.noAutoplay.enabled.v1';
+    var ALLOW_PREFIX = 'wblock.noAutoplayAllow.v1:';
+    var HINT_KEY = '__wblock_no_autoplay_arm_v1';
+    var NATIVE_MESSAGE_TIMEOUT_MS = 3500;
+
+    var hasExtensionContext = typeof browser !== 'undefined'
+        && !!browser.runtime
+        && typeof browser.runtime.sendNativeMessage === 'function'
+        && !!browser.storage
+        && !!browser.storage.local;
+    if (!hasExtensionContext) return;
+
+    // ------------------------------------------------------------------
+    // Gate. Runs in the page world (serialized via Function.prototype
+    // .toString into an inline <script>) or, as the CSP fallback, directly
+    // in this isolated world. It must stay fully self-contained: no
+    // references to the enclosing scope.
+    // ------------------------------------------------------------------
+    function noAutoplayGate(token) {
+        'use strict';
+
+        if (window.__wblockNoAutoplayGateActive) return;
+        window.__wblockNoAutoplayGateActive = true;
+
+        var doc = document;
+        var disabled = false;
+        var unlocked = typeof WeakSet === 'function' ? new WeakSet() : null;
+
+        // Execution marker: the controller checks this attribute to learn
+        // whether page-world injection survived the page's CSP.
+        try {
+            if (doc.documentElement) {
+                doc.documentElement.setAttribute('data-wblock-no-autoplay-gate', '1');
+            }
+        } catch (e) { /* ignore */ }
+
+        function makeNotAllowed() {
+            try {
+                return new DOMException(
+                    'The play() request was interrupted because autoplay is disabled.',
+                    'NotAllowedError'
+                );
+            } catch (e) {
+                var err = new Error('The play() request was interrupted because autoplay is disabled.');
+                err.name = 'NotAllowedError';
+                return err;
+            }
+        }
+
+        function isMedia(node) {
+            return !!(node && (node.localName === 'video' || node.localName === 'audio'));
+        }
+
+        // The unlocked state is mirrored into a DOM attribute so that the
+        // page-world gate and an isolated-world gate agree on it even though
+        // expandos and WeakSets do not cross worlds.
+        function isUnlocked(media) {
+            if (disabled) return true;
+            if (!media) return false;
+            try { if (media._wblockNoAutoplayUnlocked) return true; } catch (e) { /* ignore */ }
+            try {
+                if (media.getAttribute && media.getAttribute('data-wblock-no-autoplay-unlocked') === '1') return true;
+            } catch (e) { /* ignore */ }
+            return !!(unlocked && unlocked.has(media));
+        }
+
+        function unlock(media) {
+            if (!isMedia(media)) return;
+            try { media._wblockNoAutoplayUnlocked = true; } catch (e) { /* ignore */ }
+            try { media.setAttribute('data-wblock-no-autoplay-unlocked', '1'); } catch (e) { /* ignore */ }
+            if (unlocked) {
+                try { unlocked.add(media); } catch (e) { /* ignore */ }
+            }
+        }
+
+        function disarm(media) {
+            if (disabled || !isMedia(media) || isUnlocked(media)) return;
+            try { media.autoplay = false; } catch (e) { /* ignore */ }
+            try { media.removeAttribute('autoplay'); } catch (e) { /* ignore */ }
+            try { media.setAttribute('data-wblock-no-autoplay', '1'); } catch (e) { /* ignore */ }
+        }
+
+        function pauseIfLocked(media) {
+            if (disabled || !isMedia(media) || isUnlocked(media)) return;
+            disarm(media);
+            try {
+                if (!media.paused) media.pause();
+            } catch (e) { /* ignore */ }
+        }
+
+        function watchMedia(media) {
+            if (!isMedia(media)) return;
+            disarm(media);
+            pauseIfLocked(media);
+        }
+
+        function scan(root) {
+            if (disabled || !root) return;
+            if (isMedia(root)) watchMedia(root);
+            if (!root.querySelectorAll) return;
+            var list = root.querySelectorAll('video, audio');
+            for (var i = 0; i < list.length; i++) watchMedia(list[i]);
+        }
+
+        function eventPath(event) {
+            try {
+                if (typeof event.composedPath === 'function') return event.composedPath();
+            } catch (e) { /* ignore */ }
+            var path = [];
+            var node = event.target;
+            while (node) {
+                path.push(node);
+                node = node.parentNode || node.host;
+            }
+            return path;
+        }
+
+        // A gesture on the media itself (or on the single-media player around
+        // it, e.g. a custom play button) unlocks that element.
+        function unlockFromEvent(event) {
+            if (disabled) return;
+            var path = eventPath(event);
+            var i;
+            for (i = 0; i < path.length; i++) {
+                if (isMedia(path[i])) {
+                    unlock(path[i]);
+                    return;
+                }
+            }
+            var el = event.target;
+            for (i = 0; i < 8 && el; i++) {
+                if (el.querySelectorAll) {
+                    var list = el.querySelectorAll('video, audio');
+                    if (list.length === 1) {
+                        unlock(list[0]);
+                        return;
+                    }
+                    if (list.length > 1) return;
+                }
+                el = el.parentElement || el.parentNode;
+            }
+        }
+
+        function onKey(event) {
+            var key = event.key;
+            if (key !== ' ' && key !== 'k' && key !== 'K' && key !== 'MediaPlayPause') return;
+            unlockFromEvent(event);
+        }
+
+        function onPlayEvent(event) {
+            pauseIfLocked(event.target);
+        }
+
+        try {
+            var nativePlay = HTMLMediaElement.prototype.play;
+            HTMLMediaElement.prototype.play = function () {
+                if (isUnlocked(this)) return nativePlay.apply(this, arguments);
+                disarm(this);
+                try { if (!this.paused) this.pause(); } catch (e) { /* ignore */ }
+                return Promise.reject(makeNotAllowed());
+            };
+        } catch (e) { /* ignore */ }
+
+        try {
+            var autoplayDesc = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'autoplay');
+            if (autoplayDesc && typeof autoplayDesc.set === 'function' && typeof autoplayDesc.get === 'function') {
+                Object.defineProperty(HTMLMediaElement.prototype, 'autoplay', {
+                    configurable: true,
+                    enumerable: autoplayDesc.enumerable,
+                    get: function () {
+                        return isUnlocked(this) ? autoplayDesc.get.call(this) : false;
+                    },
+                    set: function (value) {
+                        if (!isUnlocked(this) && value) {
+                            autoplayDesc.set.call(this, false);
+                            try { this.removeAttribute('autoplay'); } catch (e) { /* ignore */ }
+                            return;
+                        }
+                        autoplayDesc.set.call(this, value);
+                    }
+                });
+            }
+        } catch (e) { /* ignore */ }
+
+        try {
+            var nativeCreateElement = Document.prototype.createElement;
+            Document.prototype.createElement = function (name) {
+                var el = nativeCreateElement.apply(this, arguments);
+                if (typeof name === 'string' && /^(video|audio)$/i.test(name)) watchMedia(el);
+                return el;
+            };
+        } catch (e) { /* ignore */ }
+
+        var observer = new MutationObserver(function (mutations) {
+            if (disabled) return;
+            for (var i = 0; i < mutations.length; i++) {
+                var mutation = mutations[i];
+                if (mutation.type === 'attributes') {
+                    if (!isUnlocked(mutation.target)) disarm(mutation.target);
+                    continue;
+                }
+                var nodes = mutation.addedNodes;
+                for (var j = 0; j < nodes.length; j++) scan(nodes[j]);
+            }
+        });
+
+        function observeRoot(root) {
+            if (!root || root._wblockNoAutoplayObserved) return;
+            root._wblockNoAutoplayObserved = true;
+            try {
+                observer.observe(root, {
+                    childList: true,
+                    subtree: true,
+                    attributes: true,
+                    attributeFilter: ['autoplay']
+                });
+            } catch (e) { /* ignore */ }
+            scan(root);
+        }
+
+        try {
+            var nativeAttachShadow = Element.prototype.attachShadow;
+            if (nativeAttachShadow && !nativeAttachShadow._wblockNoAutoplayPatched) {
+                var patchedAttachShadow = function () {
+                    var root = nativeAttachShadow.apply(this, arguments);
+                    observeRoot(root);
+                    return root;
+                };
+                patchedAttachShadow._wblockNoAutoplayPatched = true;
+                Element.prototype.attachShadow = patchedAttachShadow;
+            }
+        } catch (e) { /* ignore */ }
+
+        // Control channel from the extension controller. DOM events cross
+        // worlds, so the same channel reaches a page-world or isolated-world
+        // gate. The token is random per page load so page scripts cannot
+        // guess the event names ahead of time.
+        try {
+            doc.addEventListener('wblock-no-autoplay-disable-' + token, function () {
+                disabled = true;
+            }, false);
+            doc.addEventListener('wblock-no-autoplay-enable-' + token, function () {
+                disabled = false;
+                scan(doc.documentElement || doc);
+            }, false);
+        } catch (e) { /* ignore */ }
+
+        function boot() {
+            try {
+                doc.addEventListener('pointerdown', unlockFromEvent, true);
+                doc.addEventListener('touchstart', unlockFromEvent, true);
+                doc.addEventListener('click', unlockFromEvent, true);
+                doc.addEventListener('keydown', onKey, true);
+                doc.addEventListener('play', onPlayEvent, true);
+                doc.addEventListener('playing', onPlayEvent, true);
+            } catch (e) { /* ignore */ }
+            if (doc.documentElement) observeRoot(doc.documentElement);
+            else doc.addEventListener('DOMContentLoaded', function () {
+                if (doc.documentElement) observeRoot(doc.documentElement);
+            });
+        }
+
+        boot();
+    }
+
+    // ------------------------------------------------------------------
+    // Controller (isolated world): decides whether the gate is armed.
+    // ------------------------------------------------------------------
+
+    var armed = false;
+    var desired = false;
+    var waitingForRoot = false;
+    var token = null;
+    var reconcileSeq = 0;
+
+    function readHint() {
+        try { return localStorage.getItem(HINT_KEY) === '1'; } catch (e) { return false; }
+    }
+
+    function writeHint(shouldArm) {
+        try {
+            if (shouldArm) localStorage.setItem(HINT_KEY, '1');
+            else localStorage.removeItem(HINT_KEY);
+        } catch (e) { /* ignore */ }
+    }
+
+    function makeToken() {
+        try {
+            var bytes = new Uint8Array(16);
+            crypto.getRandomValues(bytes);
+            var out = '';
+            for (var i = 0; i < bytes.length; i++) out += (bytes[i] + 256).toString(16).slice(1);
+            return out;
+        } catch (e) {
+            return String(Date.now()) + '-' + String(Math.random()).slice(2);
+        }
+    }
+
+    function dispatchControl(action) {
+        if (!token) return;
+        try {
+            document.dispatchEvent(new Event('wblock-no-autoplay-' + action + '-' + token));
+        } catch (e) { /* ignore */ }
+    }
+
+    // Best-effort CSP nonce detection, same approach as the userscript injector.
+    function getCspNonce() {
+        try {
+            var el = document.querySelector('script[nonce]');
+            var nonce = el ? (el.nonce || el.getAttribute('nonce') || '') : '';
+            return nonce || '';
+        } catch (e) {
+            return '';
+        }
+    }
+
+    function injectPageGate(gateToken) {
+        try {
+            var parent = document.head || document.documentElement;
+            if (!parent) return false;
+            var el = document.createElement('script');
+            el.textContent = '(' + noAutoplayGate.toString() + ')(' + JSON.stringify(gateToken) + ');';
+            el.setAttribute('type', 'text/javascript');
+            var nonce = getCspNonce();
+            if (nonce) el.nonce = nonce;
+            parent.appendChild(el);
+            el.remove();
+            // Inline scripts execute synchronously on append; the gate marks
+            // the document element, so a missing marker means the page's CSP
+            // blocked execution.
+            return !!(document.documentElement
+                && document.documentElement.getAttribute('data-wblock-no-autoplay-gate') === '1');
+        } catch (e) {
+            return false;
+        }
+    }
+
+    function armNow() {
+        if (armed) {
+            dispatchControl('enable');
+            return;
+        }
+        token = makeToken();
+        if (!injectPageGate(token)) {
+            // Strict CSP: run the gate in this world instead. The play() and
+            // autoplay patches then only cover this world, but attribute
+            // stripping, pause-on-play, and unlock tracking act on the shared
+            // DOM, so autoplay is still suppressed.
+            noAutoplayGate(token);
+        }
+        armed = true;
+    }
+
+    function ensureArmed() {
+        if (armed) {
+            dispatchControl('enable');
+            return;
+        }
+        if (document.head || document.documentElement) {
+            armNow();
+            return;
+        }
+        // document_start can run before the document element exists. Nothing
+        // page-visible has executed yet at that point, so arming at the
+        // earliest childList mutation still lands the gate before any page
+        // script runs (the parser reaches a microtask checkpoint before it
+        // executes a script).
+        if (waitingForRoot) return;
+        waitingForRoot = true;
+        try {
+            var rootObserver = new MutationObserver(function () {
+                if (!document.documentElement) return;
+                rootObserver.disconnect();
+                waitingForRoot = false;
+                if (desired && !armed) armNow();
+            });
+            rootObserver.observe(document, { childList: true });
+        } catch (e) {
+            waitingForRoot = false;
+            armNow();
+        }
+    }
+
+    function standDown() {
+        if (armed) dispatchControl('disable');
+    }
+
+    function withTimeout(promise, ms) {
+        return new Promise(function (resolve, reject) {
+            var timer = setTimeout(function () { reject(new Error('timeout')); }, ms);
+            Promise.resolve(promise).then(
+                function (value) { clearTimeout(timer); resolve(value); },
+                function (error) { clearTimeout(timer); reject(error); }
+            );
+        });
+    }
+
+    function getSiteDisabled(host) {
+        return withTimeout(
+            browser.runtime.sendNativeMessage('application.id', { action: 'getSiteDisabledState', host: host }),
+            NATIVE_MESSAGE_TIMEOUT_MS
+        ).then(function (response) {
+            return !!(response && response.disabled);
+        }).catch(function () {
+            return false;
+        });
+    }
+
+    async function computeShouldArm() {
+        var host = location.hostname;
+        if (!host) return false;
+        var allowKey = ALLOW_PREFIX + host;
+        var stored = await browser.storage.local.get([ENABLED_KEY, allowKey]);
+        if (!stored || stored[ENABLED_KEY] !== true) return false;
+        if (stored[allowKey] === true) return false;
+        if (await getSiteDisabled(host)) return false;
+        return true;
+    }
+
+    async function reconcile() {
+        var seq = ++reconcileSeq;
+        var shouldArm = false;
+        try {
+            shouldArm = await computeShouldArm();
+        } catch (e) {
+            shouldArm = false;
+        }
+        if (seq !== reconcileSeq) return; // superseded by a newer reconcile
+        writeHint(shouldArm);
+        desired = shouldArm;
+        if (shouldArm) ensureArmed();
+        else standDown();
+    }
+
+    // Synchronous path: arm before page scripts run when the last
+    // authoritative decision for this origin was "armed".
+    if (readHint()) {
+        desired = true;
+        ensureArmed();
+    }
+
+    // Authoritative path: extension storage plus the native disabled-sites
+    // state. Corrects the hint in both directions.
+    reconcile();
+
+    // Live updates when the popup changes the global or per-site setting.
+    try {
+        browser.storage.onChanged.addListener(function (changes, area) {
+            if (area !== 'local') return;
+            if ((ENABLED_KEY in changes) || ((ALLOW_PREFIX + location.hostname) in changes)) {
+                reconcile();
+            }
+        });
+    } catch (e) { /* ignore */ }
+})();

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.html
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.html
@@ -71,6 +71,26 @@
             <div id="zapper-rules" class="rules" hidden></div>
         </div>
 
+        <div class="section">
+            <div class="row">
+                <div id="no-autoplay-title" class="label" data-i18n="popup_no_autoplay">No Autoplay</div>
+                <div class="row-trailing">
+                    <label class="switch" for="no-autoplay-enabled-toggle">
+                        <input id="no-autoplay-enabled-toggle" type="checkbox" aria-labelledby="no-autoplay-title" />
+                        <span class="slider" aria-hidden="true"></span>
+                    </label>
+                </div>
+            </div>
+            <label id="no-autoplay-site-row" class="toggle-row" for="no-autoplay-site-toggle" hidden>
+                <span class="label" data-i18n="popup_no_autoplay_allow_site">Allow autoplay on this site</span>
+                <span class="switch">
+                    <input id="no-autoplay-site-toggle" type="checkbox" />
+                    <span class="slider" aria-hidden="true"></span>
+                </span>
+            </label>
+            <div class="hint" data-i18n="popup_no_autoplay_hint">Media stays paused until you tap or click it.</div>
+        </div>
+
         <div id="userscript-commands" class="section" hidden></div>
 
         <div class="popup-actions">

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.js
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.js
@@ -1,6 +1,8 @@
 const NATIVE_HOST_ID = 'application.id';
 const ZAPPER_STORAGE_PREFIX = 'wblock.zapperRules.v1:';
 const ZAPPER_META_PREFIX = 'wblock.zapperMeta.v1:';
+const NO_AUTOPLAY_ENABLED_KEY = 'wblock.noAutoplay.enabled.v1';
+const NO_AUTOPLAY_ALLOW_PREFIX = 'wblock.noAutoplayAllow.v1:';
 const SUPPORT_PROBE_TIMEOUT_MS = 1200;
 const SUPPORT_PROBE_ATTEMPTS = 5;
 const SUPPORT_PROBE_RETRY_DELAY_MS = 200;
@@ -956,6 +958,55 @@ async function invokeUserscriptCommand(tabId, frameId, bridgeId, commandId) {
     }
 }
 
+let noAutoplaySiteDisabled = false;
+
+function noAutoplayAllowKey(siteHost) {
+    return `${NO_AUTOPLAY_ALLOW_PREFIX}${siteHost}`;
+}
+
+async function getNoAutoplayState(siteHost) {
+    const keys = [NO_AUTOPLAY_ENABLED_KEY];
+    if (siteHost) keys.push(noAutoplayAllowKey(siteHost));
+    try {
+        const result = await browser.storage.local.get(keys);
+        return {
+            enabled: result[NO_AUTOPLAY_ENABLED_KEY] === true,
+            siteAllowed: siteHost ? result[noAutoplayAllowKey(siteHost)] === true : false,
+        };
+    } catch {
+        return { enabled: false, siteAllowed: false };
+    }
+}
+
+async function setNoAutoplayEnabled(enabled) {
+    await browser.storage.local.set({ [NO_AUTOPLAY_ENABLED_KEY]: enabled === true });
+}
+
+async function setNoAutoplaySiteAllowed(siteHost, allowed) {
+    if (!siteHost) return;
+    if (allowed === true) {
+        await browser.storage.local.set({ [noAutoplayAllowKey(siteHost)]: true });
+    } else {
+        await browser.storage.local.remove(noAutoplayAllowKey(siteHost));
+    }
+}
+
+function updateNoAutoplayControls(state, options = {}) {
+    const enabledToggle = document.getElementById('no-autoplay-enabled-toggle');
+    const siteRow = document.getElementById('no-autoplay-site-row');
+    const siteToggle = document.getElementById('no-autoplay-site-toggle');
+    const locked = options.locked === true;
+    if (enabledToggle) {
+        enabledToggle.checked = state.enabled;
+        enabledToggle.disabled = locked;
+    }
+    if (siteRow) siteRow.hidden = !state.enabled || !options.host;
+    if (siteToggle) {
+        siteToggle.checked = state.siteAllowed;
+        siteToggle.disabled = locked || options.siteDisabled === true;
+    }
+}
+
 function setupListeners() {
     const rulesToggle = document.getElementById('zapper-rules-toggle');
     const rulesContainer = document.getElementById('zapper-rules');
@@ -1075,6 +1126,45 @@ function setupListeners() {
                 zapperEnabledToggle.checked = !nextEnabled;
             } finally {
                 zapperEnabledToggle.disabled = false;
+            }
+        });
+    }
+
+    const noAutoplayEnabledToggle = document.getElementById('no-autoplay-enabled-toggle');
+    const noAutoplaySiteToggle = document.getElementById('no-autoplay-site-toggle');
+
+    if (noAutoplayEnabledToggle) {
+        noAutoplayEnabledToggle.addEventListener('change', async () => {
+            const nextEnabled = noAutoplayEnabledToggle.checked;
+            try {
+                setError('');
+                noAutoplayEnabledToggle.disabled = true;
+                await setNoAutoplayEnabled(nextEnabled);
+                const state = await getNoAutoplayState(host);
+                updateNoAutoplayControls(state, { host, siteDisabled: noAutoplaySiteDisabled });
+            } catch (error) {
+                console.error('[wBlock] Failed to update No Autoplay state:', error);
+                setError(t('popup_error_update_site_setting', undefined, 'Failed to update site setting.'));
+                noAutoplayEnabledToggle.checked = !nextEnabled;
+            } finally {
+                noAutoplayEnabledToggle.disabled = false;
+            }
+        });
+    }
+
+    if (noAutoplaySiteToggle) {
+        noAutoplaySiteToggle.addEventListener('change', async () => {
+            const nextAllowed = noAutoplaySiteToggle.checked;
+            try {
+                setError('');
+                noAutoplaySiteToggle.disabled = true;
+                await setNoAutoplaySiteAllowed(host, nextAllowed);
+            } catch (error) {
+                console.error('[wBlock] Failed to update No Autoplay site setting:', error);
+                setError(t('popup_error_update_site_setting', undefined, 'Failed to update site setting.'));
+                noAutoplaySiteToggle.checked = !nextAllowed;
+            } finally {
+                noAutoplaySiteToggle.disabled = noAutoplaySiteDisabled;
             }
         });
     }
@@ -1286,6 +1376,7 @@ async function refreshUi() {
         });
         await updateZapperCount('');
         setRulesExpanded(false);
+        updateNoAutoplayControls(await getNoAutoplayState(''), { host: '', locked: true });
         return;
     }
 
@@ -1301,14 +1392,16 @@ async function refreshUi() {
     const contentScriptReachablePromise = probeTabSupport(tab.id);
     const zapperStatePromise = getAuthoritativeZapperState(host);
     const zapperCountPromise = updateZapperCount(host);
+    const noAutoplayStatePromise = getNoAutoplayState(host);
 
     setStatus(t('popup_status_checking', undefined, 'Checking…'), 'neutral');
 
-    const [pauseState, disabled, zapperState, contentScriptReachable] = await Promise.all([
+    const [pauseState, disabled, zapperState, contentScriptReachable, noAutoplayState] = await Promise.all([
         blockingPausedPromise,
         disabledPromise,
         zapperStatePromise,
         contentScriptReachablePromise,
+        noAutoplayStatePromise,
     ]);
     if (pauseState === null) {
         setStatus(t('popup_status_error', undefined, 'Error'), 'disabled');
@@ -1319,6 +1412,7 @@ async function refreshUi() {
         if (resumeButton) resumeButton.disabled = true;
         if (pausedPrompt) pausedPrompt.hidden = true;
         if (resumeButton) resumeButton.hidden = true;
+        updateNoAutoplayControls(noAutoplayState, { host, locked: true });
         return;
     }
 
@@ -1358,6 +1452,8 @@ async function refreshUi() {
         zapperEnabledToggle.checked = !zapperRulesDisabled;
         zapperEnabledToggle.disabled = siteDisabled || zapperPaused;
     }
+    noAutoplaySiteDisabled = siteDisabled;
+    updateNoAutoplayControls(noAutoplayState, { host, siteDisabled });
     setStatus(
         blockingPaused && !partiallyPaused
             ? t('popup_status_paused', undefined, 'Paused')

--- a/wBlock.xcodeproj/project.pbxproj
+++ b/wBlock.xcodeproj/project.pbxproj
@@ -364,6 +364,7 @@
 				Resources/background.js,
 				Resources/content.js,
 				Resources/manifest.json,
+				"Resources/no-autoplay.js",
 				Resources/pages,
 				Resources/rules/csp_strip_rules.json,
 				"Resources/userscript-injector.js",


### PR DESCRIPTION
## Summary

Adds **No Autoplay** as a native feature of the wBlock Scripts extension instead of a separate userscript (the userscript variant has been reverted from wBlock-userscripts and its registration branch deleted).

- `no-autoplay.js` content script (shared by the macOS and iOS Scripts targets) injects a page-world gate at `document_start` that patches `HTMLMediaElement.prototype.play` and the `autoplay` attribute/property so media stays paused until the user taps, clicks, or key-activates it (or the single-media player around it).
- Under a strict CSP that blocks inline scripts, the same gate runs in the isolated world, where DOM-level enforcement (autoplay stripping, pause-on-play, unlock tracking via a shared data attribute) still applies.
- Arming state: a page-`localStorage` hint re-arms repeat visits synchronously before first paint (same trust model as the userscript injector warm-start cache); `browser.storage.local` plus the native `getSiteDisabledState` remain authoritative and correct the hint in both directions, live via `storage.onChanged`.
- If the content script runs before `document.documentElement` exists, arming defers to the earliest childList mutation, which still lands before any page script executes (found via real-WebKit testing).
- Popup: new No Autoplay section with a global toggle and a per-site 'Allow autoplay on this site' override; strings added to all 17 locales. The per-site toggle is disabled when wBlock is disabled on the site, and the gate also stands down there.

## Testing

- `scripts/test_no_autoplay.mjs` (new, plus a `.sh` wrapper so `run-ci-tests.sh` picks it up): 45 behavioral checks running the shipped script in a vm sandbox — synchronous warm-hint arming, play() rejection and gesture unlocks, boot-scan/mutation disarming, per-site allow, site-disabled stand-down, live storage re-arm/disarm, CSP fallback, deferred-root arming, hostless frames.
- Verified in real WebKit via Playwright (ad hoc): gate arms at document-start, strips markup autoplay, rejects locked `play()`, unlocks via direct click / player button, gates late-inserted media, per-site allow and global-off leave playback untouched.
- Existing related tests pass: popup enable-site/filter-update/resume contracts, content scriptlet injection, userscript bridge auth, blocking pause guardrails.
- `xcodebuild` Release builds for macOS and iOS Simulator succeed and both Scripts appexes bundle `no-autoplay.js`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 48e76825fd560fe3daa47d9c67cf90f89e16a2c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->