### PR TITLE
Shield combined engine publish from suspension (0xDEAD10CC)

### DIFF
--- a/scripts/test_engine_publish_suspension_shield.swift
+++ b/scripts/test_engine_publish_suspension_shield.swift
@@ -1,0 +1,44 @@
+#!/usr/bin/env swift
+
+import Foundation
+
+func require(_ condition: Bool, _ message: String) {
+    guard condition else { fputs("FAIL: \(message)\n", stderr); exit(1) }
+}
+
+let service = try String(contentsOfFile: "wBlockCoreService/wBlockCoreService.swift", encoding: .utf8)
+
+func position(of needle: String) -> String.Index {
+    guard let range = service.range(of: needle) else {
+        fputs("FAIL: missing \(needle)\n", stderr)
+        exit(1)
+    }
+    return range.lowerBound
+}
+
+// The combined-engine publish holds exclusive kernel flocks on app group files
+// for the entire rebuild. iOS kills any app that suspends while holding a file
+// lock in a shared container (0xDEAD10CC), so every publish - including the
+// manual apply pipeline, which has no auto-update suspension shield - must
+// defer suspension while the locks are held and unwind (releasing the locks)
+// when suspension becomes imminent.
+require(service.contains("EnginePublishSuspensionShield"),
+        "the engine publish needs a suspension shield")
+require(service.contains("performExpiringActivity"),
+        "the shield must hold an expiring-activity assertion while locks are held")
+require(service.contains("case suspensionImminent"),
+        "imminent suspension must abort the publish via a dedicated internal error")
+require(service.contains("throw CombinedEnginePublishError.suspensionImminent"),
+        "the suspension checkpoint must throw so lock scopes unwind")
+
+let publishStart = position(of: "public static func publishCombinedFilterEngine")
+let shieldCreation = position(of: "let shield = EnginePublishSuspensionShield")
+let buildLock = position(of: "try withCombinedEngineBuildLock(at: baseURL)")
+require(publishStart < shieldCreation && shieldCreation < buildLock,
+        "the shield must be installed before the build lock is acquired")
+require(service.contains("defer { shield.release() }"),
+        "the assertion must lapse when the publish unwinds")
+require(service.components(separatedBy: "try ensureNotSuspending()").count == 4,
+        "the publish must observe imminent suspension before the skip check, the rebuild, and the commit")
+
+print("PASS: combined engine publish suspension shield contract")

