### PR TITLE
Fix 2.2.0 to 3.0.0 upgrade leftovers

### DIFF
--- a/scripts/test_builtin_userscripts.swift
+++ b/scripts/test_builtin_userscripts.swift
@@ -39,6 +39,18 @@ guard !definitionsBlock.contains("YouTube Classic")
     exit(1)
 }
 
+guard !source.contains("urlString.contains(\"adamlui/youtube-classic\")")
+    && !source.contains("absoluteString.contains(\"adamlui/youtube-classic\")") else {
+    fputs("FAIL: isRetiredYouTubeClassicScript must not match adamlui/youtube-classic on full absoluteString\n", stderr)
+    exit(1)
+}
+
+guard source.contains("isRetiredYouTubeClassicScript")
+    && source.contains("url.path") else {
+    fputs("FAIL: isRetiredYouTubeClassicScript must use URL path-based matching\n", stderr)
+    exit(1)
+}
+
 guard source.contains("name: \"tinyShield\"") else {
     fputs("FAIL: tinyShield built-in userscript definition is missing\n", stderr)
     exit(1)
@@ -64,6 +76,14 @@ guard !source.contains("tinyShieldGroupedDefinition")
 guard source.contains("anyLegacyEnabled")
     && source.contains("userScripts[retainedIndex].isEnabled = userScripts[retainedIndex].isEnabled || anyLegacyEnabled") else {
     fputs("FAIL: tinyShield migration must preserve blocking when any regional variant was enabled\n", stderr)
+    exit(1)
+}
+
+guard source.contains("if fullIndex == nil")
+    && source.contains("userScripts[retainedIndex].content = \"\"")
+    && source.contains("userScripts[retainedIndex].resourceContents = [:]")
+    && source.contains("await downloadMissingDefaultScripts()") else {
+    fputs("FAIL: tinyShield in-place migration must clear regional content and download canonical script\n", stderr)
     exit(1)
 }
 

--- a/scripts/test_builtin_userscripts.swift
+++ b/scripts/test_builtin_userscripts.swift
@@ -61,6 +61,12 @@ guard !source.contains("tinyShieldGroupedDefinition")
     exit(1)
 }
 
+guard source.contains("anyLegacyEnabled")
+    && source.contains("userScripts[retainedIndex].isEnabled = userScripts[retainedIndex].isEnabled || anyLegacyEnabled") else {
+    fputs("FAIL: tinyShield migration must preserve blocking when any regional variant was enabled\n", stderr)
+    exit(1)
+}
+
 guard source.contains("name: \"Bypass Paywalls Clean\"")
     && source.contains("languages: [\"en\"]")
     && source.contains("func builtInLanguages(for userScript: UserScript)")

--- a/scripts/test_builtin_userscripts.swift
+++ b/scripts/test_builtin_userscripts.swift
@@ -14,7 +14,27 @@ guard !source.contains("name: \"YouTube Ad Blocking\"")
     exit(1)
 }
 
