### PR TITLE
Polish Scripts popup status and card edges

### DIFF
--- a/scripts/test_popup_native_layout_contract.mjs
+++ b/scripts/test_popup_native_layout_contract.mjs
@@ -80,8 +80,8 @@ if (sticky.get("background") !== "Canvas") {
 }
 
 const section = declarationsFor(".section");
-if (section.get("box-shadow") !== "0 0 0 0.5px var(--separator)") {
-  fail("grouped rows must keep a hairline so they still read on the sheet");
+if (section.get("border") !== "0.5px solid var(--separator)") {
+  fail("grouped rows need a hairline border; a 0.5px shadow spread drops the top edge in Safari");
 }
 
 if (!js.includes("if (popup) popup.scrollTop = 0")) {

--- a/scripts/test_popup_native_layout_contract.mjs
+++ b/scripts/test_popup_native_layout_contract.mjs
@@ -78,6 +78,9 @@ if (sticky.get("position") !== "sticky" || sticky.get("top") !== "0") {
 if (sticky.get("background") !== "Canvas") {
   fail("sticky header must stay opaque on the sheet while scrolling");
 }
+if (sticky.get("margin") !== "-10px -12px 16px") {
+  fail("sections must sit below the header so the first card keeps its top edge");
+}
 
 const section = declarationsFor(".section");
 if (section.get("border") !== "0.5px solid var(--separator)") {

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.css
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.css
@@ -67,7 +67,7 @@ body {
   position: sticky;
   top: 0;
   z-index: 3;
-  margin: -10px -12px 8px;
+  margin: -10px -12px 16px;
   padding: 10px 12px 8px;
   background: Canvas;
 }

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.css
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.css
@@ -127,29 +127,35 @@ body {
 }
 
 .pill {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 12px;
+  font-weight: 650;
   letter-spacing: -0.08px;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  color: var(--subtext);
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--separator);
+  background: var(--fill);
+  color: var(--text);
   white-space: nowrap;
 }
 
 .pill.is-active {
-  color: var(--accent);
+  background: rgba(52, 199, 89, 0.22);
+  border-color: rgba(52, 199, 89, 0.45);
 }
 
 .pill.is-disabled {
-  color: var(--subtext);
+  background: rgba(142, 142, 147, 0.22);
+  border-color: rgba(142, 142, 147, 0.5);
 }
 
 .pill.is-neutral {
-  color: var(--subtext);
+  background: var(--fill);
+  border-color: var(--separator);
 }
 
 .pill.is-error {
+  background: var(--danger-soft);
+  border-color: var(--danger);
   color: var(--danger);
 }
 

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.css
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.css
@@ -164,7 +164,7 @@ body {
   border-radius: 10px;
   margin-bottom: 8px;
   overflow: hidden;
-  box-shadow: 0 0 0 0.5px var(--separator);
+  border: 0.5px solid var(--separator);
 }
 
 .section > * + * {


### PR DESCRIPTION
After the native sheet redo, Active flattened into plain text and the first grouped card lost its top edge on macOS. This puts the capsule status back, draws the cards with a real hairline border instead of a 0.5px shadow, and drops the sections a bit so they sit clear of the sticky header.

Checked with the popup layout, scroll, and no-autoplay contracts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cbfb668316077861105de746a66251c4e98b7ba3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->