--- a/wBlockCoreService/wBlockCoreService.swift
+++ b/wBlockCoreService/wBlockCoreService.swift
@@ -92,7 +92,52 @@ public struct ContentBlockerSaveResult: Sendable {
 
     private enum CombinedEnginePublishError: Error {
         case supersededRequest
+        case suspensionImminent
     }
+
+    #if os(iOS)
+    /// Defers app suspension while a combined-engine publish holds kernel file
+    /// locks in the app group container. iOS kills any app that suspends while
+    /// holding a file lock in a shared container (0xDEAD10CC). If the system
+    /// decides to suspend anyway, the expiration callback flips a flag that the
+    /// publish checkpoints observe to unwind and release the locks first.
+    private final class EnginePublishSuspensionShield: @unchecked Sendable {
+        private let completion = DispatchSemaphore(value: 0)
+        private let stateLock = NSLock()
+        private var expired = false
+
+        init(reason: String) {
+            let completion = completion
+            ProcessInfo.processInfo.performExpiringActivity(withReason: reason) { [weak self] isExpired in
+                if isExpired {
+                    // Runs when suspension is imminent: immediately when no
+                    // background time is available, otherwise concurrently
+                    // with the blocked non-expired invocation below.
+                    self?.markExpired()
+                } else {
+                    // The assertion holds for as long as this invocation blocks.
+                    completion.wait()
+                }
+            }
+        }
+
+        var isExpired: Bool {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return expired
+        }
+
+        private func markExpired() {
+            stateLock.lock()
+            expired = true
+            stateLock.unlock()
+        }
+
+        func release() {
+            completion.signal()
+        }
+    }
+    #endif
 
     /// Built-in compatibility rules that improve blocking of common dynamic ad script
     /// patterns and dynamic ad containers across filter sets.
@@ -1603,8 +1648,25 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adSlots', 'undefin
         let rulesData = Data(combinedAdvancedRules.utf8)
         let fingerprint = combinedEngineFingerprint(rulesData: rulesData, safariVersion: safariVersion)
 
+        #if os(iOS)
+        // The section below holds exclusive kernel flocks on app group files for
+        // the entire rebuild. Defer suspension while they are held and unwind
+        // (releasing the locks) when suspension becomes imminent (0xDEAD10CC).
+        let shield = EnginePublishSuspensionShield(reason: "wBlock combined engine publish")
+        defer { shield.release() }
+        let ensureNotSuspending: () throws -> Void = {
+            if shield.isExpired {
+                os_log(.info, "Abandoning combined filter engine publish before suspension")
+                throw CombinedEnginePublishError.suspensionImminent
+            }
+        }
+        #else
+        let ensureNotSuspending: () throws -> Void = {}
+        #endif
+
         try measure(label: combinedAdvancedRules.isEmpty ? "Clearing filter engine" : "Building combined filter engine") {
             try withCombinedEngineBuildLock(at: baseURL) {
+                try ensureNotSuspending()
                 let skipped = try withEngineCriticalSection(at: baseURL) {
                     try withCombinedEngineRequestLock(at: baseURL) {
                         try ensureCombinedEngineRequestIsCurrent(at: baseURL, requestToken: requestToken)
@@ -1616,6 +1678,7 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adSlots', 'undefin
                     return
                 }
 
+                try ensureNotSuspending()
                 let temporaryBuild = try buildTemporaryEngine(
                     rulesData: rulesData,
                     safariVersion: safariVersion,
@@ -1625,6 +1688,7 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adSlots', 'undefin
 
                 let published = try withEngineCriticalSection(at: baseURL) {
                     try withCombinedEngineRequestLock(at: baseURL) {
+                        try ensureNotSuspending()
                         try ensureCombinedEngineRequestIsCurrent(at: baseURL, requestToken: requestToken)
                         if canSkipCombinedEnginePublish(fingerprint: fingerprint, baseURL: baseURL) {
                             return false


### PR DESCRIPTION
## Summary

Fixes a RunningBoard `0xDEAD10CC` kill seen on iOS 27.0 (build 865, TestFlight): iOS terminates any app that gets suspended while holding a file lock in a shared container.

`ContentBlockerService.publishCombinedFilterEngine` holds exclusive kernel `flock`s (build lock, engine file lock, request lock) on app group files for the entire engine rebuild. The auto-update path already wraps its runs in a `performExpiringActivity` suspension shield, but the manual apply pipeline, `clearAllExtensionsAndEngine`, and the onboarding reset call the publish directly with no suspension protection. Backgrounding the app mid-apply left the locks held at suspension, and the crash log shows exactly that: a utility-QoS thread mid-JSON-parse when RunningBoard killed the process.

## Changes

- Install an expiring-activity suspension shield inside `publishCombinedFilterEngine` itself (iOS only), so every caller is covered.
- When the assertion expires (suspension imminent), a flag is set and checkpoints before the skip check, the rebuild, and the commit throw `CombinedEnginePublishError.suspensionImminent`, unwinding the lock scopes so the flocks are released before suspension instead of the process being killed.
- Add `scripts/test_engine_publish_suspension_shield.swift` source-contract test enforcing the shield, its placement before the build lock, and all three checkpoints.

## Testing

- `swift scripts/test_engine_publish_suspension_shield.swift` passes
- `swift scripts/test_combined_engine_publish.swift` and `swift scripts/test_shared_auto_update_repairs.swift` still pass, along with the rest of the plain source-contract scripts
- `xcodebuild -scheme wBlockCoreService` builds for both `generic/platform=iOS` and `generic/platform=macOS`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit efa760aa5dc953075579bb80dc8a3125670e53e2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->