### PR TITLE
Add badge for Open-Source iOS Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 
 [![Join Discord](https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white)](https://discord.gg/Y3yTFPpbXr)
 
+[![Mentioned in Open-Source iOS Apps](https://awesome.re/mentioned-badge.svg)](https://github.com/dkhamsing/open-source-ios-apps)
 </div>
 
 <br>


### PR DESCRIPTION
wBlock got added to [dkhamsing/open-source-ios-apps](https://github.com/dkhamsing/open-source-ios-apps) so you can have this badge and perhaps it will help people find more amazing open-source apps. 