### PR TITLE
Fix Scripts popup header overlap and Autoplay edge

### DIFF
--- a/scripts/test_popup_native_layout_contract.mjs
+++ b/scripts/test_popup_native_layout_contract.mjs
@@ -62,23 +62,26 @@ if (checked.get("background") !== "var(--accent)") {
   fail("on-state toggles must use the blue accent, not a custom track color");
 }
 
-if (!html.includes('class="popup-sticky"') || html.indexOf('id="error"') > html.indexOf('class="section"')) {
-  fail("errors must sit in the sticky header, above the first section");
+if (!html.includes('class="popup-sticky"') || !html.includes('class="popup-body"') || html.indexOf('id="error"') > html.indexOf('class="section"')) {
+  fail("errors must sit in the pinned header, above the first section");
 }
 
 const popup = declarationsFor(".popup");
 if (popup.get("background") !== "transparent") {
   fail("popup must sit on Safari's sheet instead of painting a grouped well");
 }
+if (popup.get("display") !== "flex" || popup.get("flex-direction") !== "column") {
+  fail("popup must pin the header in a flex column so cards cannot paint through it");
+}
+if (popup.get("overflow") !== "hidden") {
+  fail("popup must not scroll the header over the first card");
+}
 
-const sticky = declarationsFor(".popup-sticky");
-if (sticky.get("position") !== "sticky" || sticky.get("top") !== "0") {
-  fail("status and errors must stay pinned while the popup scrolls");
+const body = declarationsFor(".popup-body");
+if (body.get("overflow-y") !== "auto") {
+  fail("cards must scroll under a pinned header");
 }
-if (sticky.get("background") !== "Canvas") {
-  fail("sticky header must stay opaque on the sheet while scrolling");
-}
-if (sticky.get("margin") !== "-10px -12px 16px") {
+if (body.get("padding") !== "16px 12px 12px") {
   fail("sections must sit below the header so the first card keeps its top edge");
 }
 
@@ -87,8 +90,8 @@ if (section.get("border") !== "0.5px solid var(--separator)") {
   fail("grouped rows need a hairline border; a 0.5px shadow spread drops the top edge in Safari");
 }
 
-if (!js.includes("if (popup) popup.scrollTop = 0")) {
-  fail("setError must jump back to the sticky banner");
+if (!js.includes("querySelector('.popup-body')") || !js.includes("popupBody.scrollTop = 0")) {
+  fail("setError must jump back to the pinned banner");
 }
 
 if (!js.includes("kind === 'error'") || !js.includes("popup_status_error")) {

--- a/scripts/test_popup_no_autoplay_contract.mjs
+++ b/scripts/test_popup_no_autoplay_contract.mjs
@@ -56,6 +56,12 @@ if (hidden.get("display") !== "none !important") {
   fail("[hidden] must force display:none so iOS cannot show flex toggle rows");
 }
 
+const autoplaySection = declarationsFor("#no-autoplay-section");
+const sectionTop = Number.parseInt(autoplaySection.get("margin-top") || "", 10);
+if (!Number.isFinite(sectionTop) || sectionTop < 8) {
+  fail("#no-autoplay-section must sit below the zapper hint so its top edge renders");
+}
+
 const siteRow = declarationsFor("#no-autoplay-site-row");
 const marginTop = Number.parseInt(siteRow.get("margin-top") || "", 10);
 if (!Number.isFinite(marginTop) || marginTop < 8) {

--- a/scripts/test_popup_scroll_contract.mjs
+++ b/scripts/test_popup_scroll_contract.mjs
@@ -50,14 +50,22 @@ if (rootRule.get("background") !== "Canvas") {
 }
 
 const popup = declarationsFor(".popup");
-if (popup.get("overflow-y") !== "auto") {
-  fail(".popup must scroll vertically when runtime content exceeds the menu height");
+if (popup.get("overflow") !== "hidden") {
+  fail(".popup must keep the header pinned instead of scrolling it over the cards");
 }
 if (popup.get("max-height") !== "600px") {
   fail(".popup must be capped below Safari's popover clipping height");
 }
 if (popup.get("min-height") !== "0") {
   fail(".popup must be allowed to shrink before it can scroll");
+}
+
+const body = declarationsFor(".popup-body");
+if (body.get("overflow-y") !== "auto") {
+  fail(".popup-body must scroll vertically when runtime content exceeds the menu height");
+}
+if (body.get("min-height") !== "0") {
+  fail(".popup-body must be allowed to shrink before it can scroll");
 }
 
 const rules = declarationsFor(".rules");

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.css
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.css
@@ -198,6 +198,10 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+#no-autoplay-section {
+  margin-top: 8px;
+}
+
 #no-autoplay-site-row {
   margin-top: 8px;
 }

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.css
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.css
@@ -52,24 +52,32 @@ body {
 }
 
 .popup {
+  display: flex;
+  flex-direction: column;
   width: 100%;
   max-width: 380px;
   max-height: 600px;
   min-height: 0;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  padding: 10px 12px 12px;
+  overflow: hidden;
+  padding: 0;
   box-sizing: border-box;
   background: transparent;
 }
 
 .popup-sticky {
-  position: sticky;
-  top: 0;
+  flex: 0 0 auto;
   z-index: 3;
-  margin: -10px -12px 16px;
   padding: 10px 12px 8px;
-  background: Canvas;
+  background: transparent;
+}
+
+.popup-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 16px 12px 12px;
+  box-sizing: border-box;
 }
 
 .top {
@@ -323,7 +331,7 @@ body {
   padding: 2px 0 0;
 }
 
-.popup > .hint {
+.popup-body > .hint {
   padding: 6px 16px 12px;
   margin-top: -2px;
 }

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.html
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.html
@@ -24,6 +24,7 @@
             <div id="error" class="error" role="alert" hidden></div>
         </div>
 
+        <div class="popup-body">
         <div class="section">
             <label class="toggle-row" for="enable-toggle">
                 <span class="label" data-i18n="popup_enable_on_site">Enable on this site</span>
@@ -103,6 +104,7 @@
         </div>
 
         <footer class="footer"></footer>
+        </div>
     </div>
 </body>
 </html>

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.html
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.html
@@ -72,7 +72,7 @@
         </div>
         <div class="hint" data-i18n="popup_hint_tap_to_hide">Tap an element on the page to hide it. Use "Add Rule" in the zapper for manual selectors.</div>
 
-        <div class="section">
+        <div id="no-autoplay-section" class="section">
             <div class="row">
                 <div id="no-autoplay-title" class="label" data-i18n="popup_no_autoplay">No Autoplay</div>
                 <div class="row-trailing">

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.js
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.js
@@ -287,8 +287,8 @@ function setError(message) {
     }
     el.hidden = false;
     el.textContent = message;
-    const popup = document.querySelector('.popup');
-    if (popup) popup.scrollTop = 0;
+    const popupBody = document.querySelector('.popup-body');
+    if (popupBody) popupBody.scrollTop = 0;
 }
 
 function setStatus(text, kind = 'neutral') {


### PR DESCRIPTION
Safari was treating the sticky hostname row as an overlay, so Enable on this site showed through it. The header now sits outside the scrolling pane. No Autoplay also moves down a bit so its top edge renders, same as Enable.

Checked with the popup layout, scroll, and no-autoplay contracts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Safari extension popup HTML/CSS/JS only; behavior is guarded by existing layout contract tests with no auth or data-path changes.
> 
> **Overview**
> Fixes Safari iOS treating the hostname/status **sticky** row as an overlay so **Enable on this site** showed through the header. The popup now uses a **flex column**: `.popup-sticky` stays fixed (no `position: sticky` / opaque header fill), `.popup` uses `overflow: hidden`, and a new **`.popup-body`** holds the cards and scrolls (`overflow-y: auto`).
> 
> **`setError`** resets scroll on `.popup-body` so errors in the pinned header stay visible. The **No Autoplay** block gets `id="no-autoplay-section"` and **`margin-top: 8px`** so its top edge clears the zapper hint; the bottom hint selector moves to `.popup-body > .hint`.
> 
> Layout, scroll, and no-autoplay **contract scripts** are updated for the pinned-header model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5ccaa7f1b6b0dd838048ef3dcc3d78686661718. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->