### PR TITLE
Skip reload when nothing changed

### DIFF
--- a/scripts/test_issue_546_update_skip.swift
+++ b/scripts/test_issue_546_update_skip.swift
@@ -1,0 +1,135 @@
+#!/usr/bin/env swift
+import Foundation
+
+func check(_ condition: Bool, _ message: String) {
+    guard condition else { fputs("FAIL: \(message)\n", stderr); exit(1) }
+}
+
+func requiresFullApply(
+    hasUnappliedChanges: Bool,
+    missingFilterCount: Int,
+    missingScriptCount: Int
+) -> Bool {
+    hasUnappliedChanges || missingFilterCount > 0 || missingScriptCount > 0
+}
+
+func extractFunctionBody(_ source: String, signature: String) -> String {
+    guard let start = source.range(of: signature) else {
+        fputs("FAIL: missing \(signature)\n", stderr)
+        exit(1)
+    }
+    let after = source[start.lowerBound...]
+    let searchFrom = after.index(after: start.upperBound)
+    let nextFunc = after.range(
+        of: "\n    func ",
+        range: searchFrom..<after.endIndex
+    ) ?? after.range(
+        of: "\n    static func ",
+        range: searchFrom..<after.endIndex
+    )
+    return nextFunc.map { String(after[..<$0.lowerBound]) } ?? String(after)
+}
+
+let repoRoot = FileManager.default.currentDirectoryPath
+func read(_ relative: String) throws -> String {
+    try String(contentsOfFile: "\(repoRoot)/\(relative)", encoding: .utf8)
+}
+
+let manager = try read("wBlock/AppFilterManager.swift")
+let settings = try read("wBlock/SettingsView.swift")
+let content = try read("wBlock/ContentView.swift")
+let onboarding = try read("wBlock/OnboardingView.swift")
+
+let exactExpr = "hasUnappliedChanges || missingFilterCount > 0 || missingScriptCount > 0"
+check(
+    manager.contains(exactExpr),
+    "AppFilterManager.swift must contain exact requiresFullApply expression"
+)
+
+check(
+    requiresFullApply(hasUnappliedChanges: false, missingFilterCount: 0, missingScriptCount: 0) == false,
+    "all-false → false"
+)
+for (u, f, s) in [
+    (true, 0, 0),
+    (false, 1, 0),
+    (false, 0, 1),
+    (true, 2, 3),
+    (false, 5, 0),
+] {
+    check(
+        requiresFullApply(hasUnappliedChanges: u, missingFilterCount: f, missingScriptCount: s),
+        "any true input → true (u=\(u) f=\(f) s=\(s))"
+    )
+}
+
+check(manager.contains("func applyOrCheckForUpdates()"), "applyOrCheckForUpdates must exist")
+check(manager.contains("Self.requiresFullApply("), "applyOrCheckForUpdates must call requiresFullApply")
+
+let applyBody = extractFunctionBody(manager, signature: "func applyOrCheckForUpdates()")
+check(applyBody.contains("waitUntilReady()"), "applyOrCheckForUpdates must await waitUntilReady()")
+check(
+    applyBody.contains("UserScriptManager.shared.waitUntilReady()"),
+    "applyOrCheckForUpdates must await UserScriptManager.shared.waitUntilReady()"
+)
+check(
+    applyBody.contains("filterUpdater.userScriptManager == nil"),
+    "applyOrCheckForUpdates must nil-guard userScriptManager before setUserScriptManager"
+)
+check(
+    applyBody.contains("setUserScriptManager(UserScriptManager.shared)"),
+    "applyOrCheckForUpdates must setUserScriptManager when nil"
+)
+check(applyBody.contains("refreshMissingItems()"), "applyOrCheckForUpdates must refresh missing items")
+check(applyBody.contains("performFilterUpdate()"), "applyOrCheckForUpdates must reference performFilterUpdate")
+check(applyBody.contains("checkForUpdates()"), "applyOrCheckForUpdates must reference checkForUpdates")
+
+if let ifRange = applyBody.range(of: "if Self.requiresFullApply") {
+    let afterIf = applyBody[ifRange.lowerBound...]
+    guard let elseRange = afterIf.range(of: "} else {") else {
+        fputs("FAIL: applyOrCheckForUpdates missing else branch\n", stderr)
+        exit(1)
+    }
+    let trueBranch = String(afterIf[..<elseRange.lowerBound])
+    let falseBranch = String(afterIf[elseRange.upperBound...])
+    check(trueBranch.contains("performFilterUpdate()"), "performFilterUpdate must be in true branch")
+    check(!trueBranch.contains("checkForUpdates()"), "checkForUpdates must not be in true branch")
+    check(falseBranch.contains("checkForUpdates()"), "checkForUpdates must be in else branch")
+    check(!falseBranch.contains("performFilterUpdate()"), "performFilterUpdate must not be in else branch")
+} else {
+    fputs("FAIL: applyOrCheckForUpdates missing requiresFullApply guard\n", stderr)
+    exit(1)
+}
+
+check(
+    manager.contains("self.checkAndEnableFilters(forceReload: true)"),
+    "AppFilterManager debounce must still call checkAndEnableFilters(forceReload: true)"
+)
+
+let updateNowCalls = settings.components(separatedBy: "filterManager.applyOrCheckForUpdates()").count - 1
+check(updateNowCalls >= 2, "SettingsView Update Now → applyOrCheckForUpdates (found \(updateNowCalls))")
+check(
+    !settings.contains("checkAndEnableFilters(forceReload: true)"),
+    "SettingsView must not call checkAndEnableFilters(forceReload: true)"
+)
+
+let applyPendingBody = extractFunctionBody(content, signature: "private func applyPendingChanges()")
+check(
+    applyPendingBody.contains("applyOrCheckForUpdates()"),
+    "ContentView applyPendingChanges → applyOrCheckForUpdates()"
+)
+check(
+    !applyPendingBody.contains("checkAndEnableFilters(forceReload: true)"),
+    "ContentView applyPendingChanges must not force-reload"
+)
+
+let externalBody = extractFunctionBody(content, signature: "private func applyFilterChangesFromExternalTrigger()")
+check(
+    externalBody.contains("checkAndEnableFilters(forceReload: true)"),
+    "applyFilterChangesFromExternalTrigger must still force-reload"
+)
+
+let onboardingForceCount = onboarding.components(separatedBy: "checkAndEnableFilters(forceReload: true)").count - 1
+check(onboardingForceCount >= 2, "OnboardingView force-reload twice")
+
+print("PASS: issue 546 manager and view contract")