-guard !source.contains("adamlui/youtube-classic") else {
+guard let definitionsStart = source.range(of: "static let definitions: [BuiltInUserScriptDefinition] = [") else {
+    fputs("FAIL: BuiltInUserScripts.definitions block not found\n", stderr)
+    exit(1)
+}
+var definitionsIndex = definitionsStart.upperBound
+var definitionsDepth = 1
+while definitionsIndex < source.endIndex && definitionsDepth > 0 {
+    let character = source[definitionsIndex]
+    if character == "[" { definitionsDepth += 1 }
+    else if character == "]" { definitionsDepth -= 1 }
+    definitionsIndex = source.index(after: definitionsIndex)
+}
+let definitionsBlock = String(source[definitionsStart.lowerBound..<definitionsIndex])
+let sourceOutsideDefinitions = source.replacingOccurrences(of: definitionsBlock, with: "")
+
+guard !definitionsBlock.contains("YouTube Classic")
+    && !definitionsBlock.contains("adamlui/youtube-classic")
+    && source.contains("retiredYouTubeClassicURL")
+    && source.contains("removeRetiredYouTubeAdBlockIfNeeded()")
+    && (source.contains("isRetiredYouTubeClassicScript")
+        || sourceOutsideDefinitions.contains("adamlui/youtube-classic")) else {
     fputs("FAIL: retired YouTube Classic userscript should not be offered as a built-in\n", stderr)
     exit(1)
 }

--- a/scripts/test_cloud_sync_conflict_safety_contract.swift
+++ b/scripts/test_cloud_sync_conflict_safety_contract.swift
@@ -19,4 +19,25 @@ expect(cloud.contains("origin: .remoteSync"), "Cloud userscript mutations must i
 expect(!cloud.contains("URL(string: remote.url)"), "Cloud userscript restores must canonicalize legacy aliases before lookup and download")
 expect(manager.contains("if origin == .local { recordScriptMutation"), "remote userscript mutations must not advance local revision")
 expect(manager.contains("public func removeUserScript(\n        _ userScript: UserScript,\n        origin:"), "deletions must carry mutation origin")
+
+guard let applyStart = cloud.range(of: "private func applyRemotePayload("),
+      let applyEnd = cloud.range(of: "private func encodedSectionEqual", range: applyStart.upperBound..<cloud.endIndex)
+else {
+    fputs("FAIL: applyRemotePayload not found\n", stderr)
+    exit(1)
+}
+let apply = String(cloud[applyStart.lowerBound..<applyEnd.lowerBound])
+
+func branchesOnOptionalRemote(_ field: String) -> Bool {
+    apply.contains("= payload.\(field)")
+        || apply.contains("payload.\(field) != nil")
+        || apply.contains("payload.\(field) == nil")
+}
+
+expect(branchesOnOptionalRemote("filterDisabledDomains"), "missing optional remote filterDisabledDomains must branch on if let / != nil")
+expect(!apply.contains("payload.filterDisabledDomains ??"), "missing optional remote filterDisabledDomains must not be coalesced to [] before merge")
+expect(branchesOnOptionalRemote("zapperRules"), "missing optional remote zapperRules must branch on if let / != nil")
+expect(!apply.contains("payload.zapperRules ??"), "missing optional remote zapperRules must not be coalesced to [:] before merge")
+expect(branchesOnOptionalRemote("zapperDisabledDomains"), "missing optional remote zapperDisabledDomains must branch on if let / != nil")
+expect(!apply.contains("payload.zapperDisabledDomains ??"), "missing optional remote zapperDisabledDomains must not be coalesced to [] before merge")
 print("PASS")

--- a/scripts/test_upgrade_rebuild_pending.swift
+++ b/scripts/test_upgrade_rebuild_pending.swift
@@ -1,0 +1,55 @@
+#!/usr/bin/env swift
+import Foundation
+
+func check(_ condition: Bool, _ message: String) {
+    guard condition else { fputs("FAIL: \(message)\n", stderr); exit(1) }
+}
+
+let manager = try String(contentsOfFile: "wBlock/AppFilterManager.swift", encoding: .utf8)
+let pipeline = try String(contentsOfFile: "wBlock/AppFilterManager+ApplyPipeline.swift", encoding: .utf8)
+
+for needle in [
+    "lastAppliedUpgradeSignatureKey",
+    "currentUpgradeSignature",
+    "storedUpgradeSignature",
+    "persistUpgradeRebuildSignature",
+    "needsRebuild",
+] {
+    check(manager.contains(needle), "AppFilterManager.swift is missing \(needle)")
+}
+
+check(
+    manager.contains("ContentBlockerService.embeddedCompatibilityRulesVersion"),
+    "AppFilterManager.swift must use ContentBlockerService.embeddedCompatibilityRulesVersion"
+)
+
+check(
+    pipeline.contains("persistUpgradeRebuildSignature"),
+    "ApplyPipeline.swift must call persistUpgradeRebuildSignature"
+)
+
+let markStart = manager.range(of: "func markCurrentStateApplied()")
+check(markStart != nil, "markCurrentStateApplied must exist")
+if let markStart {
+    let afterMark = manager[markStart.lowerBound...]
+    let nextFunc = afterMark.range(of: "\n    private func ", range: afterMark.index(after: markStart.upperBound)..<afterMark.endIndex)
+        ?? afterMark.range(of: "\n    func ", range: afterMark.index(after: markStart.upperBound)..<afterMark.endIndex)
+    let markBody = nextFunc.map { String(afterMark[..<$0.lowerBound]) } ?? String(afterMark)
+    check(
+        !markBody.contains("persistUpgradeRebuildSignature"),
+        "persistUpgradeRebuildSignature must not appear inside markCurrentStateApplied"
+    )
+}
+
+let setupStart = manager.range(of: "func setup()")
+check(setupStart != nil, "setup() must exist")
+if let setupStart {
+    let afterSetup = manager[setupStart.lowerBound...]
+    let nextFunc = afterSetup.range(of: "\n    private func ", range: afterSetup.index(after: setupStart.upperBound)..<afterSetup.endIndex)
+        ?? afterSetup.range(of: "\n    func ", range: afterSetup.index(after: setupStart.upperBound)..<afterSetup.endIndex)
+    let setupBody = nextFunc.map { String(afterSetup[..<$0.lowerBound]) } ?? String(afterSetup)
+    check(setupBody.contains("if needsRebuild"), "setup must contain if needsRebuild")
+    check(setupBody.contains("markNonSelectionChangesPending"), "setup must contain markNonSelectionChangesPending")
+}
+
+print("PASS: upgrade rebuild pending persistence")

--- a/wBlock.xcodeproj/project.pbxproj
+++ b/wBlock.xcodeproj/project.pbxproj
@@ -2008,7 +2008,7 @@
 				AUTOMATION_APPLE_EVENTS = NO;
 				CODE_SIGN_ENTITLEMENTS = "wBlock Scripts/wBlock Scripts.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = NO;
@@ -2064,7 +2064,7 @@
 				AUTOMATION_APPLE_EVENTS = NO;
 				CODE_SIGN_ENTITLEMENTS = "wBlock Scripts/wBlock Scripts.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = NO;
@@ -2208,7 +2208,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = wBlock/wBlock.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_APP_SANDBOX = YES;
@@ -2257,7 +2257,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = wBlock/wBlock.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_APP_SANDBOX = YES;
@@ -2519,7 +2519,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Ads/wBlock_Ads.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -2549,7 +2549,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Ads/wBlock_Ads.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -2579,7 +2579,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Ads (iOS)/wBlock_Ads_iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Ads (iOS)/Info.plist";
@@ -2610,7 +2610,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Ads (iOS)/wBlock_Ads_iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Ads (iOS)/Info.plist";
@@ -2643,7 +2643,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "wBlock Scripts (iOS)/wBlock Scripts (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Scripts (iOS)/Info.plist";
@@ -2679,7 +2679,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "wBlock Scripts (iOS)/wBlock Scripts (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Scripts (iOS)/Info.plist";
@@ -2715,7 +2715,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Security/wBlock_Security.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_APP_SANDBOX = YES;
@@ -2747,7 +2747,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Security/wBlock_Security.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_APP_SANDBOX = YES;
@@ -2779,7 +2779,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Privacy/wBlock_Privacy.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_APP_SANDBOX = YES;
@@ -2811,7 +2811,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Privacy/wBlock_Privacy.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_APP_SANDBOX = YES;
@@ -2843,7 +2843,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Foreign/wBlock_Foreign.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_APP_SANDBOX = YES;
@@ -2875,7 +2875,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Foreign/wBlock_Foreign.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_APP_SANDBOX = YES;
@@ -2907,7 +2907,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Custom/wBlock_Custom.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_APP_SANDBOX = YES;
@@ -2939,7 +2939,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Custom/wBlock_Custom.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				ENABLE_APP_SANDBOX = YES;
@@ -2971,7 +2971,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Privacy (iOS)/wBlock Privacy (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Privacy (iOS)/Info.plist";
@@ -3002,7 +3002,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Privacy (iOS)/wBlock Privacy (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Privacy (iOS)/Info.plist";
@@ -3034,7 +3034,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Security (iOS)/wBlock Security (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Security (iOS)/Info.plist";
@@ -3065,7 +3065,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Security (iOS)/wBlock Security (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Security (iOS)/Info.plist";
@@ -3097,7 +3097,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Privacy (iOS)/wBlock Privacy (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Privacy (iOS)/Info.plist";
@@ -3128,7 +3128,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Privacy (iOS)/wBlock Privacy (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Privacy (iOS)/Info.plist";
@@ -3160,7 +3160,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Multipurpose (iOS)/wBlock Multipurpose (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Multipurpose (iOS)/Info.plist";
@@ -3191,7 +3191,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Multipurpose (iOS)/wBlock Multipurpose (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Multipurpose (iOS)/Info.plist";
@@ -3223,7 +3223,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Foreign (iOS)/wBlock Foreign (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Foreign (iOS)/Info.plist";
@@ -3254,7 +3254,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Foreign (iOS)/wBlock Foreign (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Foreign (iOS)/Info.plist";
@@ -3286,7 +3286,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Experimental (iOS)/wBlock Experimental (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Experimental (iOS)/Info.plist";
@@ -3317,7 +3317,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Experimental (iOS)/wBlock Experimental (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Experimental (iOS)/Info.plist";
@@ -3349,7 +3349,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Custom (iOS)/wBlock Custom (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Custom (iOS)/Info.plist";
@@ -3380,7 +3380,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "wBlock Custom (iOS)/wBlock Custom (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = DNP7DGUB7B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wBlock Custom (iOS)/Info.plist";

--- a/wBlock/AppFilterManager+ApplyPipeline.swift
+++ b/wBlock/AppFilterManager+ApplyPipeline.swift
@@ -174,6 +174,7 @@ extension AppFilterManager {
                 self.showingApplyProgressSheet = !(cleared && cleanupSucceeded)
                 if cleared && cleanupSucceeded {
                     self.lastApplySucceeded = true
+                    self.persistUpgradeRebuildSignature()
                     self.commitApplySnapshot(runSnapshot)
                 }
             }
@@ -335,6 +336,7 @@ extension AppFilterManager {
                 self.showingApplyProgressSheet = !(cleared && cleanupSucceeded)
                 if cleared && cleanupSucceeded {
                     self.lastApplySucceeded = true
+                    self.persistUpgradeRebuildSignature()
                     self.commitApplySnapshot(runSnapshot)
                     self.lastRuleCount = 0
                     self.ruleCountsByExtension.removeAll()
@@ -773,6 +775,7 @@ extension AppFilterManager {
             if cleanupSucceeded {
                 await MainActor.run {
                     self.lastApplySucceeded = true
+                    self.persistUpgradeRebuildSignature()
                     self.commitApplySnapshot(runSnapshot)
                 }
             }
@@ -939,6 +942,7 @@ extension AppFilterManager {
                     self.showingApplyProgressSheet = false
                     if cleared {
                         self.lastApplySucceeded = true
+                        self.persistUpgradeRebuildSignature()
                         self.markCurrentStateApplied()
                         self.statusDescription = LocalizedStrings.text(
                             "Blocking paused", comment: "Apply pipeline pause status"

--- a/wBlock/AppFilterManager.swift
+++ b/wBlock/AppFilterManager.swift
@@ -50,6 +50,7 @@ struct ApplyRunSnapshot {
 
 @MainActor
 class AppFilterManager: ObservableObject {
+    private static let lastAppliedUpgradeSignatureKey = "wBlock.lastAppliedUpgradeSignature"
     @Published var filterLists: [FilterList] = []
     @Published var isLoading: Bool = false
     @Published var statusDescription: String = LocalizedStrings.text("Ready.", comment: "Filter manager idle status")
@@ -178,6 +179,21 @@ class AppFilterManager: ObservableObject {
         hasUnappliedChanges = false
         autoApplyTask?.cancel()
         autoApplyTask = nil
+    }
+
+    private func currentUpgradeSignature() -> String {
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        return "\(appVersion)|\(ContentBlockerService.embeddedCompatibilityRulesVersion)"
+    }
+
+    private func storedUpgradeSignature() -> String? {
+        let defaults = UserDefaults(suiteName: GroupIdentifier.shared.value) ?? .standard
+        return defaults.string(forKey: Self.lastAppliedUpgradeSignatureKey)
+    }
+
+    func persistUpgradeRebuildSignature() {
+        let defaults = UserDefaults(suiteName: GroupIdentifier.shared.value) ?? .standard
+        defaults.set(currentUpgradeSignature(), forKey: Self.lastAppliedUpgradeSignatureKey)
     }
 
     func captureApplySnapshot() {
@@ -498,6 +514,8 @@ class AppFilterManager: ObservableObject {
         // Migrate old AdGuard Annoyances filter to new split filters
         storedFilterLists = migrateOldAnnoyancesFilter(in: storedFilterLists)
 
+        var selectedDeprecatedListWasRemoved = false
+
         // Remove deprecated filter lists that are no longer shipped by wBlock.
         let deprecatedFilterLists = storedFilterLists.filter { filter in
             !filter.isCustom
@@ -524,6 +542,7 @@ class AppFilterManager: ObservableObject {
             }
 
             if removedSelected {
+                selectedDeprecatedListWasRemoved = true
                 markNonSelectionChangesPending()
             }
         }
@@ -603,7 +622,16 @@ class AppFilterManager: ObservableObject {
         // Set up observer for disabled sites changes
         setupDisabledSitesObserver()
 
-        markCurrentStateApplied()
+        let currentSignature = currentUpgradeSignature()
+        let storedSignature = storedUpgradeSignature()
+        let signatureMismatch = storedSignature != currentSignature
+        let needsRebuild = dataManager.hasCompletedOnboarding
+            && (hasURLMigrations || selectedDeprecatedListWasRemoved || signatureMismatch)
+        if needsRebuild {
+            markNonSelectionChangesPending()
+        } else {
+            markCurrentStateApplied()
+        }
         statusDescription = LocalizedStrings.format(
             "Initialized with %d filter list(s).",
             comment: "Filter manager initialization status",

--- a/wBlock/CloudSyncManager.swift
+++ b/wBlock/CloudSyncManager.swift
@@ -784,23 +784,37 @@ final class CloudSyncManager: ObservableObject {
             baseline: whitelistBaseline,
             remote: payload.whitelistDomains
         ))
-        await dataManager.setFilterDisabledDomains(Self.mergeStringSet(
-            local: currentContent.filterDisabledDomains ?? [],
-            baseline: filterDisabledBaseline ?? [],
-            remote: payload.filterDisabledDomains ?? []
-        ))
+        // A 2.2.0 payload omits these 3.0.0-only keys. Nil means no remote opinion:
+        // keep local. A present empty collection still means remote cleared the set.
+        if let remoteFilterDisabledDomains = payload.filterDisabledDomains {
+            await dataManager.setFilterDisabledDomains(Self.mergeStringSet(
+                local: currentContent.filterDisabledDomains ?? [],
+                baseline: filterDisabledBaseline ?? [],
+                remote: remoteFilterDisabledDomains
+            ))
+        }
 
         // Merge zapper hosts per key and disabled-host choices as a set.
-        let mergedZapperRules = Self.mergeDictionary(
-            local: currentContent.zapperRules ?? [:],
-            baseline: zapperBaseline ?? [:],
-            remote: payload.zapperRules ?? [:]
-        )
-        let mergedZapperDisabled = Self.mergeStringSet(
-            local: currentContent.zapperDisabledDomains ?? [],
-            baseline: zapperDisabledBaseline ?? [],
-            remote: payload.zapperDisabledDomains ?? []
-        )
+        let mergedZapperRules: [String: [String]]
+        if let remoteZapperRules = payload.zapperRules {
+            mergedZapperRules = Self.mergeDictionary(
+                local: currentContent.zapperRules ?? [:],
+                baseline: zapperBaseline ?? [:],
+                remote: remoteZapperRules
+            )
+        } else {
+            mergedZapperRules = currentContent.zapperRules ?? [:]
+        }
+        let mergedZapperDisabled: [String]
+        if let remoteZapperDisabledDomains = payload.zapperDisabledDomains {
+            mergedZapperDisabled = Self.mergeStringSet(
+                local: currentContent.zapperDisabledDomains ?? [],
+                baseline: zapperDisabledBaseline ?? [],
+                remote: remoteZapperDisabledDomains
+            )
+        } else {
+            mergedZapperDisabled = currentContent.zapperDisabledDomains ?? []
+        }
         await applyRemoteZapperRules(mergedZapperRules, disabledDomains: mergedZapperDisabled)
 
         await applyRemoteFilters(

--- a/wBlock/UserScriptManagerView.swift
+++ b/wBlock/UserScriptManagerView.swift
@@ -128,6 +128,22 @@ private struct EditorMetadataAutofillState: Equatable {
     }
 }
 
+private enum BetaUserscriptWarning {
+    static let acknowledgedKey = "wBlock.hasAcknowledgedBetaUserscriptWarning"
+
+    private static var defaults: UserDefaults {
+        UserDefaults(suiteName: GroupIdentifier.shared.value) ?? .standard
+    }
+
+    static var hasAcknowledged: Bool {
+        defaults.bool(forKey: acknowledgedKey)
+    }
+
+    static func acknowledge() {
+        defaults.set(true, forKey: acknowledgedKey)
+    }
+}
+
 struct UserScriptManagerView: View {
     @ObservedObject var userScriptManager: UserScriptManager
     let hasPendingChanges: Bool
@@ -145,6 +161,7 @@ struct UserScriptManagerView: View {
     @State private var isDropTarget = false
     @State private var isDropProcessing = false
     @State private var dropErrorMessage: String?
+    @State private var pendingBetaEnableScript: UserScriptListItem?
 
     private var totalScriptsCount: Int {
         scripts.filter { !$0.isUserStyle }.count
@@ -255,6 +272,20 @@ struct UserScriptManagerView: View {
             Button("OK", role: .cancel) { dropErrorMessage = nil }
         } message: {
             Text(dropErrorMessage ?? "")
+        }
+        .alert("Enable Beta Userscript?", isPresented: Binding(
+            get: { pendingBetaEnableScript != nil },
+            set: { newValue in if !newValue { pendingBetaEnableScript = nil } }
+        )) {
+            Button("Cancel", role: .cancel) { pendingBetaEnableScript = nil }
+            Button("Enable") {
+                guard let script = pendingBetaEnableScript else { return }
+                pendingBetaEnableScript = nil
+                BetaUserscriptWarning.acknowledge()
+                applyEnabledState(for: script, newValue: true)
+            }
+        } message: {
+            Text("Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time.")
         }
     }
 
@@ -574,6 +605,37 @@ struct UserScriptManagerView: View {
 
     #endif
 
+    private func applyEnabledState(for script: UserScriptListItem, newValue: Bool) {
+        guard let latestState = userScriptManager.userScriptToggleState(for: script.id),
+              latestState.desired != newValue
+        else { return }
+        let managedScript = userScriptManager.userScript(withId: script.id)
+        let shouldDownloadBeforeEnabling =
+            newValue && !(managedScript?.isDownloaded ?? script.isDownloaded)
+                && !(managedScript?.isLocal ?? script.isLocal)
+                && (managedScript?.url ?? script.url) != nil
+        if shouldDownloadBeforeEnabling {
+            downloadingScriptIDs.insert(script.id)
+        }
+
+        Task {
+            guard let managedScript = userScriptManager.userScript(withId: script.id) else {
+                await MainActor.run { _ = downloadingScriptIDs.remove(script.id) }
+                return
+            }
+            await ConcurrentLogManager.shared.debug(
+                .userScript,
+                LocalizedStrings.text("Setting userscript enabled state"),
+                metadata: ["script": script.name, "enabled": "\(newValue)"]
+            )
+            await userScriptManager.setUserScript(managedScript, isEnabled: newValue)
+            await MainActor.run {
+                downloadingScriptIDs.remove(script.id)
+                refreshScripts()
+            }
+        }
+    }
+
     private func scriptRowView(script: UserScriptListItem) -> some View {
         let managedScript = userScriptManager.userScript(withId: script.id)
         let toggleState = userScriptManager.userScriptToggleState(for: script.id)
@@ -667,33 +729,11 @@ struct UserScriptManagerView: View {
                 Toggle("", isOn: Binding(
                     get: { displayedEnabled || downloadingScriptIDs.contains(script.id) },
                     set: { newValue in
-                        guard let latestState = userScriptManager.userScriptToggleState(for: script.id),
-                              latestState.desired != newValue
-                        else { return }
-                        let shouldDownloadBeforeEnabling =
-                            newValue && !(managedScript?.isDownloaded ?? script.isDownloaded)
-                                && !(managedScript?.isLocal ?? script.isLocal)
-                                && (managedScript?.url ?? script.url) != nil
-                        if shouldDownloadBeforeEnabling {
-                            downloadingScriptIDs.insert(script.id)
+                        if newValue, script.isBeta, !BetaUserscriptWarning.hasAcknowledged {
+                            pendingBetaEnableScript = script
+                            return
                         }
-
-                        Task {
-                            guard let managedScript = userScriptManager.userScript(withId: script.id) else {
-                                await MainActor.run { _ = downloadingScriptIDs.remove(script.id) }
-                                return
-                            }
-                            await ConcurrentLogManager.shared.debug(
-                                .userScript,
-                                LocalizedStrings.text("Setting userscript enabled state"),
-                                metadata: ["script": script.name, "enabled": "\(newValue)"]
-                            )
-                            await userScriptManager.setUserScript(managedScript, isEnabled: newValue)
-                            await MainActor.run {
-                                downloadingScriptIDs.remove(script.id)
-                                refreshScripts()
-                            }
-                        }
+                        applyEnabledState(for: script, newValue: newValue)
                     }
                 ))
                 .labelsHidden()

--- a/wBlock/ar.lproj/Localizable.strings
+++ b/wBlock/ar.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "الخيار الأفضل افتراضيًا";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "لا تزال السكربتات التجريبية قيد الاختبار وقد تعطّل الصفحات أو تتصرف بشكل غير متوقع. يمكنك إيقافها في أي وقت.";
 "BGAppRefresh" = "تحديث التطبيقات في الخلفية";
 "BGProcessing" = "معالجة الخلفية";
 "Blocked requests (%d)" = "الطلبات المحظورة (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "تفعيل";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "فعّل 'wBlock Scripts' → السماح دائمًا على كل موقع ويب";
 "Enable all 5 Content Blocker extensions" = "فعّل جميع امتدادات حظر المحتوى الخمسة";
+"Enable Beta Userscript?" = "تفعيل سكربت المستخدم التجريبي؟";
 "Enable extra fixes and finish setup." = "فعّل إصلاحات إضافية وأنهِ الإعداد.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "فعّل امتدادات Safari حتى يتمكن wBlock من حظر الإعلانات وتشغيل سكربتات المستخدم.";
 "Enable the Safari extensions so wBlock can block ads." = "قم بتمكين ملحقات Safari حتى يتمكن wBlock من حظر الإعلانات.";

--- a/wBlock/de.lproj/Localizable.strings
+++ b/wBlock/de.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "Beste Voreinstellung";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "Beta-Userscripts werden noch getestet und können Seiten beschädigen oder sich unerwartet verhalten. Du kannst sie jederzeit wieder ausschalten.";
 "BGAppRefresh" = "Hintergrund-App-Aktualisierung";
 "BGProcessing" = "Hintergrundverarbeitung";
 "Blocked requests (%d)" = "Blockierte Anfragen (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "Aktivieren";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "Aktiviere 'wBlock Scripts' → Auf jeder Website immer erlauben";
 "Enable all 5 Content Blocker extensions" = "Aktiviere alle 5 Content-Blocker-Erweiterungen";
+"Enable Beta Userscript?" = "Beta-Userscript aktivieren?";
 "Enable extra fixes and finish setup." = "Aktiviere zusätzliche Fixes und schließe die Einrichtung ab.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "Aktiviere die Safari-Erweiterungen, damit wBlock Werbung blockieren und Userscripts ausführen kann.";
 "Enable the Safari extensions so wBlock can block ads." = "Aktiviere die Safari-Erweiterungen, damit wBlock Werbung blockieren kann.";

--- a/wBlock/el.lproj/Localizable.strings
+++ b/wBlock/el.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "Καλύτερη προεπιλογή";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "Τα beta userscripts βρίσκονται ακόμη υπό δοκιμή και μπορεί να χαλάσουν σελίδες ή να συμπεριφερθούν απρόσμενα. Μπορείτε να τα απενεργοποιήσετε ανά πάσα στιγμή.";
 "BGAppRefresh" = "Ανανέωση εφαρμογής στο παρασκήνιο";
 "BGProcessing" = "Επεξεργασία φόντου";
 "Blocked requests (%d)" = "Αποκλεισμένα αιτήματα (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "Ενεργοποίηση";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "Ενεργοποίηση 'wBlock Scripts' → Να επιτρέπονται πάντα σε κάθε ιστότοπο";
 "Enable all 5 Content Blocker extensions" = "Ενεργοποίηση και των 5 επεκτάσεων του Content Blocker";
+"Enable Beta Userscript?" = "Ενεργοποίηση beta userscript;";
 "Enable extra fixes and finish setup." = "Ενεργοποίηση επιπλέον διορθώσεων και ολοκλήρωση ρύθμισης.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "Ενεργοποιήστε τις επεκτάσεις του Safari ώστε το wBlock να μπορεί να αποκλείει διαφημίσεις και να εκτελεί userscripts.";
 "Enable the Safari extensions so wBlock can block ads." = "Ενεργοποιήστε τις επεκτάσεις του Safari ώστε το wBlock να μπορεί να αποκλείει διαφημίσεις.";

--- a/wBlock/en.lproj/Localizable.strings
+++ b/wBlock/en.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "Best default";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time.";
 "BGAppRefresh" = "BGAppRefresh";
 "BGProcessing" = "BGProcessing";
 "Blocked requests (%d)" = "Blocked requests (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "Enable";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "Enable 'wBlock Scripts' → Always Allow on Every Website";
 "Enable all 5 Content Blocker extensions" = "Enable all 5 Content Blocker extensions";
+"Enable Beta Userscript?" = "Enable Beta Userscript?";
 "Enable extra fixes and finish setup." = "Enable extra fixes and finish setup.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "Enable the Safari extensions so wBlock can block ads and run userscripts.";
 "Enable the Safari extensions so wBlock can block ads." = "Enable the Safari extensions so wBlock can block ads.";

--- a/wBlock/es.lproj/Localizable.strings
+++ b/wBlock/es.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "Mejor opción predeterminada";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "Los userscripts beta todavía están en pruebas y pueden romper páginas o comportarse de forma inesperada. Puedes desactivarlos en cualquier momento.";
 "BGAppRefresh" = "Actualización de la aplicación en segundo plano";
 "BGProcessing" = "Procesamiento en segundo plano";
 "Blocked requests (%d)" = "Solicitudes bloqueadas (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "Activar";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "Activa 'wBlock Scripts' → Permitir siempre en todos los sitios web";
 "Enable all 5 Content Blocker extensions" = "Activa las 5 extensiones de bloqueador de contenido";
+"Enable Beta Userscript?" = "¿Activar userscript beta?";
 "Enable extra fixes and finish setup." = "Activa correcciones adicionales y termina la configuración.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "Activa las extensiones de Safari para que wBlock pueda bloquear anuncios y ejecutar userscripts.";
 "Enable the Safari extensions so wBlock can block ads." = "Activa las extensiones de Safari para que wBlock pueda bloquear anuncios.";

--- a/wBlock/fr.lproj/Localizable.strings
+++ b/wBlock/fr.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "Meilleur choix par défaut";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "Les userscripts beta sont encore en cours de test et peuvent casser des pages ou se comporter de façon inattendue. Vous pouvez les désactiver à tout moment.";
 "BGAppRefresh" = "Actualisation de l'application en arrière-plan";
 "BGProcessing" = "Traitement en arrière-plan";
 "Blocked requests (%d)" = "Requêtes bloquées (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "Activer";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "Activer 'wBlock Scripts' → Toujours autoriser sur tous les sites web";
 "Enable all 5 Content Blocker extensions" = "Activez les 5 extensions de bloqueur de contenu";
+"Enable Beta Userscript?" = "Activer ce userscript beta ?";
 "Enable extra fixes and finish setup." = "Activez des correctifs supplémentaires et terminez la configuration.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "Activez les extensions Safari pour que wBlock puisse bloquer les publicités et exécuter des userscripts.";
 "Enable the Safari extensions so wBlock can block ads." = "Activez les extensions Safari pour que wBlock puisse bloquer les publicités.";

--- a/wBlock/hu.lproj/Localizable.strings
+++ b/wBlock/hu.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "Legjobb alapértelmezett";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "A beta userscriptek még tesztelés alatt állnak, ezért elronthatnak oldalakat vagy váratlanul viselkedhetnek. Bármikor kikapcsolhatod őket.";
 "BGAppRefresh" = "Háttér alkalmazás frissítése";
 "BGProcessing" = "Háttérfeldolgozás";
 "Blocked requests (%d)" = "Blokkolt kérések (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "Engedélyezés";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "Engedélyezd a 'wBlock Scripts' bővítményt → Mindig engedélyezve minden webhelyen";
 "Enable all 5 Content Blocker extensions" = "Engedélyezd mind az 5 tartalomblokkoló bővítményt";
+"Enable Beta Userscript?" = "Beta userscript engedélyezése?";
 "Enable extra fixes and finish setup." = "Engedélyezd az extra javításokat, és fejezd be a beállítást.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "Engedélyezd a Safari-bővítményeket, hogy a wBlock blokkolhassa a hirdetéseket és futtathasson userscripteket.";
 "Enable the Safari extensions so wBlock can block ads." = "Engedélyezze a Safari bővítményeket, hogy a wBlock blokkolhassa a hirdetéseket.";

--- a/wBlock/it.lproj/Localizable.strings
+++ b/wBlock/it.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "Migliore predefinito";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "Gli userscript beta sono ancora in fase di test e possono rompere le pagine o comportarsi in modo imprevisto. Puoi disattivarli in qualsiasi momento.";
 "BGAppRefresh" = "Aggiornamento dell'app in background";
 "BGProcessing" = "Elaborazione in background";
 "Blocked requests (%d)" = "Richieste bloccate (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "Abilita";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "Abilita 'wBlock Scripts' → Consenti sempre su tutti i siti web";
 "Enable all 5 Content Blocker extensions" = "Abilita tutte e 5 le estensioni Content Blocker";
+"Enable Beta Userscript?" = "Abilitare lo userscript beta?";
 "Enable extra fixes and finish setup." = "Abilita correzioni aggiuntive e completa la configurazione.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "Abilita le estensioni Safari così wBlock può bloccare le pubblicità ed eseguire gli userscript.";
 "Enable the Safari extensions so wBlock can block ads." = "Abilita le estensioni di Safari in modo che wBlock possa bloccare le pubblicità.";

--- a/wBlock/ja.lproj/Localizable.strings
+++ b/wBlock/ja.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "おすすめの既定値";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "ベータ版ユーザースクリプトはまだテスト中で、ページが崩れたり予期しない動作をしたりすることがあります。いつでもオフにできます。";
 "BGAppRefresh" = "アプリのバックグラウンド更新";
 "BGProcessing" = "バックグラウンド処理";
 "Blocked requests (%d)" = "ブロックしたリクエスト (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "有効にする";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "'wBlock Scripts'を有効化 → すべてのWebサイトで常に許可";
 "Enable all 5 Content Blocker extensions" = "5つすべてのContent Blocker拡張機能を有効にする";
+"Enable Beta Userscript?" = "ベータ版ユーザースクリプトを有効にしますか？";
 "Enable extra fixes and finish setup." = "追加の修正を有効にして設定を完了します。";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "広告ブロックとユーザースクリプト実行のため、Safari拡張機能を有効にしてください。";
 "Enable the Safari extensions so wBlock can block ads." = "wBlockが広告をブロックできるようにSafari拡張機能を有効にしてください。";

--- a/wBlock/ko.lproj/Localizable.strings
+++ b/wBlock/ko.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "최적 기본값";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "베타 유저스크립트는 아직 테스트 중이라 페이지가 깨지거나 예기치 않게 동작할 수 있습니다. 언제든지 끌 수 있습니다.";
 "BGAppRefresh" = "백그라운드 앱 새로 고침";
 "BGProcessing" = "백그라운드 처리";
 "Blocked requests (%d)" = "차단된 요청 (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "활성화";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "'wBlock Scripts' 활성화 → 모든 웹 사이트에서 항상 허용";
 "Enable all 5 Content Blocker extensions" = "5개의 콘텐츠 차단기 확장 프로그램 모두 활성화";
+"Enable Beta Userscript?" = "베타 유저스크립트를 활성화할까요?";
 "Enable extra fixes and finish setup." = "추가 수정 기능을 켜고 설정을 완료하세요.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "광고 차단과 유저스크립트 실행을 위해 Safari 확장을 활성화하세요.";
 "Enable the Safari extensions so wBlock can block ads." = "wBlock이 광고를 차단할 수 있도록 Safari 확장을 활성화하세요.";

--- a/wBlock/pl.lproj/Localizable.strings
+++ b/wBlock/pl.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "Najlepszy domyślny wybór";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "Skrypty użytkownika w wersji beta są wciąż testowane i mogą psuć strony lub działać nieprzewidywalnie. Możesz je wyłączyć w dowolnej chwili.";
 "BGAppRefresh" = "Odświeżanie aplikacji w tle";
 "BGProcessing" = "Przetwarzanie w tle";
 "Blocked requests (%d)" = "Zablokowane żądania (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "Włącz";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "Włącz 'wBlock Scripts' → Zawsze zezwalaj na każdej witrynie";
 "Enable all 5 Content Blocker extensions" = "Włącz wszystkie 5 rozszerzeń Content Blocker";
+"Enable Beta Userscript?" = "Włączyć skrypt użytkownika w wersji beta?";
 "Enable extra fixes and finish setup." = "Włącz dodatkowe poprawki i zakończ konfigurację.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "Włącz rozszerzenia Safari, aby wBlock mógł blokować reklamy i uruchamiać userscripty.";
 "Enable the Safari extensions so wBlock can block ads." = "Włącz rozszerzenia Safari, aby wBlock mógł blokować reklamy.";

--- a/wBlock/pt-BR.lproj/Localizable.strings
+++ b/wBlock/pt-BR.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "Melhor padrão";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "Os userscripts beta ainda estão em testes e podem quebrar páginas ou se comportar de forma inesperada. Você pode desativá-los a qualquer momento.";
 "BGAppRefresh" = "Atualização de aplicativo em segundo plano";
 "BGProcessing" = "Processamento em segundo plano";
 "Blocked requests (%d)" = "Requisições bloqueadas (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "Ativar";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "Ative 'wBlock Scripts' → Sempre Permitir em Todos os Sites";
 "Enable all 5 Content Blocker extensions" = "Ative todas as 5 extensões de Bloqueador de Conteúdo";
+"Enable Beta Userscript?" = "Ativar userscript beta?";
 "Enable extra fixes and finish setup." = "Ative correções extras e conclua a configuração.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "Ative as extensões do Safari para que o wBlock possa bloquear anúncios e executar userscripts.";
 "Enable the Safari extensions so wBlock can block ads." = "Ative as extensões do Safari para que o wBlock possa bloquear anúncios.";

--- a/wBlock/ro.lproj/Localizable.strings
+++ b/wBlock/ro.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "Cea mai bună opțiune implicită";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "Userscripturile beta sunt încă în testare și pot strica pagini sau se pot comporta neașteptat. Le poți dezactiva oricând.";
 "BGAppRefresh" = "Actualizează aplicația de fundal";
 "BGProcessing" = "Procesare în fundal";
 "Blocked requests (%d)" = "Solicitări blocate (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "Activează";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "Activează 'wBlock Scripts' → Permite întotdeauna pe fiecare site web";
 "Enable all 5 Content Blocker extensions" = "Activează toate cele 5 extensii Content Blocker";
+"Enable Beta Userscript?" = "Activezi userscriptul beta?";
 "Enable extra fixes and finish setup." = "Activează remedieri suplimentare și finalizează configurarea.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "Activează extensiile Safari ca wBlock să poată bloca reclamele și să ruleze userscripturi.";
 "Enable the Safari extensions so wBlock can block ads." = "Activează extensiile Safari pentru ca wBlock să poată bloca reclamele.";

--- a/wBlock/ru.lproj/Localizable.strings
+++ b/wBlock/ru.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "Лучший вариант по умолчанию";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "Бета-скрипты ещё тестируются и могут ломать страницы или работать непредсказуемо. Вы можете отключить их в любой момент.";
 "BGAppRefresh" = "Фоновое обновление приложения";
 "BGProcessing" = "Фоновая обработка";
 "Blocked requests (%d)" = "Заблокированные запросы (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "Включить";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "Включите 'wBlock Scripts' → Всегда разрешать на всех веб-сайтах";
 "Enable all 5 Content Blocker extensions" = "Включите все 5 расширений Content Blocker";
+"Enable Beta Userscript?" = "Включить бета-скрипт?";
 "Enable extra fixes and finish setup." = "Включите дополнительные исправления и завершите настройку.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "Включите расширения Safari, чтобы wBlock мог блокировать рекламу и запускать пользовательские скрипты.";
 "Enable the Safari extensions so wBlock can block ads." = "Включите расширения Safari, чтобы wBlock мог блокировать рекламу.";

--- a/wBlock/tr.lproj/Localizable.strings
+++ b/wBlock/tr.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Temel kullanıcı betikleri varsayılan olarak etkindir. Bunları buradan ayarlayabilirsiniz.";
 "Best default" = "En iyi varsayılan";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "Beta kullanıcı betikleri hâlâ test ediliyor; sayfaları bozabilir veya beklenmedik şekilde davranabilir. Bunları istediğin zaman kapatabilirsin.";
 "BGAppRefresh" = "Arka planda uygulama yenileme";
 "BGProcessing" = "Arka planda işleme";
 "Blocked requests (%d)" = "Engellenen istek (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "Etkinleştir";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "'wBlock Scripts' etkinleştirin → Tüm Web Sitelerinde Her Zaman İzin Ver";
 "Enable all 5 Content Blocker extensions" = "5 İçerik Engelleyici genişletmesinin tümünü etkinleştirin";
+"Enable Beta Userscript?" = "Beta kullanıcı betiği etkinleştirilsin mi?";
 "Enable extra fixes and finish setup." = "Ek düzeltmeleri etkinleştirin ve kurulumu tamamlayın.";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "wBlock'un reklamları engellemesi ve kullanıcı betik dosyalarını çalıştırabilmesi için Safari genişletmelerini etkinleştirin.";
 "Enable the Safari extensions so wBlock can block ads." = "wBlock'un reklamları engelleyebilmesi için Safari genişletmelerini etkinleştirin.";

--- a/wBlock/zh-Hans.lproj/Localizable.strings
+++ b/wBlock/zh-Hans.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "最佳默认选项";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "Beta 用户脚本仍在测试中，可能会破坏页面或出现异常行为。你可以随时将其关闭。";
 "BGAppRefresh" = "后台应用程序刷新";
 "BGProcessing" = "后台处理";
 "Blocked requests (%d)" = "已拦截请求 (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "启用";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "启用 'wBlock Scripts' → 在每个网站上始终允许";
 "Enable all 5 Content Blocker extensions" = "启用全部 5 个内容拦截扩展";
+"Enable Beta Userscript?" = "启用 Beta 用户脚本？";
 "Enable extra fixes and finish setup." = "启用额外修复并完成设置。";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "启用 Safari 扩展，以便 wBlock 可以拦截广告并运行用户脚本。";
 "Enable the Safari extensions so wBlock can block ads." = "启用 Safari 扩展程序以使 wBlock 能够拦截广告。";

--- a/wBlock/zh-Hant.lproj/Localizable.strings
+++ b/wBlock/zh-Hant.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "Baseline userscripts are enabled by default. You can adjust them here." = "Baseline userscripts are enabled by default. You can adjust them here.";
 "Best default" = "最佳預設";
 "Beta" = "Beta";
+"Beta userscripts are still being tested and may break pages or behave unexpectedly. You can turn them off at any time." = "Beta 使用者腳本仍在測試中，可能會破壞頁面或出現異常行為。你可以隨時將其關閉。";
 "BGAppRefresh" = "後台應用程式刷新";
 "BGProcessing" = "後台處理";
 "Blocked requests (%d)" = "已封鎖的請求 (%d)";
@@ -297,6 +298,7 @@
 "Enable" = "啟用";
 "Enable 'wBlock Scripts' → Always Allow on Every Website" = "啟用「wBlock Scripts」→ 在所有網站上一律允許";
 "Enable all 5 Content Blocker extensions" = "啟用全部 5 個內容阻擋器延伸功能";
+"Enable Beta Userscript?" = "啟用 Beta 使用者腳本？";
 "Enable extra fixes and finish setup." = "啟用額外修正並完成設定。";
 "Enable the Safari extensions so wBlock can block ads and run userscripts." = "啟用 Safari 延伸功能，以便 wBlock 可以封鎖廣告並執行使用者腳本。";
 "Enable the Safari extensions so wBlock can block ads." = "啟用 Safari 擴充功能以使 wBlock 能夠封鎖廣告。";

--- a/wBlockCoreService/UserScriptManager.swift
+++ b/wBlockCoreService/UserScriptManager.swift
@@ -1683,11 +1683,19 @@ public class UserScriptManager: ObservableObject {
     }
 
     private func isRetiredYouTubeClassicScript(_ script: UserScript) -> Bool {
-        guard let urlString = script.url?.absoluteString else { return false }
-        if urlString == BuiltInUserScripts.retiredYouTubeClassicURL {
+        guard let url = script.url else { return false }
+        if url.absoluteString == BuiltInUserScripts.retiredYouTubeClassicURL {
             return true
         }
-        return urlString.contains("adamlui/youtube-classic")
+        let path = url.path
+        if path.contains("/adamlui/youtube-classic/") {
+            return true
+        }
+        if path.hasPrefix("/adamlui/youtube-classic") {
+            let suffix = path.dropFirst("/adamlui/youtube-classic".count)
+            return suffix.isEmpty || suffix.hasPrefix("/")
+        }
+        return false
     }
 
     private func removeRetiredYouTubeAdBlockIfNeeded() async {
@@ -1792,12 +1800,20 @@ public class UserScriptManager: ObservableObject {
         }
         var retainedIndex = fullIndex ?? legacyIndices[0]
         let anyLegacyEnabled = legacyIndices.contains { userScripts[$0].isEnabled }
+        var scriptsToDeleteFromDisk: [UserScript] = []
         if fullIndex == nil {
             // No canonical record survived: migrate one legacy record in place so the
             // consolidated legacy choice becomes the configured canonical choice.
+            let legacyScript = userScripts[retainedIndex]
             userScripts[retainedIndex].url = URL(string: BuiltInUserScripts.tinyShieldURL)
             userScripts[retainedIndex].name = "tinyShield"
             userScripts[retainedIndex].description = BuiltInUserScripts.tinyShieldDescription
+            userScripts[retainedIndex].version = ""
+            userScripts[retainedIndex].updateURL = nil
+            userScripts[retainedIndex].downloadURL = nil
+            userScripts[retainedIndex].content = ""
+            userScripts[retainedIndex].resourceContents = [:]
+            scriptsToDeleteFromDisk.append(legacyScript)
         }
         userScripts[retainedIndex].isEnabled = userScripts[retainedIndex].isEnabled || anyLegacyEnabled
 
@@ -1811,7 +1827,16 @@ public class UserScriptManager: ObservableObject {
             userScripts.remove(at: index)
             if index < retainedIndex { retainedIndex -= 1 }
         }
+
+        for script in scriptsToDeleteFromDisk {
+            removeUserScriptFile(script)
+        }
+
         await persistUserScriptsNow(authoritative: true)
+
+        if userScripts[retainedIndex].isEnabled {
+            await downloadMissingDefaultScripts()
+        }
     }
 
     private func shouldPrefetchMetadata(for userScript: UserScript) -> Bool {

--- a/wBlockCoreService/UserScriptManager.swift
+++ b/wBlockCoreService/UserScriptManager.swift
@@ -113,6 +113,8 @@ enum BuiltInUserScripts {
         "tinyShield helps block ads reinserted by Ad-Shield on matching sites."
     static let retiredYouTubeAdBlockURL =
         "https://raw.githubusercontent.com/SysAdminDoc/YoutubeAdblock/main/YoutubeAdblock.user.js"
+    static let retiredYouTubeClassicURL =
+        "https://cdn.jsdelivr.net/gh/adamlui/youtube-classic/greasemonkey/youtube-classic.user.js"
 
     static let tubeCleanerURL = "https://raw.githubusercontent.com/0xCUB3/wBlock-userscripts/main/packages/tube-cleaner/dist/tube-cleaner.user.js"
     static let playerCleanerURL = "https://raw.githubusercontent.com/0xCUB3/wBlock-userscripts/main/packages/player-cleaner/dist/player-cleaner.user.js"
@@ -1680,17 +1682,27 @@ public class UserScriptManager: ObservableObject {
         }
     }
 
+    private func isRetiredYouTubeClassicScript(_ script: UserScript) -> Bool {
+        guard let urlString = script.url?.absoluteString else { return false }
+        if urlString == BuiltInUserScripts.retiredYouTubeClassicURL {
+            return true
+        }
+        return urlString.contains("adamlui/youtube-classic")
+    }
+
     private func removeRetiredYouTubeAdBlockIfNeeded() async {
-        let retiredScripts = userScripts.filter {
-            $0.url?.absoluteString == BuiltInUserScripts.retiredYouTubeAdBlockURL
+        let retiredScripts = userScripts.filter { script in
+            script.url?.absoluteString == BuiltInUserScripts.retiredYouTubeAdBlockURL
+                || isRetiredYouTubeClassicScript(script)
         }
         guard !retiredScripts.isEmpty else { return }
 
         for script in retiredScripts {
             removeUserScriptFile(script)
         }
-        userScripts.removeAll {
-            $0.url?.absoluteString == BuiltInUserScripts.retiredYouTubeAdBlockURL
+        userScripts.removeAll { script in
+            script.url?.absoluteString == BuiltInUserScripts.retiredYouTubeAdBlockURL
+                || isRetiredYouTubeClassicScript(script)
         }
         await persistUserScriptsNow(authoritative: true)
     }

--- a/wBlockCoreService/UserScriptManager.swift
+++ b/wBlockCoreService/UserScriptManager.swift
@@ -1791,14 +1791,15 @@ public class UserScriptManager: ObservableObject {
             $0.url?.absoluteString == BuiltInUserScripts.tinyShieldURL
         }
         var retainedIndex = fullIndex ?? legacyIndices[0]
+        let anyLegacyEnabled = legacyIndices.contains { userScripts[$0].isEnabled }
         if fullIndex == nil {
             // No canonical record survived: migrate one legacy record in place so the
             // consolidated legacy choice becomes the configured canonical choice.
-            userScripts[retainedIndex].isEnabled = legacyIndices.contains { userScripts[$0].isEnabled }
             userScripts[retainedIndex].url = URL(string: BuiltInUserScripts.tinyShieldURL)
             userScripts[retainedIndex].name = "tinyShield"
             userScripts[retainedIndex].description = BuiltInUserScripts.tinyShieldDescription
         }
+        userScripts[retainedIndex].isEnabled = userScripts[retainedIndex].isEnabled || anyLegacyEnabled
 
         let duplicateIDs = legacyIndices.compactMap { index -> UUID? in
             guard userScripts.indices.contains(index), index != retainedIndex else { return nil }

--- a/wBlockCoreService/wBlockCoreService.swift
+++ b/wBlockCoreService/wBlockCoreService.swift
@@ -73,7 +73,7 @@ public struct ContentBlockerSaveResult: Sendable {
     /// Version marker for built-in compatibility rules that are appended to
     /// every conversion. Bump this when changing `embeddedCompatibilityRules`
     /// so cached base JSON gets invalidated.
-    private static let embeddedCompatibilityRulesVersion = "5"
+    public static let embeddedCompatibilityRulesVersion = "5"
     private static let combinedEngineMarkerFileName = "combined-rules.sha256"
     private static let combinedEngineMarkerFormatVersion = 2
     private static let combinedEngineBuildLockFileName = "combined-engine-build.lock"


### PR DESCRIPTION
2.2.0 installs kept a leftover YouTube Classic script, could drop a regional tinyShield choice, and left Safari on old rules until the user happened to Apply. A device still on 2.2.0 could also wipe 3.0.0-only iCloud site exceptions.

First launch after 3.0.0 now rebuilds when the app version, compatibility rules, or a catalog URL changed. Classic leftovers are removed, tinyShield stays on if a regional variant was, missing iCloud keys from older apps are ignored, enabling a beta userscript warns once, and the App Store build is 109.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 097619d91a9e118c7059c7c8f2918670a7ba4343. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->