### PR TITLE
Fix Enable on this site lag in Scripts popup

### DIFF
--- a/scripts/test_popup_enable_site_toggle.mjs
+++ b/scripts/test_popup_enable_site_toggle.mjs
@@ -9,6 +9,12 @@ const popup = readFileSync(path.join(root, "wBlock Scripts (iOS)", "Resources/pa
 const html = readFileSync(path.join(root, "wBlock Scripts (iOS)", "Resources/pages/popup/popup.html"), "utf8");
 const localesRoot = path.join(root, "wBlock Scripts (iOS)", "Resources/_locales");
 const localeNames = ["ar", "de", "el", "en", "es", "fr", "hu", "it", "ja", "ko", "pl", "pt_BR", "ro", "ru", "tr", "zh_CN", "zh_TW"];
+const english = JSON.parse(readFileSync(path.join(localesRoot, "en", "messages.json"), "utf8"));
+const requiredKeys = [
+  "popup_enable_on_site",
+  "popup_warning_open_app_to_apply",
+  "popup_status_unavailable",
+];
 
 const check = (condition, message) => {
   if (!condition) {
@@ -20,23 +26,81 @@ const check = (condition, message) => {
 check(html.includes('data-i18n="popup_enable_on_site"'), "popup uses the enable wording key");
 check(html.includes('id="enable-toggle"'), "popup uses the enable toggle control");
 check(!/<label[^>]*\bclass="[^"]*\btoggle-row\b[^"]*"[^>]*\bfor="enable-toggle"/i.test(html) && !/<label[^>]*\bfor="enable-toggle"[^>]*\bclass="[^"]*\btoggle-row\b/i.test(html), "enable row must not be a wrapping label");
-check(/<div\s+class="toggle-row">\s*<div\s+id="enable-title"\s+class="label"\s+data-i18n="popup_enable_on_site">[\s\S]*?<label\s+class="switch"\s+for="enable-toggle">\s*<input\s+id="enable-toggle"\s+type="checkbox"\s+aria-labelledby="enable-title"\s*\/>/m.test(html), "enable row must use switch-only label markup");
+check(/<div\s+class="toggle-row">\s*<div\s+id="enable-title"\s+class="label"\s+data-i18n="popup_enable_on_site">[\s\S]*?<label\s+class="switch"\s+for="enable-toggle">\s*<input\b[^>]*\bid="enable-toggle"[^>]*\/>/m.test(html), "enable row must use switch-only label markup");
+check(/<input\b[^>]*\bid="enable-toggle"[^>]*\bdisabled\b[^>]*\/>/m.test(html), "enable toggle must start disabled until native state is known");
 check(popup.includes("const disableToggle = document.getElementById('enable-toggle');"), "popup binds the enable control");
+
+// Slice setupListeners body and the enable-toggle change handler specifically
+const setupListenersMatch = popup.match(/function\s+setupListeners\s*\(\)\s*\{([\s\S]*?)\n\}/);
+check(Boolean(setupListenersMatch), "setupListeners function found in popup.js");
+const setupListenersBody = setupListenersMatch[1];
+
+const enableHandlerStartIndex = setupListenersBody.indexOf("if (disableToggle) {");
+const zapperHandlerStartIndex = setupListenersBody.indexOf("if (zapperEnabledToggle) {");
+check(enableHandlerStartIndex !== -1, "enable-toggle block found in setupListeners");
+check(zapperHandlerStartIndex !== -1, "zapperEnabledToggle block found in setupListeners");
+check(enableHandlerStartIndex < zapperHandlerStartIndex, "enable-toggle block comes before zapper block in setupListeners");
+
+const enableHandlerBlock = setupListenersBody.slice(enableHandlerStartIndex, zapperHandlerStartIndex);
+
+// 1. Handler must NOT contain settleMs, sleep(350), or sleep(1200)
+check(!enableHandlerBlock.includes("settleMs"), "enable handler must not contain settleMs");
+check(!enableHandlerBlock.includes("sleep(350)"), "enable handler must not contain sleep(350)");
+check(!enableHandlerBlock.includes("sleep(1200)"), "enable handler must not contain sleep(1200)");
+
+// 2. Handler must contain previousChecked and targetHost/targetTab locals
+check(enableHandlerBlock.includes("const previousChecked = !disableToggle.checked;"), "enable handler must define previousChecked local");
+check(enableHandlerBlock.includes("const targetHost = host;"), "enable handler must snapshot host as targetHost local");
+check(enableHandlerBlock.includes("const targetTab = tab;"), "enable handler must snapshot tab as targetTab local");
+
+// 3. Handler must NOT assign `disableToggle.checked = next` (without bang).
+//    Success uses `disableToggle.checked = !next`; unknown failure uses previousChecked; known reconcile uses !actuallyDisabled.
+check(!/disableToggle\.checked\s*=\s*next(?!\w)/.test(enableHandlerBlock), "enable handler must not assign disableToggle.checked = next");
+check(enableHandlerBlock.includes("disableToggle.checked = !next;"), "enable handler success path assigns disableToggle.checked = !next");
+check(enableHandlerBlock.includes("disableToggle.checked = !actuallyDisabled;"), "enable handler reconcile path assigns disableToggle.checked = !actuallyDisabled");
+check(enableHandlerBlock.includes("disableToggle.checked = previousChecked;"), "enable handler unknown failure path reverts to previousChecked");
+
+// 4. Empty-host path reverts previousChecked
+check(/if\s*\(!targetHost\)\s*\{\s*disableToggle\.checked\s*=\s*previousChecked;\s*return;\s*\}/m.test(enableHandlerBlock), "empty-host path reverts to previousChecked and returns");
+
+// 5. setupListeners must not enable the toggle except in the change-handler finally (refreshUi is what enables it via disableToggle.disabled = filtersPaused)
+const setupListenersWithoutFinally = setupListenersBody.replace(/finally\s*\{[\s\S]*?\}/g, "");
+check(!/disableToggle\.disabled\s*=\s*false/.test(setupListenersWithoutFinally), "setupListeners must not enable toggle outside of change-handler finally block");
+check(/finally\s*\{[\s\S]*?disableToggle\.disabled\s*=\s*false;[\s\S]*?\}/.test(enableHandlerBlock), "enable handler finally block must re-enable disableToggle");
+
+// 6. Keep all existing checks
 check(popup.includes("const next = !disableToggle.checked;"), "checked=true maps to disabled=false when changing the site setting");
 check(popup.includes("const siteDisabled = disabled === true;"), "failed site-disabled reads must not count as enabled");
+check(popup.includes("const siteDisabledUnknown = disabled === null;"), "unknown site-disabled reads must not be treated as enabled or disabled");
 check(popup.includes("disableToggle.checked = !siteDisabled;"), "native disabled state is inverted for the checked enable control");
 check(popup.includes("pageUserScriptsRenderedDisabled = disableToggle ? !disableToggle.checked : false;"), "userscript rendering uses the inverted enable state");
 check(popup.includes("zapperActivate.disabled = (disableToggle ? !disableToggle.checked : false) || disabled;"), "zapper activation uses the inverted enable state");
+check(popup.includes("let siteToggleGeneration = 0;"), "site toggle must track generations so stale refreshes cannot win");
+check(popup.includes("let siteToggleInFlight = false;"), "site toggle must ignore overlapping refresh commits while a write is in flight");
+check(popup.includes("const skipSiteToggleCommit = siteToggleInFlight || generationAtStart !== siteToggleGeneration;"), "refresh must not clobber an in-flight site toggle");
+check(popup.includes("if (!siteToggleInFlight)"), "refresh must keep an in-flight site-toggle error visible");
+check(popup.includes("readSiteDisabledStateAfterTimeout"), "timed-out writes must re-read native state before failing");
+check(popup.includes("popup_warning_open_app_to_apply"), "missing base-rules cache must ask the user to open wBlock");
+check(popup.includes("popup_status_unavailable"), "unreadable site state must surface an Unavailable status");
+check(popup.includes("requiresFullApply"), "site toggle must honor native requiresFullApply");
 
 for (const checked of [false, true]) {
   const nativeDisabled = !checked;
   check((!checked) === nativeDisabled, `toggle semantics failed for checked=${checked}`);
 }
 
+check(localeNames.length === 17, "site-toggle copy must cover all 17 locales");
 for (const locale of localeNames) {
   const messages = JSON.parse(readFileSync(path.join(localesRoot, locale, "messages.json"), "utf8"));
-  check(messages.popup_enable_on_site?.message, `missing enable toggle translation in ${locale}`);
+  check(JSON.stringify(Object.keys(messages).sort()) === JSON.stringify(Object.keys(english).sort()), `${locale} must preserve popup locale key parity`);
+  for (const key of requiredKeys) {
+    check(messages[key]?.message, `missing ${key} translation in ${locale}`);
+  }
   check(!messages.popup_disable_on_site, `stale disable toggle key remains in ${locale}`);
+  if (locale !== "en") {
+    check(messages.popup_warning_open_app_to_apply.message !== english.popup_warning_open_app_to_apply.message, `${locale} must have a real open-app-to-apply translation`);
+    check(messages.popup_status_unavailable.message !== english.popup_status_unavailable.message, `${locale} must have a real unavailable-status translation`);
+  }
 }
 
 console.log("PASS");

--- a/scripts/test_popup_enable_site_toggle.sh
+++ b/scripts/test_popup_enable_site_toggle.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# CI wrapper for the popup site-enable toggle contract.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+node scripts/test_popup_enable_site_toggle.mjs

--- a/scripts/test_popup_native_layout_contract.mjs
+++ b/scripts/test_popup_native_layout_contract.mjs
@@ -105,10 +105,18 @@ if (!(nextIdx >= 0 && nextIdx < tryIdx)) {
   fail("desired site state must be visible to the timeout catch");
 }
 
-if (!js.includes("return null;") ||
+if (!js.includes("readSiteDisabledStateAfterTimeout") ||
     !js.includes("typeof actuallyDisabled === 'boolean'") ||
     !js.includes("actuallyDisabled === next")) {
   fail("timed-out site toggles must reconcile only from a confirmed native read");
+}
+
+if (!js.includes("popup_status_unavailable") || !js.includes("siteDisabledUnknown")) {
+  fail("unreadable site state must not look enabled");
+}
+
+if (!js.includes("popup_warning_open_app_to_apply") || !js.includes("requiresFullApply")) {
+  fail("persisted toggles that still need a full apply must warn the user");
 }
 
 console.log("PASS");

--- a/scripts/test_safari_output_skip.swift
+++ b/scripts/test_safari_output_skip.swift
@@ -88,6 +88,13 @@ require(source.contains("public static func invalidateReloadMarker("), "raw relo
 require(source.contains("if let groupIdentifier, let targetRulesFilename"), "raw reload policy must require both target mapping fields")
 require(source.contains("outputDigest"), "marker must carry the exact output digest")
 require(source.contains("ReloadContext"), "marker must carry reload context")
+let reloadContext = section(
+    from: "private static var currentReloadContext",
+    to: "private static func reloadMarkerURL"
+)
+require(reloadContext.contains("sharedReloadIdentity()"), "reload context must use shared app-group identity")
+require(!reloadContext.contains("Bundle.main"), "reload context must not use process-specific Bundle.main metadata")
+require(source.contains("UserDefaults(suiteName: GroupIdentifier.shared.value)"), "reload identity must be readable from app-group defaults")
 require(source.contains("FileLock(") && source.contains("containerURL.appendingPathComponent(\".\\(targetRulesFilename).lock\")"), "marker checks must use the target output lock")
 require(source.contains("JSONEncoder().encode(newMarker).write(to: markerURL, options: .atomic)"), "marker writes must be atomic")
 require(source.contains("try? FileManager.default.removeItem(at: markerURL)"), "failed reloads must invalidate the marker")

--- a/scripts/test_safari_output_skip.swift
+++ b/scripts/test_safari_output_skip.swift
@@ -83,7 +83,7 @@ require(autoUpdate.contains("saveContentBlockerIfChanged"), "auto-update pause r
 require(source.contains("public static func reloadIfNeeded("), "reloads must go through the marker coordinator")
 require(autoUpdate.contains("groupIdentifier: GroupIdentifier.shared.value,\n                targetRulesFilename: target.rulesFilename"), "auto-update reloads must invalidate the mapped target marker")
 require(autoUpdate.contains("groupIdentifier: groupIdentifier,\n                    targetRulesFilename: target.rulesFilename"), "pause repair reloads must invalidate the mapped target marker")
-require(webExtension.contains("groupIdentifier: groupID,\n                        targetRulesFilename: target.rulesFilename"), "WebExtension reloads must invalidate the mapped target marker")
+require(webExtension.contains("await ContentBlockerService.reloadIfNeeded(\n                        identifier: target.bundleIdentifier,\n                        targetRulesFilename: target.rulesFilename,\n                        groupIdentifier: groupID"), "WebExtension disabled-sites fast path must certify mapped target markers via reloadIfNeeded")
 require(source.contains("public static func invalidateReloadMarker("), "raw reloads need an explicit marker invalidation API")
 require(source.contains("if let groupIdentifier, let targetRulesFilename"), "raw reload policy must require both target mapping fields")
 require(source.contains("outputDigest"), "marker must carry the exact output digest")

--- a/scripts/test_site_toggle_fastpath_contract.swift
+++ b/scripts/test_site_toggle_fastpath_contract.swift
@@ -1,0 +1,127 @@
+#!/usr/bin/env swift
+
+import Foundation
+
+func fail(_ message: String) -> Never {
+    fputs("FAIL: \(message)\n", stderr)
+    exit(1)
+}
+
+func require(_ condition: Bool, _ message: String) {
+    if !condition { fail(message) }
+}
+
+func section(_ source: String, from start: String, to end: String) -> String {
+    guard let startRange = source.range(of: start),
+          let endRange = source.range(of: end, range: startRange.upperBound..<source.endIndex)
+    else { fail("missing source section: \(start)") }
+    return String(source[startRange.lowerBound..<endRange.lowerBound])
+}
+
+let webExtension = try String(
+    contentsOfFile: "wBlockCoreService/WebExtensionRequestHandler.swift",
+    encoding: .utf8
+)
+let coreService = try String(
+    contentsOfFile: "wBlockCoreService/wBlockCoreService.swift",
+    encoding: .utf8
+)
+let appDisabledSites = try String(
+    contentsOfFile: "wBlock/AppFilterManager+DisabledSites.swift",
+    encoding: .utf8
+)
+
+let setSiteDisabledState = section(
+    webExtension,
+    from: "private static func handleSetSiteDisabledState",
+    to: "private static func handleGetBlockingPausedState"
+)
+let fastPath = section(
+    webExtension,
+    from: "private static func applyDisabledSitesFastPath",
+    to: "/// Returns enabled userscripts"
+)
+let reloadTargets = section(
+    webExtension,
+    from: "private static func reloadTargetsWithRetry",
+    to: "/// Returns enabled userscripts"
+)
+let reloadContext = section(
+    coreService,
+    from: "private static var currentReloadContext",
+    to: "private static func reloadMarkerURL"
+)
+let disabledSitesApplySkip = section(
+    appDisabledSites,
+    from: "if ContentBlockerService.isDisabledSitesApplyInProgress(",
+    to: "await ConcurrentLogManager.shared.info("
+)
+
+require(
+    fastPath.contains("fastUpdateDisabledSitesWithOutputChange("),
+    "disabled-sites fast path must observe whether its output changed"
+)
+require(
+    fastPath.contains("ContentBlockerService.markDisabledSitesApplyStarted(groupIdentifier: groupID)"),
+    "disabled-sites fast path must mark its cross-process apply as started"
+)
+require(
+    fastPath.contains("ContentBlockerService.markDisabledSitesApplyFinished(groupIdentifier: groupID)"),
+    "disabled-sites fast path must clear its cross-process apply marker"
+)
+require(
+    fastPath.contains("defer {"),
+    "disabled-sites fast path must clear its apply marker on every exit"
+)
+require(
+    appDisabledSites.contains("ContentBlockerService.isDisabledSitesApplyInProgress("),
+    "app disabled-sites monitor must consult the extension apply marker"
+)
+require(
+    disabledSitesApplySkip.contains("scheduleDisabledSitesApplyRetry()"),
+    "app disabled-sites monitor must retry after an extension apply is in progress"
+)
+require(
+    !disabledSitesApplySkip.contains("fastApplyDisabledSitesChanges"),
+    "extension apply marker must suppress app-side fast apply"
+)
+require(
+    !disabledSitesApplySkip.contains("hasUnappliedChanges = true")
+        && !disabledSitesApplySkip.contains("scheduleAutoApplyDebounce"),
+    "extension apply marker must not schedule a full filter rebuild"
+)
+require(
+    reloadTargets.contains("await ContentBlockerService.reloadIfNeeded("),
+    "disabled-sites fast-path reloads must use reloadIfNeeded"
+)
+require(
+    !reloadTargets.contains("await ContentBlockerService.reloadWithRetry("),
+    "disabled-sites fast-path reloads must not invalidate markers with reloadWithRetry"
+)
+require(
+    setSiteDisabledState.contains("await ProtobufDataManager.shared.setWhitelistedDomains(list)"),
+    "site disabled state must persist through setWhitelistedDomains"
+)
+require(
+    setSiteDisabledState.contains("\"requiresFullApply\": false"),
+    "no-op site-toggle replies must include requiresFullApply"
+)
+require(
+    setSiteDisabledState.contains("\"requiresFullApply\": summary.requiresFullApply"),
+    "changed site-toggle replies must include requiresFullApply"
+)
+require(
+    fastPath.contains("error.code == .fileReadCorruptFile"),
+    "missing base-rules cache must request a full apply"
+)
+require(
+    !reloadContext.contains("Bundle.main"),
+    "reload context must not read process-specific Bundle.main metadata"
+)
+require(
+    !reloadContext.contains("CFBundleShortVersionString")
+        && !reloadContext.contains("CFBundleVersion"),
+    "reload context must not use process-specific version or build metadata"
+)
+
+print("PASS: site toggle fast-path contract")

--- a/scripts/test_site_toggle_fastpath_contract.swift
+++ b/scripts/test_site_toggle_fastpath_contract.swift
@@ -30,6 +30,21 @@ let appDisabledSites = try String(
     contentsOfFile: "wBlock/AppFilterManager+DisabledSites.swift",
     encoding: .utf8
 )
+let disabledSitesApplyStart = section(
+    coreService,
+    from: "public static func markDisabledSitesApplyStarted",
+    to: "/// Clears one active Scripts-extension disabled-sites update marker."
+)
+let disabledSitesApplyRefresh = section(
+    coreService,
+    from: "public static func refreshDisabledSitesApplyInProgress",
+    to: "/// Clears one active Scripts-extension disabled-sites update marker."
+)
+let disabledSitesApplyFinish = section(
+    coreService,
+    from: "public static func markDisabledSitesApplyFinished",
+    to: "/// Returns whether a Scripts-extension disabled-sites update started recently."
+)
 
 let setSiteDisabledState = section(
     webExtension,
@@ -45,6 +60,11 @@ let reloadTargets = section(
     webExtension,
     from: "private static func reloadTargetsWithRetry",
     to: "/// Returns enabled userscripts"
+)
+let sharedReloadIdentity = section(
+    coreService,
+    from: "private static func sharedReloadIdentity",
+    to: "private static var currentReloadContext"
 )
 let reloadContext = section(
     coreService,
@@ -62,16 +82,22 @@ require(
     "disabled-sites fast path must observe whether its output changed"
 )
 require(
-    fastPath.contains("ContentBlockerService.markDisabledSitesApplyStarted(groupIdentifier: groupID)"),
-    "disabled-sites fast path must mark its cross-process apply as started"
+    !fastPath.contains("ContentBlockerService.markDisabledSitesApplyStarted(groupIdentifier: groupID)")
+        && !fastPath.contains("ContentBlockerService.markDisabledSitesApplyFinished(groupIdentifier: groupID)"),
+    "disabled-sites fast path must not change the persist-and-apply marker refcount"
 )
+if let refresh = fastPath.range(of: "ContentBlockerService.refreshDisabledSitesApplyInProgress(groupIdentifier: groupID)"),
+   let reload = fastPath.range(of: "reloadTargetsWithRetry(targetsToReload)") {
+    require(refresh.lowerBound < reload.lowerBound, "fast path must refresh its apply marker before Safari reload")
+} else {
+    fail("fast path must refresh its apply marker before Safari reload")
+}
 require(
-    fastPath.contains("ContentBlockerService.markDisabledSitesApplyFinished(groupIdentifier: groupID)"),
-    "disabled-sites fast path must clear its cross-process apply marker"
-)
-require(
-    fastPath.contains("defer {"),
-    "disabled-sites fast path must clear its apply marker on every exit"
+    disabledSitesApplyRefresh.contains("startedAt: now")
+        && disabledSitesApplyRefresh.contains("count: stamp.count")
+        && disabledSitesApplyRefresh.contains("writeDisabledSitesApplyInProgressStamp")
+        && coreService.contains("try? data.write(to: url, options: .atomic)"),
+    "refresh must atomically update the timestamp without changing the refcount"
 )
 require(
     appDisabledSites.contains("ContentBlockerService.isDisabledSitesApplyInProgress("),
@@ -98,9 +124,16 @@ require(
     !reloadTargets.contains("await ContentBlockerService.reloadWithRetry("),
     "disabled-sites fast-path reloads must not invalidate markers with reloadWithRetry"
 )
+if let applyStart = setSiteDisabledState.range(of: "ContentBlockerService.markDisabledSitesApplyStarted(groupIdentifier: groupID)"),
+   let persist = setSiteDisabledState.range(of: "await ProtobufDataManager.shared.setWhitelistedDomains(list)") {
+    require(applyStart.lowerBound < persist.lowerBound, "site disabled state must mark apply started before persisting")
+} else {
+    fail("site disabled state must mark apply started before persisting")
+}
 require(
-    setSiteDisabledState.contains("await ProtobufDataManager.shared.setWhitelistedDomains(list)"),
-    "site disabled state must persist through setWhitelistedDomains"
+    setSiteDisabledState.contains("defer {")
+        && setSiteDisabledState.contains("ContentBlockerService.markDisabledSitesApplyFinished(groupIdentifier: groupID)"),
+    "site disabled state must clear its apply marker on every exit"
 )
 require(
     setSiteDisabledState.contains("\"requiresFullApply\": false"),
@@ -115,13 +148,107 @@ require(
     "missing base-rules cache must request a full apply"
 )
 require(
+    reloadContext.contains("sharedReloadIdentity()"),
+    "reload context must use the shared app upgrade identity"
+)
+require(
     !reloadContext.contains("Bundle.main"),
     "reload context must not read process-specific Bundle.main metadata"
 )
 require(
-    !reloadContext.contains("CFBundleShortVersionString")
-        && !reloadContext.contains("CFBundleVersion"),
-    "reload context must not use process-specific version or build metadata"
+    sharedReloadIdentity.contains("UserDefaults(suiteName: GroupIdentifier.shared.value)"),
+    "shared reload identity must use app-group defaults"
 )
+require(
+    sharedReloadIdentity.contains("if Bundle.main.bundleIdentifier == \"skula.wBlock\""),
+    "only the containing app may publish reload identity"
+)
+if let publisher = sharedReloadIdentity.range(of: "if Bundle.main.bundleIdentifier == \"skula.wBlock\""),
+   let versionWrite = sharedReloadIdentity.range(of: "defaults?.set(appVersion, forKey: reloadContextAppVersionKey)"),
+   let buildWrite = sharedReloadIdentity.range(of: "defaults?.set(appBuild, forKey: reloadContextAppBuildKey)") {
+    require(publisher.lowerBound < versionWrite.lowerBound && publisher.lowerBound < buildWrite.lowerBound, "reload identity writes must be app-only")
+} else {
+    fail("shared reload identity must publish version and build")
+}
+require(
+    sharedReloadIdentity.contains("defaults?.string(forKey: reloadContextAppVersionKey) ?? \"\"")
+        && sharedReloadIdentity.contains("defaults?.string(forKey: reloadContextAppBuildKey) ?? \"\""),
+    "non-app processes must read reload identity from app-group defaults"
+)
+require(
+    coreService.contains("disabledSitesApplyInProgressMaximumAge: TimeInterval = reloadCompletionTimeout * 6")
+        || coreService.contains("disabledSitesApplyInProgressMaximumAge: TimeInterval = 180"),
+    "disabled-sites apply marker must cover the full Safari retry window"
+)
+require(
+    disabledSitesApplyStart.contains("count") && disabledSitesApplyFinish.contains("count"),
+    "disabled-sites apply start and finish must maintain a refcount"
+)
+
+struct SimulatedApplyStamp {
+    let startedAt: TimeInterval
+    let count: Int
+}
+
+let simulatedMaximumAge: TimeInterval = 180
+func simulatedApplyIsInProgress(_ stamp: SimulatedApplyStamp?, now: TimeInterval) -> Bool {
+    guard let stamp else { return false }
+    let age = now - stamp.startedAt
+    return age >= 0 && age < simulatedMaximumAge
+}
+
+func simulatedMarkApplyStarted(_ stamp: inout SimulatedApplyStamp?, now: TimeInterval) {
+    let count = simulatedApplyIsInProgress(stamp, now: now) ? stamp!.count + 1 : 1
+    stamp = SimulatedApplyStamp(startedAt: now, count: count)
+}
+
+func simulatedMarkApplyFinished(_ stamp: inout SimulatedApplyStamp?, now: TimeInterval) {
+    guard let existing = stamp, simulatedApplyIsInProgress(existing, now: now) else {
+        stamp = nil
+        return
+    }
+    let count = existing.count - 1
+    stamp = count > 0 ? SimulatedApplyStamp(startedAt: existing.startedAt, count: count) : nil
+}
+
+func simulatedRefreshApplyInProgress(_ stamp: inout SimulatedApplyStamp?, now: TimeInterval) {
+    guard let existing = stamp, simulatedApplyIsInProgress(existing, now: now) else {
+        return
+    }
+    stamp = SimulatedApplyStamp(startedAt: now, count: existing.count)
+}
+
+var simulatedStamp: SimulatedApplyStamp?
+simulatedMarkApplyStarted(&simulatedStamp, now: 1_000)
+simulatedRefreshApplyInProgress(&simulatedStamp, now: 1_010)
+require(
+    simulatedStamp?.count == 1 && simulatedStamp?.startedAt == 1_010,
+    "refresh must preserve one active refcount while updating its timestamp"
+)
+simulatedMarkApplyFinished(&simulatedStamp, now: 1_011)
+require(simulatedStamp == nil, "one finish must clear a refreshed single-count stamp")
+
+
+simulatedMarkApplyStarted(&simulatedStamp, now: 1_000) // A starts.
+simulatedMarkApplyStarted(&simulatedStamp, now: 1_001) // B starts.
+simulatedMarkApplyFinished(&simulatedStamp, now: 1_002) // A finishes.
+require(
+    simulatedApplyIsInProgress(simulatedStamp, now: 1_002),
+    "finishing A must not clear B's in-progress stamp"
+)
+simulatedMarkApplyFinished(&simulatedStamp, now: 1_003) // B finishes.
+require(
+    !simulatedApplyIsInProgress(simulatedStamp, now: 1_003),
+    "finishing B must clear the last in-progress stamp"
+)
+simulatedStamp = SimulatedApplyStamp(startedAt: 800, count: 4)
+require(
+    !simulatedApplyIsInProgress(simulatedStamp, now: 1_000),
+    "a stale apply stamp must not remain in progress"
+)
+simulatedMarkApplyStarted(&simulatedStamp, now: 1_000)
+require(simulatedStamp?.count == 1, "starting over a stale stamp must reset its refcount")
+simulatedMarkApplyFinished(&simulatedStamp, now: 1_001)
+require(simulatedStamp == nil, "one finish must clear a reset stale stamp")
 
 print("PASS: site toggle fast-path contract")

--- a/scripts/test_site_toggle_fastpath_contract.swift
+++ b/scripts/test_site_toggle_fastpath_contract.swift
@@ -18,6 +18,13 @@ func section(_ source: String, from start: String, to end: String) -> String {
     return String(source[startRange.lowerBound..<endRange.lowerBound])
 }
 
+func requireBefore(_ first: String, _ second: String, in source: String, _ message: String) {
+    guard let firstRange = source.range(of: first),
+          let secondRange = source.range(of: second)
+    else { fail("missing source-order marker: \(message)") }
+    require(firstRange.lowerBound < secondRange.lowerBound, message)
+}
+
 let webExtension = try String(
     contentsOfFile: "wBlockCoreService/WebExtensionRequestHandler.swift",
     encoding: .utf8
@@ -26,26 +33,6 @@ let coreService = try String(
     contentsOfFile: "wBlockCoreService/wBlockCoreService.swift",
     encoding: .utf8
 )
-let appDisabledSites = try String(
-    contentsOfFile: "wBlock/AppFilterManager+DisabledSites.swift",
-    encoding: .utf8
-)
-let disabledSitesApplyStart = section(
-    coreService,
-    from: "public static func markDisabledSitesApplyStarted",
-    to: "/// Clears one active Scripts-extension disabled-sites update marker."
-)
-let disabledSitesApplyRefresh = section(
-    coreService,
-    from: "public static func refreshDisabledSitesApplyInProgress",
-    to: "/// Clears one active Scripts-extension disabled-sites update marker."
-)
-let disabledSitesApplyFinish = section(
-    coreService,
-    from: "public static func markDisabledSitesApplyFinished",
-    to: "/// Returns whether a Scripts-extension disabled-sites update started recently."
-)
-
 let setSiteDisabledState = section(
     webExtension,
     from: "private static func handleSetSiteDisabledState",
@@ -54,11 +41,6 @@ let setSiteDisabledState = section(
 let fastPath = section(
     webExtension,
     from: "private static func applyDisabledSitesFastPath",
-    to: "/// Returns enabled userscripts"
-)
-let reloadTargets = section(
-    webExtension,
-    from: "private static func reloadTargetsWithRetry",
     to: "/// Returns enabled userscripts"
 )
 let sharedReloadIdentity = section(
@@ -71,184 +53,62 @@ let reloadContext = section(
     from: "private static var currentReloadContext",
     to: "private static func reloadMarkerURL"
 )
-let disabledSitesApplySkip = section(
-    appDisabledSites,
-    from: "if ContentBlockerService.isDisabledSitesApplyInProgress(",
-    to: "await ConcurrentLogManager.shared.info("
-)
 
-require(
-    fastPath.contains("fastUpdateDisabledSitesWithOutputChange("),
-    "disabled-sites fast path must observe whether its output changed"
+requireBefore(
+    "ContentBlockerService.markDisabledSitesApplyStarted(groupIdentifier: groupID)",
+    "await ProtobufDataManager.shared.setWhitelistedDomains(list)",
+    in: setSiteDisabledState,
+    "site disabled state must mark apply started before persisting"
 )
-require(
-    !fastPath.contains("ContentBlockerService.markDisabledSitesApplyStarted(groupIdentifier: groupID)")
-        && !fastPath.contains("ContentBlockerService.markDisabledSitesApplyFinished(groupIdentifier: groupID)"),
-    "disabled-sites fast path must not change the persist-and-apply marker refcount"
-)
-if let refresh = fastPath.range(of: "ContentBlockerService.refreshDisabledSitesApplyInProgress(groupIdentifier: groupID)"),
-   let reload = fastPath.range(of: "reloadTargetsWithRetry(targetsToReload)") {
-    require(refresh.lowerBound < reload.lowerBound, "fast path must refresh its apply marker before Safari reload")
-} else {
-    fail("fast path must refresh its apply marker before Safari reload")
-}
-require(
-    disabledSitesApplyRefresh.contains("startedAt: now")
-        && disabledSitesApplyRefresh.contains("count: stamp.count")
-        && disabledSitesApplyRefresh.contains("writeDisabledSitesApplyInProgressStamp")
-        && coreService.contains("try? data.write(to: url, options: .atomic)"),
-    "refresh must atomically update the timestamp without changing the refcount"
-)
-require(
-    appDisabledSites.contains("ContentBlockerService.isDisabledSitesApplyInProgress("),
-    "app disabled-sites monitor must consult the extension apply marker"
-)
-require(
-    disabledSitesApplySkip.contains("scheduleDisabledSitesApplyRetry()"),
-    "app disabled-sites monitor must retry after an extension apply is in progress"
-)
-require(
-    !disabledSitesApplySkip.contains("fastApplyDisabledSitesChanges"),
-    "extension apply marker must suppress app-side fast apply"
-)
-require(
-    !disabledSitesApplySkip.contains("hasUnappliedChanges = true")
-        && !disabledSitesApplySkip.contains("scheduleAutoApplyDebounce"),
-    "extension apply marker must not schedule a full filter rebuild"
-)
-require(
-    reloadTargets.contains("await ContentBlockerService.reloadIfNeeded("),
-    "disabled-sites fast-path reloads must use reloadIfNeeded"
-)
-require(
-    !reloadTargets.contains("await ContentBlockerService.reloadWithRetry("),
-    "disabled-sites fast-path reloads must not invalidate markers with reloadWithRetry"
-)
-if let applyStart = setSiteDisabledState.range(of: "ContentBlockerService.markDisabledSitesApplyStarted(groupIdentifier: groupID)"),
-   let persist = setSiteDisabledState.range(of: "await ProtobufDataManager.shared.setWhitelistedDomains(list)") {
-    require(applyStart.lowerBound < persist.lowerBound, "site disabled state must mark apply started before persisting")
-} else {
-    fail("site disabled state must mark apply started before persisting")
-}
 require(
     setSiteDisabledState.contains("defer {")
         && setSiteDisabledState.contains("ContentBlockerService.markDisabledSitesApplyFinished(groupIdentifier: groupID)"),
     "site disabled state must clear its apply marker on every exit"
 )
 require(
-    setSiteDisabledState.contains("\"requiresFullApply\": false"),
-    "no-op site-toggle replies must include requiresFullApply"
+    !fastPath.contains("markDisabledSitesApplyStarted")
+        && !fastPath.contains("markDisabledSitesApplyFinished")
+        && !fastPath.contains("refreshDisabledSitesApplyInProgress"),
+    "disabled-sites fast path must not manage the apply marker"
 )
 require(
-    setSiteDisabledState.contains("\"requiresFullApply\": summary.requiresFullApply"),
-    "changed site-toggle replies must include requiresFullApply"
+    fastPath.contains("fastUpdateDisabledSitesWithOutputChange(")
+        && fastPath.contains("await ContentBlockerService.reloadIfNeeded("),
+    "disabled-sites fast path must update changed output and reload it if needed"
 )
 require(
-    fastPath.contains("error.code == .fileReadCorruptFile"),
+    fastPath.contains("error.code == .fileReadCorruptFile")
+        && fastPath.contains("requiresFullApply: fullApplyTargets > 0"),
     "missing base-rules cache must request a full apply"
 )
 require(
-    reloadContext.contains("sharedReloadIdentity()"),
-    "reload context must use the shared app upgrade identity"
+    reloadContext.contains("sharedReloadIdentity()") && !reloadContext.contains("Bundle.main"),
+    "reload context must use the shared identity rather than process metadata"
 )
 require(
-    !reloadContext.contains("Bundle.main"),
-    "reload context must not read process-specific Bundle.main metadata"
+    sharedReloadIdentity.contains("if Bundle.main.bundleIdentifier == \"skula.wBlock\"")
+        && sharedReloadIdentity.contains("UserDefaults(suiteName: GroupIdentifier.shared.value)")
+        && sharedReloadIdentity.contains("defaults?.set(appVersion, forKey: reloadContextAppVersionKey)")
+        && sharedReloadIdentity.contains("defaults?.set(appBuild, forKey: reloadContextAppBuildKey)")
+        && sharedReloadIdentity.contains("defaults?.string(forKey: reloadContextAppVersionKey) ?? \"\"")
+        && sharedReloadIdentity.contains("defaults?.string(forKey: reloadContextAppBuildKey) ?? \"\""),
+    "shared reload identity must publish only from the app and read group defaults otherwise"
 )
-require(
-    sharedReloadIdentity.contains("UserDefaults(suiteName: GroupIdentifier.shared.value)"),
-    "shared reload identity must use app-group defaults"
-)
-require(
-    sharedReloadIdentity.contains("if Bundle.main.bundleIdentifier == \"skula.wBlock\""),
+requireBefore(
+    "if Bundle.main.bundleIdentifier == \"skula.wBlock\"",
+    "defaults?.set(appVersion, forKey: reloadContextAppVersionKey)",
+    in: sharedReloadIdentity,
     "only the containing app may publish reload identity"
 )
-if let publisher = sharedReloadIdentity.range(of: "if Bundle.main.bundleIdentifier == \"skula.wBlock\""),
-   let versionWrite = sharedReloadIdentity.range(of: "defaults?.set(appVersion, forKey: reloadContextAppVersionKey)"),
-   let buildWrite = sharedReloadIdentity.range(of: "defaults?.set(appBuild, forKey: reloadContextAppBuildKey)") {
-    require(publisher.lowerBound < versionWrite.lowerBound && publisher.lowerBound < buildWrite.lowerBound, "reload identity writes must be app-only")
-} else {
-    fail("shared reload identity must publish version and build")
-}
-require(
-    sharedReloadIdentity.contains("defaults?.string(forKey: reloadContextAppVersionKey) ?? \"\"")
-        && sharedReloadIdentity.contains("defaults?.string(forKey: reloadContextAppBuildKey) ?? \"\""),
-    "non-app processes must read reload identity from app-group defaults"
+requireBefore(
+    "if Bundle.main.bundleIdentifier == \"skula.wBlock\"",
+    "defaults?.set(appBuild, forKey: reloadContextAppBuildKey)",
+    in: sharedReloadIdentity,
+    "only the containing app may publish reload identity"
 )
 require(
-    coreService.contains("disabledSitesApplyInProgressMaximumAge: TimeInterval = reloadCompletionTimeout * 6")
-        || coreService.contains("disabledSitesApplyInProgressMaximumAge: TimeInterval = 180"),
+    coreService.contains("disabledSitesApplyInProgressMaximumAge: TimeInterval = reloadCompletionTimeout * 6"),
     "disabled-sites apply marker must cover the full Safari retry window"
 )
-require(
-    disabledSitesApplyStart.contains("count") && disabledSitesApplyFinish.contains("count"),
-    "disabled-sites apply start and finish must maintain a refcount"
-)
-
-struct SimulatedApplyStamp {
-    let startedAt: TimeInterval
-    let count: Int
-}
-
-let simulatedMaximumAge: TimeInterval = 180
-func simulatedApplyIsInProgress(_ stamp: SimulatedApplyStamp?, now: TimeInterval) -> Bool {
-    guard let stamp else { return false }
-    let age = now - stamp.startedAt
-    return age >= 0 && age < simulatedMaximumAge
-}
-
-func simulatedMarkApplyStarted(_ stamp: inout SimulatedApplyStamp?, now: TimeInterval) {
-    let count = simulatedApplyIsInProgress(stamp, now: now) ? stamp!.count + 1 : 1
-    stamp = SimulatedApplyStamp(startedAt: now, count: count)
-}
-
-func simulatedMarkApplyFinished(_ stamp: inout SimulatedApplyStamp?, now: TimeInterval) {
-    guard let existing = stamp, simulatedApplyIsInProgress(existing, now: now) else {
-        stamp = nil
-        return
-    }
-    let count = existing.count - 1
-    stamp = count > 0 ? SimulatedApplyStamp(startedAt: existing.startedAt, count: count) : nil
-}
-
-func simulatedRefreshApplyInProgress(_ stamp: inout SimulatedApplyStamp?, now: TimeInterval) {
-    guard let existing = stamp, simulatedApplyIsInProgress(existing, now: now) else {
-        return
-    }
-    stamp = SimulatedApplyStamp(startedAt: now, count: existing.count)
-}
-
-var simulatedStamp: SimulatedApplyStamp?
-simulatedMarkApplyStarted(&simulatedStamp, now: 1_000)
-simulatedRefreshApplyInProgress(&simulatedStamp, now: 1_010)
-require(
-    simulatedStamp?.count == 1 && simulatedStamp?.startedAt == 1_010,
-    "refresh must preserve one active refcount while updating its timestamp"
-)
-simulatedMarkApplyFinished(&simulatedStamp, now: 1_011)
-require(simulatedStamp == nil, "one finish must clear a refreshed single-count stamp")
-
-
-simulatedMarkApplyStarted(&simulatedStamp, now: 1_000) // A starts.
-simulatedMarkApplyStarted(&simulatedStamp, now: 1_001) // B starts.
-simulatedMarkApplyFinished(&simulatedStamp, now: 1_002) // A finishes.
-require(
-    simulatedApplyIsInProgress(simulatedStamp, now: 1_002),
-    "finishing A must not clear B's in-progress stamp"
-)
-simulatedMarkApplyFinished(&simulatedStamp, now: 1_003) // B finishes.
-require(
-    !simulatedApplyIsInProgress(simulatedStamp, now: 1_003),
-    "finishing B must clear the last in-progress stamp"
-)
-simulatedStamp = SimulatedApplyStamp(startedAt: 800, count: 4)
-require(
-    !simulatedApplyIsInProgress(simulatedStamp, now: 1_000),
-    "a stale apply stamp must not remain in progress"
-)
-simulatedMarkApplyStarted(&simulatedStamp, now: 1_000)
-require(simulatedStamp?.count == 1, "starting over a stale stamp must reset its refcount")
-simulatedMarkApplyFinished(&simulatedStamp, now: 1_001)
-require(simulatedStamp == nil, "one finish must clear a reset stale stamp")
 
 print("PASS: site toggle fast-path contract")

--- a/wBlock Scripts (iOS)/Resources/_locales/ar/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ar/messages.json
@@ -87,6 +87,10 @@
     "message": "تعذر تحديث إعداد الموقع.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "افتح wBlock لإنهاء تطبيق عوامل التصفية.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "أداة إخفاء العناصر غير متاحة في هذه الصفحة.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "غير مدعوم",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "غير متاح",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "جارٍ التحقق…",

--- a/wBlock Scripts (iOS)/Resources/_locales/de/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/de/messages.json
@@ -87,6 +87,10 @@
     "message": "Website-Einstellung konnte nicht aktualisiert werden.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "Öffne wBlock, um das Anwenden der Filter abzuschließen.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "Der Element-Zapper ist auf dieser Seite nicht verfügbar.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "Nicht unterstützt",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "Nicht verfügbar",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "Wird geprüft…",

--- a/wBlock Scripts (iOS)/Resources/_locales/el/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/el/messages.json
@@ -87,6 +87,10 @@
     "message": "Αποτυχία ενημέρωσης ρύθμισης ιστότοπου.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "Άνοιξε το wBlock για να ολοκληρωθεί η εφαρμογή των φίλτρων.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "Ο αποκλεισμός στοιχείου δεν είναι διαθέσιμος σε αυτή τη σελίδα.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "Δεν υποστηρίζεται",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "Μη διαθέσιμη",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "Έλεγχος…",

--- a/wBlock Scripts (iOS)/Resources/_locales/en/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/en/messages.json
@@ -87,6 +87,10 @@
     "message": "Failed to update site setting.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "Open wBlock to finish applying filters.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "Element Zapper is unavailable on this page.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "Unsupported",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "Unavailable",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "Checking…",

--- a/wBlock Scripts (iOS)/Resources/_locales/es/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/es/messages.json
@@ -87,6 +87,10 @@
     "message": "No se pudo actualizar la configuración del sitio.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "Abre wBlock para terminar de aplicar los filtros.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "El ocultador de elementos no está disponible en esta página.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "No compatible",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "No disponible",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "Comprobando…",

--- a/wBlock Scripts (iOS)/Resources/_locales/fr/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/fr/messages.json
@@ -87,6 +87,10 @@
     "message": "Impossible de mettre à jour le paramètre du site.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "Ouvrez wBlock pour terminer l’application des filtres.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "Le zappeur d’éléments n’est pas disponible sur cette page.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "Non pris en charge",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "Indisponible",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "Vérification…",

--- a/wBlock Scripts (iOS)/Resources/_locales/hu/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/hu/messages.json
@@ -87,6 +87,10 @@
     "message": "Nem sikerült frissíteni a webhely beállítását.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "Nyisd meg a wBlockot a szűrők alkalmazásának befejezéséhez.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "Az elemeltávolító nem érhető el ezen az oldalon.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "Nem támogatott",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "Nem elérhető",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "Ellenőrzés…",

--- a/wBlock Scripts (iOS)/Resources/_locales/it/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/it/messages.json
@@ -87,6 +87,10 @@
     "message": "Impossibile aggiornare l’impostazione del sito.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "Apri wBlock per completare l’applicazione dei filtri.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "Lo Zapper elementi non è disponibile su questa pagina.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "Non supportato",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "Non disponibile",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "Verifica in corso…",

--- a/wBlock Scripts (iOS)/Resources/_locales/ja/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ja/messages.json
@@ -87,6 +87,10 @@
     "message": "サイト設定の更新に失敗しました。",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "フィルターの適用を完了するには wBlock を開いてください。",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "このページでは要素ザッパーを利用できません。",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "非対応",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "利用できません",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "確認中…",

--- a/wBlock Scripts (iOS)/Resources/_locales/ko/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ko/messages.json
@@ -87,6 +87,10 @@
     "message": "사이트 설정을 업데이트하지 못했습니다.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "필터 적용을 마치려면 wBlock을 여세요.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "이 페이지에서는 요소 제거기를 사용할 수 없습니다.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "지원되지 않음",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "사용할 수 없음",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "확인 중…",

--- a/wBlock Scripts (iOS)/Resources/_locales/pl/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/pl/messages.json
@@ -87,6 +87,10 @@
     "message": "Nie udało się zaktualizować ustawienia witryny.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "Otwórz wBlock, aby dokończyć stosowanie filtrów.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "Usuwacz elementów jest niedostępny na tej stronie.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "Nieobsługiwane",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "Niedostępne",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "Sprawdzanie…",

--- a/wBlock Scripts (iOS)/Resources/_locales/pt_BR/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/pt_BR/messages.json
@@ -87,6 +87,10 @@
     "message": "Falha ao atualizar a configuração do site.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "Abra o wBlock para concluir a aplicação dos filtros.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "O ocultador de elementos não está disponível nesta página.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "Não compatível",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "Indisponível",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "Verificando…",

--- a/wBlock Scripts (iOS)/Resources/_locales/ro/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ro/messages.json
@@ -87,6 +87,10 @@
     "message": "Nu s-a putut actualiza setarea site-ului.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "Deschide wBlock pentru a finaliza aplicarea filtrelor.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "Eliminatorul de elemente nu este disponibil pe această pagină.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "Nesuportat",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "Indisponibil",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "Se verifică…",

--- a/wBlock Scripts (iOS)/Resources/_locales/ru/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/ru/messages.json
@@ -87,6 +87,10 @@
     "message": "Не удалось обновить настройку сайта.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "Откройте wBlock, чтобы завершить применение фильтров.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "Скрытие элементов недоступно на этой странице.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "Не поддерживается",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "Недоступно",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "Проверка…",

--- a/wBlock Scripts (iOS)/Resources/_locales/tr/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/tr/messages.json
@@ -87,6 +87,10 @@
     "message": "Site ayarı güncellenemedi.",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "Filtrelerin uygulanmasını tamamlamak için wBlock’u açın.",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "Öğe Zaplayıcı bu sayfada kullanılamıyor.",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "Desteklenmiyor",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "Kullanılamıyor",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "Kontrol ediliyor…",

--- a/wBlock Scripts (iOS)/Resources/_locales/zh_CN/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/zh_CN/messages.json
@@ -87,6 +87,10 @@
     "message": "更新网站设置失败。",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "打开 wBlock 以完成过滤器应用。",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "此页面无法使用元素清除器。",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "不支持",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "不可用",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "正在检查…",

--- a/wBlock Scripts (iOS)/Resources/_locales/zh_TW/messages.json
+++ b/wBlock Scripts (iOS)/Resources/_locales/zh_TW/messages.json
@@ -87,6 +87,10 @@
     "message": "更新網站設定失敗。",
     "description": "Error shown when popup fails to update per-site enabled state."
   },
+  "popup_warning_open_app_to_apply": {
+    "message": "請開啟 wBlock 以完成套用過濾器。",
+    "description": "Warning shown when the site toggle persisted but a full filter apply is still required."
+  },
   "popup_error_zapper_unavailable": {
     "message": "此頁面無法使用元素消除器。",
     "description": "Error shown when zapper cannot be activated on the current tab."
@@ -102,6 +106,10 @@
   "popup_status_unsupported": {
     "message": "不支援",
     "description": "Status label indicating current page does not support popup actions."
+  },
+  "popup_status_unavailable": {
+    "message": "無法使用",
+    "description": "Status label indicating the current site setting could not be read."
   },
   "popup_status_checking": {
     "message": "檢查中…",

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.html
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.html
@@ -29,7 +29,7 @@
             <div class="toggle-row">
                 <div id="enable-title" class="label" data-i18n="popup_enable_on_site">Enable on this site</div>
                 <label class="switch" for="enable-toggle">
-                    <input id="enable-toggle" type="checkbox" aria-labelledby="enable-title" />
+                    <input id="enable-toggle" type="checkbox" aria-labelledby="enable-title" disabled />
                     <span class="slider" aria-hidden="true"></span>
                 </label>
             </div>

--- a/wBlock Scripts (iOS)/Resources/pages/popup/popup.js
+++ b/wBlock Scripts (iOS)/Resources/pages/popup/popup.js
@@ -581,6 +581,8 @@ let currentZapperRules = [];
 let currentPageUserScripts = [];
 let host = '';
 let tab = null;
+let siteToggleGeneration = 0;
+let siteToggleInFlight = false;
 
 const DISCLOSURE_DURATION_MS = 200;
 
@@ -816,6 +818,15 @@ async function getSiteDisabledState(host) {
         console.error('[wBlock] Failed to get disabled state:', error);
         return null;
     }
+}
+
+async function readSiteDisabledStateAfterTimeout(targetHost) {
+    let actuallyDisabled = await getSiteDisabledState(targetHost);
+    for (let attempt = 0; attempt < 2 && typeof actuallyDisabled !== 'boolean'; attempt += 1) {
+        await sleep(300);
+        actuallyDisabled = await getSiteDisabledState(targetHost);
+    }
+    return actuallyDisabled;
 }
 
 async function setSiteDisabledState(host, disabled) {
@@ -1348,52 +1359,77 @@ function setupListeners() {
 
     if (disableToggle) {
         disableToggle.addEventListener('change', async () => {
+            const generation = ++siteToggleGeneration;
+            siteToggleInFlight = true;
             const next = !disableToggle.checked;
+            const previousChecked = !disableToggle.checked;
+            const targetHost = host;
+            const targetTab = tab;
             try {
+                if (!targetHost) {
+                    disableToggle.checked = previousChecked;
+                    return;
+                }
+
                 setError('');
                 disableToggle.disabled = true;
                 setStatus(next
                     ? t('popup_status_disabling', undefined, 'Disabling…')
                     : t('popup_status_enabling', undefined, 'Enabling…'), 'neutral');
-                const updateResult = await setSiteDisabledState(host, next);
+                const updateResult = await setSiteDisabledState(targetHost, next);
                 try {
                     await browser.runtime.sendMessage({ action: 'wblock:clearCache' });
                 } catch (error) {
                     console.warn('[wBlock] Failed to clear configuration cache:', error);
                 }
-                const settleMs = updateResult && updateResult.failedTargets > 0 ? 1200 : 350;
-                await sleep(settleMs);
+                const failedTargets = Number(updateResult && updateResult.failedTargets) || 0;
+                const requiresFullApply = Boolean(updateResult && updateResult.requiresFullApply);
+                if (requiresFullApply) {
+                    setError(t(
+                        'popup_warning_open_app_to_apply',
+                        undefined,
+                        'Open wBlock to finish applying filters.'
+                    ));
+                } else if (failedTargets > 0) {
+                    setError(t('popup_error_update_site_setting', undefined, 'Failed to update site setting.'));
+                }
+                disableToggle.checked = !next;
                 setStatus(next
                     ? t('popup_status_disabled', undefined, 'Disabled')
                     : t('popup_status_active', undefined, 'Active'),
                 next ? 'disabled' : 'active');
-                await reloadActiveTab(tab.id);
+                await reloadActiveTab(targetTab && targetTab.id);
             } catch (error) {
                 console.error('[wBlock] Failed to update disabled state:', error);
                 // The native write can finish after the popup times out. Re-read
                 // the authoritative state before treating this as a hard failure.
+                let actuallyDisabled = null;
                 try {
-                    const actuallyDisabled = await getSiteDisabledState(host);
-                    if (typeof actuallyDisabled === 'boolean' && actuallyDisabled === next) {
-                        disableToggle.checked = !actuallyDisabled;
+                    actuallyDisabled = await readSiteDisabledStateAfterTimeout(targetHost);
+                } catch (reconcileError) {
+                    console.warn('[wBlock] Failed to reconcile site setting after error:', reconcileError);
+                    actuallyDisabled = null;
+                }
+                if (typeof actuallyDisabled === 'boolean') {
+                    disableToggle.checked = !actuallyDisabled;
+                    if (actuallyDisabled === next) {
                         setStatus(next
                             ? t('popup_status_disabled', undefined, 'Disabled')
                             : t('popup_status_active', undefined, 'Active'),
                         next ? 'disabled' : 'active');
-                        await reloadActiveTab(tab && tab.id);
+                        await reloadActiveTab(targetTab && targetTab.id);
                         return;
                     }
-                    disableToggle.checked = typeof actuallyDisabled === 'boolean'
-                        ? !actuallyDisabled
-                        : next;
-                } catch (reconcileError) {
-                    console.warn('[wBlock] Failed to reconcile site setting after error:', reconcileError);
-                    disableToggle.checked = next;
+                } else {
+                    disableToggle.checked = previousChecked;
                 }
                 setError(t('popup_error_update_site_setting', undefined, 'Failed to update site setting.'));
                 setStatus(t('popup_status_error', undefined, 'Error'), 'error');
             } finally {
-                disableToggle.disabled = false;
+                if (generation === siteToggleGeneration) {
+                    siteToggleInFlight = false;
+                    disableToggle.disabled = false;
+                }
             }
         });
     }
@@ -1610,7 +1646,10 @@ function setupListeners() {
 }
 
 async function refreshUi() {
-    setError('');
+    const generationAtStart = siteToggleGeneration;
+    if (!siteToggleInFlight) {
+        setError('');
+    }
     const isMac = await isMacPlatform();
     const updateFiltersButton = document.getElementById('update-filters');
     if (updateFiltersButton) updateFiltersButton.hidden = !isMac;
@@ -1717,10 +1756,16 @@ async function refreshUi() {
         filtersPaused && userScriptsPaused && zapperPaused
     );
     const siteDisabled = disabled === true;
+    const siteDisabledUnknown = disabled === null;
+    const skipSiteToggleCommit = siteToggleInFlight || generationAtStart !== siteToggleGeneration;
     const zapperRulesDisabled = zapperState.disabled === true;
     if (disableToggle) {
-        disableToggle.checked = !siteDisabled;
-        disableToggle.disabled = filtersPaused;
+        if (siteDisabledUnknown) {
+            disableToggle.disabled = true;
+        } else if (!skipSiteToggleCommit) {
+            disableToggle.checked = !siteDisabled;
+            disableToggle.disabled = filtersPaused;
+        }
     }
     if (pausedPrompt) pausedPrompt.hidden = !blockingPaused;
     if (resumeButton) resumeButton.hidden = !(blockingPaused && resumeAvailable);
@@ -1746,16 +1791,23 @@ async function refreshUi() {
     }
     noAutoplaySiteDisabled = siteDisabled;
     updateNoAutoplayControls(noAutoplayState, { host, siteDisabled });
-    setStatus(
-        blockingPaused && !partiallyPaused
-            ? t('popup_status_paused', undefined, 'Paused')
-            : blockingPaused
-                ? t('popup_status_partially_paused', undefined, 'Partially Paused')
-                : siteDisabled
-                    ? t('popup_status_disabled', undefined, 'Disabled')
-                    : t('popup_status_active', undefined, 'Active'),
-        blockingPaused || siteDisabled ? 'disabled' : 'active'
-    );
+    const shouldCommitSiteStatus = !skipSiteToggleCommit || blockingPaused;
+    if (shouldCommitSiteStatus) {
+        if (siteDisabledUnknown && !blockingPaused) {
+            setStatus(t('popup_status_unavailable', undefined, 'Unavailable'), 'neutral');
+        } else {
+            setStatus(
+                blockingPaused && !partiallyPaused
+                    ? t('popup_status_paused', undefined, 'Paused')
+                    : blockingPaused
+                        ? t('popup_status_partially_paused', undefined, 'Partially Paused')
+                        : siteDisabled
+                            ? t('popup_status_disabled', undefined, 'Disabled')
+                            : t('popup_status_active', undefined, 'Active'),
+                blockingPaused || siteDisabled ? 'disabled' : 'active'
+            );
+        }
+    }
 
     if (zapperActivate) {
         zapperActivate.disabled = siteDisabled || zapperPaused || zapperRulesDisabled;

--- a/wBlock/AppFilterManager+DisabledSites.swift
+++ b/wBlock/AppFilterManager+DisabledSites.swift
@@ -1,6 +1,11 @@
 import Foundation
 import wBlockCoreService
 
+@MainActor
+private var disabledSitesApplyRetryTask: Task<Void, Never>?
+@MainActor
+private var disabledSitesApplyRetryID: UUID?
+
 extension AppFilterManager {
     /// Sets up an observer to automatically rebuild content blockers when disabled sites change
     func setupDisabledSitesObserver() {
@@ -55,6 +60,13 @@ extension AppFilterManager {
         let currentDisabledSites = effectiveFilterDisabledSites()
 
         if currentDisabledSites != lastKnownDisabledSites {
+            if ContentBlockerService.isDisabledSitesApplyInProgress(
+                groupIdentifier: GroupIdentifier.shared.value
+            ) {
+                scheduleDisabledSitesApplyRetry()
+                return
+            }
+
             await ConcurrentLogManager.shared.info(
                 .whitelist, LocalizedStrings.text("Disabled sites changed, fast rebuilding content blockers"),
                 metadata: [
@@ -69,6 +81,30 @@ extension AppFilterManager {
             } else {
                 lastKnownDisabledSites = currentDisabledSites
             }
+        }
+    }
+
+    /// Retries the directory-monitor check after an extension-owned site toggle
+    /// has had time to finish its Safari reload. Replacing the task coalesces
+    /// repeated filesystem events without marking the app state dirty.
+    private func scheduleDisabledSitesApplyRetry() {
+        let retryID = UUID()
+        disabledSitesApplyRetryTask?.cancel()
+        disabledSitesApplyRetryID = retryID
+        disabledSitesApplyRetryTask = Task { @MainActor [weak self] in
+            defer {
+                if disabledSitesApplyRetryID == retryID {
+                    disabledSitesApplyRetryTask = nil
+                    disabledSitesApplyRetryID = nil
+                }
+            }
+            do {
+                try await Task.sleep(nanoseconds: 2_000_000_000)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            await self?.checkForDisabledSitesChanges()
         }
     }
 

--- a/wBlock/AppFilterManager+DisabledSites.swift
+++ b/wBlock/AppFilterManager+DisabledSites.swift
@@ -3,8 +3,6 @@ import wBlockCoreService
 
 @MainActor
 private var disabledSitesApplyRetryTask: Task<Void, Never>?
-@MainActor
-private var disabledSitesApplyRetryID: UUID?
 
 extension AppFilterManager {
     /// Sets up an observer to automatically rebuild content blockers when disabled sites change
@@ -88,21 +86,9 @@ extension AppFilterManager {
     /// has had time to finish its Safari reload. Replacing the task coalesces
     /// repeated filesystem events without marking the app state dirty.
     private func scheduleDisabledSitesApplyRetry() {
-        let retryID = UUID()
         disabledSitesApplyRetryTask?.cancel()
-        disabledSitesApplyRetryID = retryID
         disabledSitesApplyRetryTask = Task { @MainActor [weak self] in
-            defer {
-                if disabledSitesApplyRetryID == retryID {
-                    disabledSitesApplyRetryTask = nil
-                    disabledSitesApplyRetryID = nil
-                }
-            }
-            do {
-                try await Task.sleep(nanoseconds: 2_000_000_000)
-            } catch {
-                return
-            }
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
             guard !Task.isCancelled else { return }
             await self?.checkForDisabledSitesChanges()
         }

--- a/wBlockCoreService/WebExtensionRequestHandler.swift
+++ b/wBlockCoreService/WebExtensionRequestHandler.swift
@@ -796,8 +796,6 @@ public enum WebExtensionRequestHandler {
             )
         }
 
-        // Keep the existing cross-process ownership stamp alive through Safari's retry window.
-        ContentBlockerService.refreshDisabledSitesApplyInProgress(groupIdentifier: groupID)
         let results = await reloadTargetsWithRetry(targetsToReload)
         return (
             reloadedTargets: results.reloadedTargets,

--- a/wBlockCoreService/WebExtensionRequestHandler.swift
+++ b/wBlockCoreService/WebExtensionRequestHandler.swift
@@ -439,7 +439,8 @@ public enum WebExtensionRequestHandler {
                     "reloadDurationMs": 0,
                     "reloadedTargets": 0,
                     "skippedTargets": 0,
-                    "failedTargets": 0
+                    "failedTargets": 0,
+                    "requiresFullApply": false
                 ])
                 context.completeRequest(returningItems: [response])
                 return
@@ -485,7 +486,8 @@ public enum WebExtensionRequestHandler {
                 "reloadDurationMs": applyDurationMs,
                 "reloadedTargets": summary.reloadedTargets,
                 "skippedTargets": summary.skippedTargets,
-                "failedTargets": summary.failedTargets
+                "failedTargets": summary.failedTargets,
+                "requiresFullApply": summary.requiresFullApply
             ])
             context.completeRequest(returningItems: [response])
         }
@@ -748,72 +750,100 @@ public enum WebExtensionRequestHandler {
     private static func applyDisabledSitesFastPath(disabledSites: [String], platform: Platform) async -> (
         reloadedTargets: Int,
         skippedTargets: Int,
-        failedTargets: Int
+        failedTargets: Int,
+        requiresFullApply: Bool
     ) {
         let groupID = GroupIdentifier.shared.value
+        ContentBlockerService.markDisabledSitesApplyStarted(groupIdentifier: groupID)
+        defer {
+            ContentBlockerService.markDisabledSitesApplyFinished(groupIdentifier: groupID)
+        }
+
         let targets = ContentBlockerTargetManager.shared.allTargets(forPlatform: platform)
 
-        // Update JSON for all targets, then only reload targets that actually have rules.
+        // Update JSON for all targets, then reload only outputs whose bytes changed.
         var targetsToReload: [ContentBlockerTargetInfo] = []
         var updateFailures = 0
+        var fullApplyTargets = 0
         for target in targets {
             do {
-                let updateResult = try ContentBlockerService.fastUpdateDisabledSites(
+                let updateResult = try ContentBlockerService.fastUpdateDisabledSitesWithOutputChange(
                     groupIdentifier: groupID,
                     targetRulesFilename: target.rulesFilename,
                     disabledSites: disabledSites
                 )
-                if updateResult.safariRulesCount > 0 {
+                if updateResult.outputChanged {
                     targetsToReload.append(target)
                 }
+            } catch let error as CocoaError where error.code == .fileReadCorruptFile {
+                fullApplyTargets += 1
             } catch {
                 updateFailures += 1
             }
         }
 
-        let skippedTargets = max(targets.count - targetsToReload.count - updateFailures, 0)
+        let unchangedTargets = max(
+            targets.count - targetsToReload.count - updateFailures - fullApplyTargets,
+            0
+        )
         guard !targetsToReload.isEmpty else {
-            return (reloadedTargets: 0, skippedTargets: skippedTargets, failedTargets: updateFailures)
+            return (
+                reloadedTargets: 0,
+                skippedTargets: unchangedTargets,
+                failedTargets: updateFailures,
+                requiresFullApply: fullApplyTargets > 0
+            )
         }
 
         let results = await reloadTargetsWithRetry(targetsToReload)
         return (
             reloadedTargets: results.reloadedTargets,
-            skippedTargets: skippedTargets,
-            failedTargets: results.failedTargets + updateFailures
+            skippedTargets: unchangedTargets + results.skippedTargets,
+            failedTargets: results.failedTargets + updateFailures,
+            requiresFullApply: fullApplyTargets > 0
         )
     }
 
     private static func reloadTargetsWithRetry(_ targets: [ContentBlockerTargetInfo]) async -> (
         reloadedTargets: Int,
+        skippedTargets: Int,
         failedTargets: Int
     ) {
         let groupID = GroupIdentifier.shared.value
         // Safari reloads distinct content blocker identifiers independently, so reload
-        // them concurrently instead of serially. Behind the popup's 5s toggle timeout
+        // them concurrently instead of serially. Behind the popup's 10s toggle timeout
         // a sequential loop (`for target in targets { await ... }`) was the dominant
         // cost and the reason Disable-on-this-site intermittently reported failure on
         // profiles with several selected filter lists.
-        return await withTaskGroup(of: Bool.self) { group in
+        return await withTaskGroup(of: ContentBlockerService.ReloadAttemptResult.self) { group in
             for target in targets {
                 group.addTask {
-                    await ContentBlockerService.reloadWithRetry(
+                    await ContentBlockerService.reloadIfNeeded(
                         identifier: target.bundleIdentifier,
-                        groupIdentifier: groupID,
-                        targetRulesFilename: target.rulesFilename
-                    ).success
+                        targetRulesFilename: target.rulesFilename,
+                        groupIdentifier: groupID
+                    )
                 }
             }
             var reloadedTargets = 0
+            var skippedTargets = 0
             var failedTargets = 0
-            for await success in group {
-                if success {
-                    reloadedTargets += 1
+            for await result in group {
+                if result.success {
+                    if result.skipped {
+                        skippedTargets += 1
+                    } else {
+                        reloadedTargets += 1
+                    }
                 } else {
                     failedTargets += 1
                 }
             }
-            return (reloadedTargets: reloadedTargets, failedTargets: failedTargets)
+            return (
+                reloadedTargets: reloadedTargets,
+                skippedTargets: skippedTargets,
+                failedTargets: failedTargets
+            )
         }
     }
 

--- a/wBlockCoreService/WebExtensionRequestHandler.swift
+++ b/wBlockCoreService/WebExtensionRequestHandler.swift
@@ -446,6 +446,12 @@ public enum WebExtensionRequestHandler {
                 return
             }
 
+            let groupID = GroupIdentifier.shared.value
+            ContentBlockerService.markDisabledSitesApplyStarted(groupIdentifier: groupID)
+            defer {
+                ContentBlockerService.markDisabledSitesApplyFinished(groupIdentifier: groupID)
+            }
+
             await ProtobufDataManager.shared.setWhitelistedDomains(list)
 
             // Regenerate RemoveParam DNR rules detached from the response: they are read
@@ -754,11 +760,6 @@ public enum WebExtensionRequestHandler {
         requiresFullApply: Bool
     ) {
         let groupID = GroupIdentifier.shared.value
-        ContentBlockerService.markDisabledSitesApplyStarted(groupIdentifier: groupID)
-        defer {
-            ContentBlockerService.markDisabledSitesApplyFinished(groupIdentifier: groupID)
-        }
-
         let targets = ContentBlockerTargetManager.shared.allTargets(forPlatform: platform)
 
         // Update JSON for all targets, then reload only outputs whose bytes changed.
@@ -795,6 +796,8 @@ public enum WebExtensionRequestHandler {
             )
         }
 
+        // Keep the existing cross-process ownership stamp alive through Safari's retry window.
+        ContentBlockerService.refreshDisabledSitesApplyInProgress(groupIdentifier: groupID)
         let results = await reloadTargetsWithRetry(targetsToReload)
         return (
             reloadedTargets: results.reloadedTargets,

--- a/wBlockCoreService/wBlockCoreService.swift
+++ b/wBlockCoreService/wBlockCoreService.swift
@@ -536,6 +536,8 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adSlots', 'undefin
 
     private static let reloadMarkerSchema = 1
     private static let reloadMarkerFileSuffix = ".reload-marker.json"
+    private static let disabledSitesApplyInProgressFilename = ".disabled-sites-apply-in-progress"
+    private static let disabledSitesApplyInProgressMaximumAge: TimeInterval = 20
     private static let maxReloadVerificationPasses = 3
     private static let reloadCoordinator = ReloadCoordinator()
 
@@ -547,13 +549,13 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adSlots', 'undefin
         #endif
         let os = ProcessInfo.processInfo.operatingSystemVersion
         let osVersion = "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)"
-        let info = Bundle.main.infoDictionary ?? [:]
+        // Markers are shared by the app and Scripts extension processes, whose bundle versions can differ.
         return ReloadContext(
             schema: reloadMarkerSchema,
             platform: platform,
             osVersion: osVersion,
-            appVersion: info["CFBundleShortVersionString"] as? String ?? "",
-            appBuild: info["CFBundleVersion"] as? String ?? ""
+            appVersion: "",
+            appBuild: ""
         )
     }
 
@@ -564,6 +566,45 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adSlots', 'undefin
         containerURL.appendingPathComponent(
             "\(targetRulesFilename)\(reloadMarkerFileSuffix)"
         )
+    }
+
+    private static func disabledSitesApplyInProgressURL(groupIdentifier: String) -> URL? {
+        FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: groupIdentifier
+        )?.appendingPathComponent(disabledSitesApplyInProgressFilename)
+    }
+
+    /// Marks a Scripts-extension disabled-sites update as active so the containing
+    /// app does not begin a concurrent reload before Safari finishes the first one.
+    public static func markDisabledSitesApplyStarted(groupIdentifier: String) {
+        guard let stampURL = disabledSitesApplyInProgressURL(groupIdentifier: groupIdentifier) else {
+            return
+        }
+        let timestamp = String(Date().timeIntervalSince1970)
+        try? Data(timestamp.utf8).write(to: stampURL, options: .atomic)
+    }
+
+    /// Clears the cross-process disabled-sites update marker.
+    public static func markDisabledSitesApplyFinished(groupIdentifier: String) {
+        guard let stampURL = disabledSitesApplyInProgressURL(groupIdentifier: groupIdentifier) else {
+            return
+        }
+        try? FileManager.default.removeItem(at: stampURL)
+    }
+
+    /// Returns whether a Scripts-extension disabled-sites update started recently.
+    /// A stale or malformed stamp is ignored so a terminated extension cannot
+    /// block later app-side updates indefinitely.
+    public static func isDisabledSitesApplyInProgress(groupIdentifier: String) -> Bool {
+        guard let stampURL = disabledSitesApplyInProgressURL(groupIdentifier: groupIdentifier),
+              let timestampData = try? Data(contentsOf: stampURL),
+              let timestampString = String(data: timestampData, encoding: .utf8),
+              let timestamp = TimeInterval(timestampString.trimmingCharacters(in: .whitespacesAndNewlines))
+        else {
+            return false
+        }
+        let age = Date().timeIntervalSince1970 - timestamp
+        return age >= 0 && age < disabledSitesApplyInProgressMaximumAge
     }
 
     private static func validOutputDigest(_ data: Data?) -> String? {

--- a/wBlockCoreService/wBlockCoreService.swift
+++ b/wBlockCoreService/wBlockCoreService.swift
@@ -537,9 +537,31 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adSlots', 'undefin
     private static let reloadMarkerSchema = 1
     private static let reloadMarkerFileSuffix = ".reload-marker.json"
     private static let disabledSitesApplyInProgressFilename = ".disabled-sites-apply-in-progress"
-    private static let disabledSitesApplyInProgressMaximumAge: TimeInterval = 20
+    private static let disabledSitesApplyInProgressLockFilename = ".disabled-sites-apply-in-progress.lock"
+    // Five total attempts can each wait reloadCompletionTimeout; retain one extra timeout as margin.
+    private static let disabledSitesApplyInProgressMaximumAge: TimeInterval = reloadCompletionTimeout * 6
+    private static let disabledSitesApplyInProgressLockTimeout: TimeInterval = 2
+    private static let reloadContextAppVersionKey = "wBlock.reloadContext.appVersion"
+    private static let reloadContextAppBuildKey = "wBlock.reloadContext.appBuild"
     private static let maxReloadVerificationPasses = 3
     private static let reloadCoordinator = ReloadCoordinator()
+
+    /// Uses the containing app as the sole publisher so all app-group processes
+    /// compare reload markers against the same app upgrade identity.
+    private static func sharedReloadIdentity() -> (appVersion: String, appBuild: String) {
+        let defaults = UserDefaults(suiteName: GroupIdentifier.shared.value)
+        if Bundle.main.bundleIdentifier == "skula.wBlock" {
+            let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+            let appBuild = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
+            defaults?.set(appVersion, forKey: reloadContextAppVersionKey)
+            defaults?.set(appBuild, forKey: reloadContextAppBuildKey)
+            return (appVersion, appBuild)
+        }
+        return (
+            defaults?.string(forKey: reloadContextAppVersionKey) ?? "",
+            defaults?.string(forKey: reloadContextAppBuildKey) ?? ""
+        )
+    }
 
     private static var currentReloadContext: ReloadContext {
         #if os(iOS)
@@ -549,13 +571,13 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adSlots', 'undefin
         #endif
         let os = ProcessInfo.processInfo.operatingSystemVersion
         let osVersion = "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)"
-        // Markers are shared by the app and Scripts extension processes, whose bundle versions can differ.
+        let identity = sharedReloadIdentity()
         return ReloadContext(
             schema: reloadMarkerSchema,
             platform: platform,
             osVersion: osVersion,
-            appVersion: "",
-            appBuild: ""
+            appVersion: identity.appVersion,
+            appBuild: identity.appBuild
         )
     }
 
@@ -574,22 +596,119 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adSlots', 'undefin
         )?.appendingPathComponent(disabledSitesApplyInProgressFilename)
     }
 
+    private struct DisabledSitesApplyInProgressStamp: Codable {
+        let startedAt: TimeInterval
+        let count: Int
+    }
+
+    private static func disabledSitesApplyInProgressStamp(at url: URL) -> DisabledSitesApplyInProgressStamp? {
+        guard let data = try? Data(contentsOf: url) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(DisabledSitesApplyInProgressStamp.self, from: data)
+    }
+
+    private static func isDisabledSitesApplyInProgressStampFresh(
+        _ stamp: DisabledSitesApplyInProgressStamp,
+        now: TimeInterval
+    ) -> Bool {
+        let age = now - stamp.startedAt
+        return age >= 0 && age < disabledSitesApplyInProgressMaximumAge
+    }
+
+    private static func writeDisabledSitesApplyInProgressStamp(
+        _ stamp: DisabledSitesApplyInProgressStamp,
+        to url: URL
+    ) {
+        guard let data = try? JSONEncoder().encode(stamp) else {
+            return
+        }
+        try? data.write(to: url, options: .atomic)
+    }
+
+    private static func withDisabledSitesApplyInProgressLock(
+        at stampURL: URL,
+        _ body: () -> Void
+    ) {
+        let lockURL = stampURL.deletingLastPathComponent()
+            .appendingPathComponent(disabledSitesApplyInProgressLockFilename)
+        guard let fileLock = FileLock(filePath: lockURL.path),
+              fileLock.lock(before: Date().addingTimeInterval(disabledSitesApplyInProgressLockTimeout))
+        else {
+            return
+        }
+        defer { _ = fileLock.unlock() }
+        body()
+    }
+
     /// Marks a Scripts-extension disabled-sites update as active so the containing
     /// app does not begin a concurrent reload before Safari finishes the first one.
     public static func markDisabledSitesApplyStarted(groupIdentifier: String) {
         guard let stampURL = disabledSitesApplyInProgressURL(groupIdentifier: groupIdentifier) else {
             return
         }
-        let timestamp = String(Date().timeIntervalSince1970)
-        try? Data(timestamp.utf8).write(to: stampURL, options: .atomic)
+
+        withDisabledSitesApplyInProgressLock(at: stampURL) {
+            let now = Date().timeIntervalSince1970
+            let count: Int
+            if let stamp = disabledSitesApplyInProgressStamp(at: stampURL),
+               isDisabledSitesApplyInProgressStampFresh(stamp, now: now) {
+                count = stamp.count + 1
+            } else {
+                count = 1
+            }
+            writeDisabledSitesApplyInProgressStamp(
+                DisabledSitesApplyInProgressStamp(startedAt: now, count: count),
+                to: stampURL
+            )
+        }
     }
 
-    /// Clears the cross-process disabled-sites update marker.
+    /// Refreshes an existing Scripts-extension disabled-sites update marker without
+    /// changing its refcount, extending it through Safari's reload retry window.
+    public static func refreshDisabledSitesApplyInProgress(groupIdentifier: String) {
+        guard let stampURL = disabledSitesApplyInProgressURL(groupIdentifier: groupIdentifier) else {
+            return
+        }
+
+        withDisabledSitesApplyInProgressLock(at: stampURL) {
+            let now = Date().timeIntervalSince1970
+            guard let stamp = disabledSitesApplyInProgressStamp(at: stampURL),
+                  isDisabledSitesApplyInProgressStampFresh(stamp, now: now)
+            else {
+                return
+            }
+            writeDisabledSitesApplyInProgressStamp(
+                DisabledSitesApplyInProgressStamp(startedAt: now, count: stamp.count),
+                to: stampURL
+            )
+        }
+    }
+
+    /// Clears one active Scripts-extension disabled-sites update marker.
     public static func markDisabledSitesApplyFinished(groupIdentifier: String) {
         guard let stampURL = disabledSitesApplyInProgressURL(groupIdentifier: groupIdentifier) else {
             return
         }
-        try? FileManager.default.removeItem(at: stampURL)
+
+        withDisabledSitesApplyInProgressLock(at: stampURL) {
+            let now = Date().timeIntervalSince1970
+            guard let stamp = disabledSitesApplyInProgressStamp(at: stampURL),
+                  isDisabledSitesApplyInProgressStampFresh(stamp, now: now)
+            else {
+                try? FileManager.default.removeItem(at: stampURL)
+                return
+            }
+
+            guard stamp.count > 1 else {
+                try? FileManager.default.removeItem(at: stampURL)
+                return
+            }
+            writeDisabledSitesApplyInProgressStamp(
+                DisabledSitesApplyInProgressStamp(startedAt: stamp.startedAt, count: stamp.count - 1),
+                to: stampURL
+            )
+        }
     }
 
     /// Returns whether a Scripts-extension disabled-sites update started recently.
@@ -597,13 +716,23 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adSlots', 'undefin
     /// block later app-side updates indefinitely.
     public static func isDisabledSitesApplyInProgress(groupIdentifier: String) -> Bool {
         guard let stampURL = disabledSitesApplyInProgressURL(groupIdentifier: groupIdentifier),
-              let timestampData = try? Data(contentsOf: stampURL),
-              let timestampString = String(data: timestampData, encoding: .utf8),
+              let data = try? Data(contentsOf: stampURL)
+        else {
+            return false
+        }
+
+        let now = Date().timeIntervalSince1970
+        if let stamp = try? JSONDecoder().decode(DisabledSitesApplyInProgressStamp.self, from: data) {
+            return isDisabledSitesApplyInProgressStampFresh(stamp, now: now)
+        }
+
+        // Recognize a recent stamp from older builds until their in-flight apply ends.
+        guard let timestampString = String(data: data, encoding: .utf8),
               let timestamp = TimeInterval(timestampString.trimmingCharacters(in: .whitespacesAndNewlines))
         else {
             return false
         }
-        let age = Date().timeIntervalSince1970 - timestamp
+        let age = now - timestamp
         return age >= 0 && age < disabledSitesApplyInProgressMaximumAge
     }
 

--- a/wBlockCoreService/wBlockCoreService.swift
+++ b/wBlockCoreService/wBlockCoreService.swift
@@ -537,10 +537,8 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adSlots', 'undefin
     private static let reloadMarkerSchema = 1
     private static let reloadMarkerFileSuffix = ".reload-marker.json"
     private static let disabledSitesApplyInProgressFilename = ".disabled-sites-apply-in-progress"
-    private static let disabledSitesApplyInProgressLockFilename = ".disabled-sites-apply-in-progress.lock"
     // Five total attempts can each wait reloadCompletionTimeout; retain one extra timeout as margin.
     private static let disabledSitesApplyInProgressMaximumAge: TimeInterval = reloadCompletionTimeout * 6
-    private static let disabledSitesApplyInProgressLockTimeout: TimeInterval = 2
     private static let reloadContextAppVersionKey = "wBlock.reloadContext.appVersion"
     private static let reloadContextAppBuildKey = "wBlock.reloadContext.appBuild"
     private static let maxReloadVerificationPasses = 3
@@ -596,119 +594,23 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adSlots', 'undefin
         )?.appendingPathComponent(disabledSitesApplyInProgressFilename)
     }
 
-    private struct DisabledSitesApplyInProgressStamp: Codable {
-        let startedAt: TimeInterval
-        let count: Int
-    }
-
-    private static func disabledSitesApplyInProgressStamp(at url: URL) -> DisabledSitesApplyInProgressStamp? {
-        guard let data = try? Data(contentsOf: url) else {
-            return nil
-        }
-        return try? JSONDecoder().decode(DisabledSitesApplyInProgressStamp.self, from: data)
-    }
-
-    private static func isDisabledSitesApplyInProgressStampFresh(
-        _ stamp: DisabledSitesApplyInProgressStamp,
-        now: TimeInterval
-    ) -> Bool {
-        let age = now - stamp.startedAt
-        return age >= 0 && age < disabledSitesApplyInProgressMaximumAge
-    }
-
-    private static func writeDisabledSitesApplyInProgressStamp(
-        _ stamp: DisabledSitesApplyInProgressStamp,
-        to url: URL
-    ) {
-        guard let data = try? JSONEncoder().encode(stamp) else {
-            return
-        }
-        try? data.write(to: url, options: .atomic)
-    }
-
-    private static func withDisabledSitesApplyInProgressLock(
-        at stampURL: URL,
-        _ body: () -> Void
-    ) {
-        let lockURL = stampURL.deletingLastPathComponent()
-            .appendingPathComponent(disabledSitesApplyInProgressLockFilename)
-        guard let fileLock = FileLock(filePath: lockURL.path),
-              fileLock.lock(before: Date().addingTimeInterval(disabledSitesApplyInProgressLockTimeout))
-        else {
-            return
-        }
-        defer { _ = fileLock.unlock() }
-        body()
-    }
-
     /// Marks a Scripts-extension disabled-sites update as active so the containing
     /// app does not begin a concurrent reload before Safari finishes the first one.
     public static func markDisabledSitesApplyStarted(groupIdentifier: String) {
-        guard let stampURL = disabledSitesApplyInProgressURL(groupIdentifier: groupIdentifier) else {
+        guard let stampURL = disabledSitesApplyInProgressURL(groupIdentifier: groupIdentifier),
+              let timestamp = String(Date().timeIntervalSince1970).data(using: .utf8)
+        else {
             return
         }
-
-        withDisabledSitesApplyInProgressLock(at: stampURL) {
-            let now = Date().timeIntervalSince1970
-            let count: Int
-            if let stamp = disabledSitesApplyInProgressStamp(at: stampURL),
-               isDisabledSitesApplyInProgressStampFresh(stamp, now: now) {
-                count = stamp.count + 1
-            } else {
-                count = 1
-            }
-            writeDisabledSitesApplyInProgressStamp(
-                DisabledSitesApplyInProgressStamp(startedAt: now, count: count),
-                to: stampURL
-            )
-        }
+        try? timestamp.write(to: stampURL, options: .atomic)
     }
 
-    /// Refreshes an existing Scripts-extension disabled-sites update marker without
-    /// changing its refcount, extending it through Safari's reload retry window.
-    public static func refreshDisabledSitesApplyInProgress(groupIdentifier: String) {
-        guard let stampURL = disabledSitesApplyInProgressURL(groupIdentifier: groupIdentifier) else {
-            return
-        }
-
-        withDisabledSitesApplyInProgressLock(at: stampURL) {
-            let now = Date().timeIntervalSince1970
-            guard let stamp = disabledSitesApplyInProgressStamp(at: stampURL),
-                  isDisabledSitesApplyInProgressStampFresh(stamp, now: now)
-            else {
-                return
-            }
-            writeDisabledSitesApplyInProgressStamp(
-                DisabledSitesApplyInProgressStamp(startedAt: now, count: stamp.count),
-                to: stampURL
-            )
-        }
-    }
-
-    /// Clears one active Scripts-extension disabled-sites update marker.
+    /// Clears the Scripts-extension disabled-sites update marker.
     public static func markDisabledSitesApplyFinished(groupIdentifier: String) {
         guard let stampURL = disabledSitesApplyInProgressURL(groupIdentifier: groupIdentifier) else {
             return
         }
-
-        withDisabledSitesApplyInProgressLock(at: stampURL) {
-            let now = Date().timeIntervalSince1970
-            guard let stamp = disabledSitesApplyInProgressStamp(at: stampURL),
-                  isDisabledSitesApplyInProgressStampFresh(stamp, now: now)
-            else {
-                try? FileManager.default.removeItem(at: stampURL)
-                return
-            }
-
-            guard stamp.count > 1 else {
-                try? FileManager.default.removeItem(at: stampURL)
-                return
-            }
-            writeDisabledSitesApplyInProgressStamp(
-                DisabledSitesApplyInProgressStamp(startedAt: stamp.startedAt, count: stamp.count - 1),
-                to: stampURL
-            )
-        }
+        try? FileManager.default.removeItem(at: stampURL)
     }
 
     /// Returns whether a Scripts-extension disabled-sites update started recently.
@@ -716,23 +618,14 @@ www.youtube.com#%#//scriptlet('set-constant', 'playerResponse.adSlots', 'undefin
     /// block later app-side updates indefinitely.
     public static func isDisabledSitesApplyInProgress(groupIdentifier: String) -> Bool {
         guard let stampURL = disabledSitesApplyInProgressURL(groupIdentifier: groupIdentifier),
-              let data = try? Data(contentsOf: stampURL)
-        else {
-            return false
-        }
-
-        let now = Date().timeIntervalSince1970
-        if let stamp = try? JSONDecoder().decode(DisabledSitesApplyInProgressStamp.self, from: data) {
-            return isDisabledSitesApplyInProgressStampFresh(stamp, now: now)
-        }
-
-        // Recognize a recent stamp from older builds until their in-flight apply ends.
-        guard let timestampString = String(data: data, encoding: .utf8),
+              let data = try? Data(contentsOf: stampURL),
+              let timestampString = String(data: data, encoding: .utf8),
               let timestamp = TimeInterval(timestampString.trimmingCharacters(in: .whitespacesAndNewlines))
         else {
             return false
         }
-        let age = now - timestamp
+
+        let age = Date().timeIntervalSince1970 - timestamp
         return age >= 0 && age < disabledSitesApplyInProgressMaximumAge
     }
 


### PR DESCRIPTION
Toggling Enable on this site in the Scripts popover waited on every content blocker reload, then slept extra, and could snap back if you hit it before the popup finished loading. Site toggles now write skippable Safari reload markers, the app waits out an in-progress extension apply instead of starting a second one, and the switch stays inert until the current site is known.

Contract tests for the fast path and popup toggle passed locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Safari content-blocker reload coordination and per-site disable apply, so races or marker bugs can leave blocking stale or force extra full applies. Changes are gated by contract tests and skippable reloads.
> 
> **Overview**
> Speeds up **Enable on this site** by dropping extra settle sleeps and reloading only content-blocker outputs that actually changed, via `reloadIfNeeded` instead of always retrying every target.
> 
> The popup switch starts disabled until native state is known, uses generation/`inFlight` guards so refreshes cannot clobber an in-progress write, and reconciles timeouts by re-reading native state. Missing base-rules cache now returns `requiresFullApply` and asks the user to open wBlock; unreadable state shows **Unavailable**.
> 
> The app waits on a shared apply-in-progress stamp so it does not start a second Safari reload while the extension is still applying. Reload markers use a shared app-group identity instead of each process’s `Bundle.main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97283fca05476d308eb6b3d5529488fc669ff4ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->