--- a/wBlock/AppFilterManager.swift
+++ b/wBlock/AppFilterManager.swift
@@ -819,6 +819,35 @@ class AppFilterManager: ObservableObject {
         }
     }
 
+    static func requiresFullApply(
+        hasUnappliedChanges: Bool,
+        missingFilterCount: Int,
+        missingScriptCount: Int
+    ) -> Bool {
+        hasUnappliedChanges || missingFilterCount > 0 || missingScriptCount > 0
+    }
+
+    func applyOrCheckForUpdates() {
+        guard !isLoading, !isApplyInFlight else { return }
+        Task {
+            await self.waitUntilReady()
+            await UserScriptManager.shared.waitUntilReady()
+            if self.filterUpdater.userScriptManager == nil {
+                self.setUserScriptManager(UserScriptManager.shared)
+            }
+            self.refreshMissingItems()
+            if Self.requiresFullApply(
+                hasUnappliedChanges: self.hasUnappliedChanges,
+                missingFilterCount: self.missingFilters.count,
+                missingScriptCount: self.missingUserScripts.count
+            ) {
+                await self.performFilterUpdate()
+            } else {
+                await self.checkForUpdates()
+            }
+        }
+    }
+
     func toggleFilterListSelection(id: UUID) {
         guard let index = filterListIndexByID[id] else { return }
         setFilterListSelection(id: id, selected: !filterLists[index].isSelected)

--- a/wBlock/ContentView.swift
+++ b/wBlock/ContentView.swift
@@ -219,7 +219,7 @@ struct ContentView: View {
 
     private func applyPendingChanges() {
         guard !filterManager.isLoading else { return }
-        filterManager.checkAndEnableFilters(forceReload: true)
+        filterManager.applyOrCheckForUpdates()
     }
 
     private var applyChangesToolbarButton: some View {

--- a/wBlock/SettingsView.swift
+++ b/wBlock/SettingsView.swift
@@ -362,7 +362,7 @@ struct SettingsView: View {
 
             #if os(iOS)
             Button {
-                filterManager.checkAndEnableFilters(forceReload: true)
+                filterManager.applyOrCheckForUpdates()
             } label: {
                 Label("Update Now", systemImage: "arrow.triangle.2.circlepath")
             }
@@ -382,7 +382,7 @@ struct SettingsView: View {
                 Text("Auto-Update")
                 Spacer()
                 Button {
-                    filterManager.checkAndEnableFilters(forceReload: true)
+                    filterManager.applyOrCheckForUpdates()
                 } label: {
                     Label("Update Now", systemImage: "arrow.triangle.2.circlepath")
                 }


### PR DESCRIPTION
Update Now and Apply no longer reconvert rules or reload Safari when there are no local changes and no filter/userscript updates. They reuse the existing check-for-updates path and the No Updates Found alert.

Onboarding, pending settings, missing lists, and upgrade rebuilds still go through the full apply pipeline. Closes #546.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the apply vs update-check decision for user-facing Apply/Update Now, so a wrong `requiresFullApply` result could skip needed reloads or still force unnecessary ones. Debounced auto-apply, onboarding, and external triggers still force a full apply.
> 
> **Overview**
> **Update Now** and **Apply** no longer force a full filter convert/Safari reload when nothing local is pending.
> 
> `applyOrCheckForUpdates()` waits for filter and userscript managers, refreshes missing items, then either runs `performFilterUpdate()` or the existing `checkForUpdates()` path (including the No Updates Found alert). Full apply still happens if there are unapplied changes or missing filter/userscript files.
> 
> Onboarding, debounce auto-apply, and the iOS notification/external trigger still call `checkAndEnableFilters(forceReload: true)`. A source-level contract test in `scripts/test_issue_546_update_skip.swift` locks this split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcee1bc3b334f917ed6162921fa0812941b79132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->