### PR TITLE
Block double-tap during update check

### DIFF
--- a/scripts/test_issue_546_update_skip.swift
+++ b/scripts/test_issue_546_update_skip.swift
@@ -84,6 +84,24 @@ check(applyBody.contains("refreshMissingItems()"), "applyOrCheckForUpdates must 
 check(applyBody.contains("performFilterUpdate()"), "applyOrCheckForUpdates must reference performFilterUpdate")
 check(applyBody.contains("checkForUpdates()"), "applyOrCheckForUpdates must reference checkForUpdates")
 
+guard let taskRange = applyBody.range(of: "Task {") else {
+    fputs("FAIL: applyOrCheckForUpdates missing Task {\n", stderr)
+    exit(1)
+}
+let beforeTask = applyBody[..<taskRange.lowerBound]
+check(
+    beforeTask.contains("isLoading = true"),
+    "applyOrCheckForUpdates must set isLoading = true synchronously before Task {"
+)
+check(
+    applyBody.contains("let started = await self.performFilterUpdate()"),
+    "applyOrCheckForUpdates must capture performFilterUpdate started result"
+)
+check(
+    applyBody.contains("if !started {") && applyBody.contains("self.isLoading = false"),
+    "applyOrCheckForUpdates must clear isLoading when performFilterUpdate did not start"
+)
+
 if let ifRange = applyBody.range(of: "if Self.requiresFullApply") {
     let afterIf = applyBody[ifRange.lowerBound...]
     guard let elseRange = afterIf.range(of: "} else {") else {

--- a/wBlock/AppFilterManager.swift
+++ b/wBlock/AppFilterManager.swift
@@ -829,6 +829,8 @@ class AppFilterManager: ObservableObject {
 
     func applyOrCheckForUpdates() {
         guard !isLoading, !isApplyInFlight else { return }
+        isLoading = true
+        statusDescription = LocalizedStrings.text("Checking for updates...", comment: "Update check status")
         Task {
             await self.waitUntilReady()
             await UserScriptManager.shared.waitUntilReady()
@@ -841,7 +843,10 @@ class AppFilterManager: ObservableObject {
                 missingFilterCount: self.missingFilters.count,
                 missingScriptCount: self.missingUserScripts.count
             ) {
-                await self.performFilterUpdate()
+                let started = await self.performFilterUpdate()
+                if !started {
+                    self.isLoading = false
+                }
             } else {
                 await self.checkForUpdates()
             }


### PR DESCRIPTION
Follow-up to #548. applyOrCheckForUpdates now sets isLoading before waitUntilReady, so a second Update Now / Apply tap cannot start another check. If the apply pipeline is already running, loading is cleared instead of getting stuck.

Addresses the Bugbot note on #548.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-state concurrency fix in applyOrCheckForUpdates. Loading is still cleared by the existing apply/check paths when work actually starts.
> 
> **Overview**
> Prevents a second **Update Now / Apply** tap from starting another check while `applyOrCheckForUpdates` is still waiting on setup.
> 
> `isLoading` (and the “Checking for updates…” status) is now set **synchronously before** `Task {`, so the existing `guard !isLoading` blocks re-entry. If `performFilterUpdate()` does not start because apply is already in flight, `isLoading` is cleared so the UI does not stick.
> 
> The issue-546 contract test now asserts this ordering and the `started` / `isLoading = false` fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6ffc739f54e5e2a1ec88fddf9b83beb72854fe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->