### PR TITLE
Add iOS portrait orientation lock

### DIFF
--- a/scripts/test_portrait_orientation_lock.swift
+++ b/scripts/test_portrait_orientation_lock.swift
@@ -1,0 +1,70 @@
+#!/usr/bin/env swift
+import Foundation
+
+func read(_ path: String) throws -> String {
+    try String(contentsOfFile: path, encoding: .utf8)
+}
+
+func check(_ condition: Bool, _ message: String) {
+    guard condition else {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let settings = try read("wBlock/SettingsView.swift")
+let appDelegate = try read("wBlock/AppDelegate.swift")
+let lock = try read("wBlock/PortraitOrientationLock.swift")
+
+check(lock.contains("static let storageKey = \"lockPortraitOrientation\""), "must persist under lockPortraitOrientation")
+check(lock.contains("UIInterfaceOrientationMask"), "must expose an orientation mask")
+check(lock.contains(".portrait"), "locked mask must be portrait")
+check(lock.contains(".allButUpsideDown"), "iPhone unlocked mask must match Info.plist")
+check(lock.contains("userInterfaceIdiom == .pad ? .all"), "iPad unlocked mask must allow all orientations")
+check(lock.contains("requestGeometryUpdate"), "must request a geometry update when the lock changes")
+check(lock.contains("setNeedsUpdateOfSupportedInterfaceOrientations"), "must refresh supported orientations")
+check(lock.contains("attemptRotationToDeviceOrientation"), "must still rotate on iOS 15")
+
+check(appDelegate.contains("supportedInterfaceOrientationsFor"), "AppDelegate must publish the lock mask")
+check(appDelegate.contains("PortraitOrientationLock.mask"), "AppDelegate must use the shared lock mask")
+check(appDelegate.contains("PortraitOrientationLock.apply()"), "launch must apply a stored portrait lock")
+
+let displayStart = settings.range(of: "private var displaySection")
+check(displayStart != nil, "iOS settings must have a display section")
+if let displayStart {
+    let before = String(settings[..<displayStart.lowerBound])
+    check(before.contains("#if os(iOS)"), "display section must be iOS-only")
+}
+check(settings.contains("@AppStorage(PortraitOrientationLock.storageKey)"), "Settings must bind the portrait lock")
+check(settings.contains("Toggle(\"Lock Portrait Orientation\""), "Settings must expose the portrait lock toggle")
+check(settings.contains("Keeps the app in portrait even if the device is rotated."), "Settings must explain the portrait lock")
+check(settings.contains("PortraitOrientationLock.apply()"), "toggling must apply the lock immediately")
+check(settings.contains("displaySection"), "iOS settings list must include the display section")
+
+let locales = ["ar", "de", "el", "en", "es", "fr", "hu", "it", "ja", "ko", "pl", "pt-BR", "ro", "ru", "tr", "zh-Hans", "zh-Hant"]
+let keys = [
+    "Lock Portrait Orientation",
+    "Keeps the app in portrait even if the device is rotated."
+]
+var english: [String: String] = [:]
+for locale in locales {
+    let url = URL(fileURLWithPath: "wBlock/\(locale).lproj/Localizable.strings")
+    guard let table = NSDictionary(contentsOf: url) as? [String: String] else {
+        fputs("FAIL: could not parse \(locale)\n", stderr)
+        exit(1)
+    }
+    for key in keys {
+        guard let value = table[key], !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            fputs("FAIL: missing \(key) in \(locale)\n", stderr)
+            exit(1)
+        }
+        if locale == "en" {
+            english[key] = value
+        } else if value == key || value == english[key] {
+            fputs("FAIL: copied English for \(key) in \(locale)\n", stderr)
+            exit(1)
+        }
+    }
+}
+
+print("PASS")

--- a/wBlock/AppDelegate.swift
+++ b/wBlock/AppDelegate.swift
@@ -378,7 +378,12 @@ extension AppDelegate: UIApplicationDelegate {
         Task { @MainActor in
             await rescheduleBackgroundTasks(reason: "Launch")
         }
+        PortraitOrientationLock.apply()
         return true
+    }
+
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        PortraitOrientationLock.mask
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {

--- a/wBlock/PortraitOrientationLock.swift
+++ b/wBlock/PortraitOrientationLock.swift
@@ -1,0 +1,38 @@
+import Foundation
+#if os(iOS)
+import UIKit
+#endif
+
+/// Device-local preference that can pin the iOS app to portrait.
+///
+/// See GitHub issue #558. Default is unlocked so iPhone landscape and iPad
+/// rotation keep matching the supported interface orientations Info.plist keys.
+enum PortraitOrientationLock {
+    static let storageKey = "lockPortraitOrientation"
+
+    static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: storageKey)
+    }
+
+    #if os(iOS)
+    static var mask: UIInterfaceOrientationMask {
+        guard isEnabled else {
+            return UIDevice.current.userInterfaceIdiom == .pad ? .all : .allButUpsideDown
+        }
+        return .portrait
+    }
+
+    @MainActor
+    static func apply() {
+        let orientations = mask
+        if #available(iOS 16.0, *) {
+            for scene in UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }) {
+                scene.requestGeometryUpdate(.iOS(interfaceOrientations: orientations)) { _ in }
+                scene.keyWindow?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+            }
+        } else {
+            UIViewController.attemptRotationToDeviceOrientation()
+        }
+    }
+    #endif
+}

--- a/wBlock/SettingsView.swift
+++ b/wBlock/SettingsView.swift
@@ -34,6 +34,7 @@ struct SettingsView: View {
     #if os(iOS)
         @State private var backupDocument: BackupDocument? = nil
         @State private var showingExportSheet = false
+        @AppStorage(PortraitOrientationLock.storageKey) private var lockPortraitOrientation = false
     #endif
 
     // Computed properties backed by protobuf
@@ -247,6 +248,20 @@ struct SettingsView: View {
             }
         )
     }
+
+    #if os(iOS)
+    @ViewBuilder
+    private var displaySection: some View {
+        Section {
+            Toggle("Lock Portrait Orientation", isOn: $lockPortraitOrientation)
+                .onChangeCompat(of: lockPortraitOrientation) { _ in
+                    PortraitOrientationLock.apply()
+                }
+        } footer: {
+            Text("Keeps the app in portrait even if the device is rotated.")
+        }
+    }
+    #endif
 
     @ViewBuilder
     private var advancedSection: some View {
@@ -628,7 +643,7 @@ struct SettingsView: View {
         CompatibleNavigationStack {
             List {
                 pauseBlockingSection
-
+                displaySection
                 autoUpdateSection
                 syncSection
                 advancedSection

--- a/wBlock/ar.lproj/Localizable.strings
+++ b/wBlock/ar.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "الاحتفاظ بالكل";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "يُبقي المرشحات محدّثة حتى عندما لا يعمل wBlock. أوقفه لتجنب عنصر تسجيل دخول دائم؛ عندها لن يتم التحديث إلا أثناء فتح wBlock.";
+"Keeps the app in portrait even if the device is rotated." = "يُبقي التطبيق في الوضع العمودي حتى إذا تم تدوير الجهاز.";
 "Languages: %@" = "اللغات: %@";
 "Languages: \\(languageSummary)" = "اللغات: \\(languageSummary)";
 "Large file - scrolling may be slow" = "ملف كبير - قد يكون التمرير بطيئًا";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "جارٍ تحميل بيانات تعريف السكربت…";
 "Loading userscripts…" = "جارٍ تحميل سكربتات المستخدم…";
 "Local Import" = "استيراد محلي";
+"Lock Portrait Orientation" = "تثبيت الاتجاه العمودي";
 "Logs" = "السجلات";
 "Logs cleared" = "تم مسح السجلات";
 "Logs will appear here as the app runs" = "ستظهر السجلات هنا أثناء تشغيل التطبيق";

--- a/wBlock/de.lproj/Localizable.strings
+++ b/wBlock/de.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "Alle behalten";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "Hält Filter aktuell, auch wenn wBlock nicht läuft. Deaktivieren, um kein dauerhaftes Anmeldeobjekt zu verwenden; Updates laufen dann nur, während wBlock geöffnet ist.";
+"Keeps the app in portrait even if the device is rotated." = "Hält die App im Hochformat, auch wenn das Gerät gedreht wird.";
 "Languages: %@" = "Sprachen: %@";
 "Languages: \\(languageSummary)" = "Sprachen: \\(languageSummary)";
 "Large file - scrolling may be slow" = "Große Datei - Scrollen kann langsam sein";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "Skript-Metadaten werden geladen…";
 "Loading userscripts…" = "Userscripts werden geladen…";
 "Local Import" = "Lokaler Import";
+"Lock Portrait Orientation" = "Hochformat sperren";
 "Logs" = "Protokolle";
 "Logs cleared" = "Protokolle gelöscht";
 "Logs will appear here as the app runs" = "Protokolle erscheinen hier, während die App läuft";

--- a/wBlock/el.lproj/Localizable.strings
+++ b/wBlock/el.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "Διατήρηση όλων";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "Διατηρεί τα φίλτρα ενημερωμένα όταν το wBlock δεν εκτελείται. Απενεργοποιήστε το για να αποφύγετε ένα μόνιμο στοιχείο σύνδεσης· οι ενημερώσεις θα εκτελούνται τότε μόνο όσο το wBlock είναι ανοιχτό.";
+"Keeps the app in portrait even if the device is rotated." = "Διατηρεί την εφαρμογή σε κατακόρυφο προσανατολισμό, ακόμα και αν η συσκευή περιστραφεί.";
 "Languages: %@" = "Γλώσσες: %@";
 "Languages: \\(languageSummary)" = "Γλώσσες: \(languageSummary)";
 "Large file - scrolling may be slow" = "Μεγάλο αρχείο - η κύλιση μπορεί να είναι αργή";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "Φόρτωση μεταδεδομένων κώδικα…";
 "Loading userscripts…" = "Φόρτωση κώδικα χρήστη…";
 "Local Import" = "Τοπική Εισαγωγή";
+"Lock Portrait Orientation" = "Κλείδωμα κατακόρυφου προσανατολισμού";
 "Logs" = "Αρχεία Καταγραφής";
 "Logs cleared" = "Εκκαθάριση αρχείων καταγραφής";
 "Logs will appear here as the app runs" = "Τα αρχεία καταγραφής θα εμφανίζονται εδώ καθώς εκτελείται η εφαρμογή";

--- a/wBlock/en.lproj/Localizable.strings
+++ b/wBlock/en.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "Keep All";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open.";
+"Keeps the app in portrait even if the device is rotated." = "Keeps the app in portrait even if the device is rotated.";
 "Languages: %@" = "Languages: %@";
 "Languages: \\(languageSummary)" = "Languages: \\(languageSummary)";
 "Large file - scrolling may be slow" = "Large file - scrolling may be slow";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "Loading script metadata…";
 "Loading userscripts…" = "Loading userscripts…";
 "Local Import" = "Local Import";
+"Lock Portrait Orientation" = "Lock Portrait Orientation";
 "Logs" = "Logs";
 "Logs cleared" = "Logs cleared";
 "Logs will appear here as the app runs" = "Logs will appear here as the app runs";

--- a/wBlock/es.lproj/Localizable.strings
+++ b/wBlock/es.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "Conservar todo";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "Mantiene los filtros actualizados cuando wBlock no está en ejecución. Desactívalo para evitar un elemento de inicio persistente; las actualizaciones solo se ejecutarán mientras wBlock esté abierto.";
+"Keeps the app in portrait even if the device is rotated." = "Mantiene la app en vertical aunque gires el dispositivo.";
 "Languages: %@" = "Idiomas: %@";
 "Languages: \\(languageSummary)" = "Idiomas: \\(languageSummary)";
 "Large file - scrolling may be slow" = "Archivo grande: el desplazamiento puede ser lento";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "Cargando metadatos del script…";
 "Loading userscripts…" = "Cargando scripts de usuario…";
 "Local Import" = "Importación local";
+"Lock Portrait Orientation" = "Bloquear orientación vertical";
 "Logs" = "Registros";
 "Logs cleared" = "Registros borrados";
 "Logs will appear here as the app runs" = "Los registros aparecerán aquí mientras la app se ejecuta";

--- a/wBlock/fr.lproj/Localizable.strings
+++ b/wBlock/fr.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "Tout conserver";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "Maintient les filtres à jour quand wBlock n'est pas lancé. Désactivez-le pour éviter un élément d'ouverture persistant ; les mises à jour ne s'exécuteront alors que lorsque wBlock est ouvert.";
+"Keeps the app in portrait even if the device is rotated." = "Garde l’app en mode portrait même si l’appareil est tourné.";
 "Languages: %@" = "Langues : %@";
 "Languages: \\(languageSummary)" = "Langues : \\(languageSummary)";
 "Large file - scrolling may be slow" = "Fichier volumineux - le défilement peut être lent";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "Chargement des métadonnées du script…";
 "Loading userscripts…" = "Chargement des userscripts…";
 "Local Import" = "Importation locale";
+"Lock Portrait Orientation" = "Verrouiller l’orientation portrait";
 "Logs" = "Journaux";
 "Logs cleared" = "Journaux effacés";
 "Logs will appear here as the app runs" = "Les journaux apparaîtront ici pendant l'exécution de l'app";

--- a/wBlock/hu.lproj/Localizable.strings
+++ b/wBlock/hu.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "Összes megtartása";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "Naprakészen tartja a szűrőket akkor is, amikor a wBlock nem fut. Kapcsolja ki, ha nem szeretne állandó bejelentkezési elemet; a frissítések ekkor csak a wBlock megnyitása alatt futnak.";
+"Keeps the app in portrait even if the device is rotated." = "Álló helyzetben tartja az appot akkor is, ha elforgatod a készüléket.";
 "Languages: %@" = "Nyelvek: %@";
 "Languages: \\(languageSummary)" = "Nyelvek: \\(languageSummary)";
 "Large file - scrolling may be slow" = "Nagy fájl - a görgetés lassú lehet";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "Szkriptmetaadatok betöltése…";
 "Loading userscripts…" = "Felhasználói szkriptek betöltése…";
 "Local Import" = "Helyi import";
+"Lock Portrait Orientation" = "Álló tájolás rögzítése";
 "Logs" = "Naplók";
 "Logs cleared" = "Naplók törölve";
 "Logs will appear here as the app runs" = "A naplók itt jelennek meg az alkalmazás futása közben";

--- a/wBlock/it.lproj/Localizable.strings
+++ b/wBlock/it.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "Mantieni tutto";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "Mantiene i filtri aggiornati quando wBlock non è in esecuzione. Disattivalo per evitare un elemento di login persistente; gli aggiornamenti verranno eseguiti solo mentre wBlock è aperto.";
+"Keeps the app in portrait even if the device is rotated." = "Mantiene l’app in verticale anche se ruoti il dispositivo.";
 "Languages: %@" = "Lingue: %@";
 "Languages: \\(languageSummary)" = "Lingue: \\(languageSummary)";
 "Large file - scrolling may be slow" = "File grande - lo scorrimento potrebbe essere lento";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "Caricamento metadati dello script…";
 "Loading userscripts…" = "Caricamento userscript…";
 "Local Import" = "Importazione locale";
+"Lock Portrait Orientation" = "Blocca orientamento verticale";
 "Logs" = "Log";
 "Logs cleared" = "Log cancellati";
 "Logs will appear here as the app runs" = "I log appariranno qui mentre l'app è in esecuzione";

--- a/wBlock/ja.lproj/Localizable.strings
+++ b/wBlock/ja.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "すべて保持";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "wBlock が実行されていないときもフィルタを更新し続けます。常駐のログイン項目を避けるにはオフにしてください。その場合、更新は wBlock を開いている間のみ実行されます。";
+"Keeps the app in portrait even if the device is rotated." = "端末を回転させてもアプリを縦向きのままにします。";
 "Languages: %@" = "言語: %@";
 "Languages: \\(languageSummary)" = "言語: \\(languageSummary)";
 "Large file - scrolling may be slow" = "大きなファイルのため、スクロールが遅くなる場合があります";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "スクリプトのメタデータを読み込み中…";
 "Loading userscripts…" = "ユーザースクリプトを読み込み中…";
 "Local Import" = "ローカルインポート";
+"Lock Portrait Orientation" = "縦向きに固定";
 "Logs" = "ログ";
 "Logs cleared" = "ログを消去しました";
 "Logs will appear here as the app runs" = "アプリの実行中にここへログが表示されます";

--- a/wBlock/ko.lproj/Localizable.strings
+++ b/wBlock/ko.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "모두 유지";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "wBlock이 실행 중이 아닐 때도 필터를 계속 업데이트합니다. 상주 로그인 항목을 원하지 않으면 끄세요. 그러면 업데이트는 wBlock이 열려 있는 동안에만 실행됩니다.";
+"Keeps the app in portrait even if the device is rotated." = "기기를 돌려도 앱을 세로 방향으로 유지합니다.";
 "Languages: %@" = "언어: %@";
 "Languages: \\(languageSummary)" = "언어: \\(languageSummary)";
 "Large file - scrolling may be slow" = "대용량 파일 - 스크롤이 느려질 수 있음";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "스크립트 메타데이터 불러오는 중…";
 "Loading userscripts…" = "유저스크립트 불러오는 중…";
 "Local Import" = "로컬 가져오기";
+"Lock Portrait Orientation" = "세로 방향 고정";
 "Logs" = "로그";
 "Logs cleared" = "로그를 지웠습니다";
 "Logs will appear here as the app runs" = "앱이 실행되면 여기에 로그가 표시됩니다";

--- a/wBlock/pl.lproj/Localizable.strings
+++ b/wBlock/pl.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "Zachowaj wszystko";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "Utrzymuje filtry aktualne, gdy wBlock nie jest uruchomiony. Wyłącz, aby uniknąć stałego elementu logowania; aktualizacje będą wtedy działać tylko, gdy wBlock jest otwarty.";
+"Keeps the app in portrait even if the device is rotated." = "Utrzymuje aplikację w orientacji pionowej, nawet po obróceniu urządzenia.";
 "Languages: %@" = "Języki: %@";
 "Languages: \\(languageSummary)" = "Języki: \\(languageSummary)";
 "Large file - scrolling may be slow" = "Duży plik - przewijanie może być wolne";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "Wczytywanie metadanych skryptu…";
 "Loading userscripts…" = "Wczytywanie userskryptów…";
 "Local Import" = "Import lokalny";
+"Lock Portrait Orientation" = "Zablokuj orientację pionową";
 "Logs" = "Logi";
 "Logs cleared" = "Wyczyszczono logi";
 "Logs will appear here as the app runs" = "Logi będą pojawiać się tutaj podczas działania aplikacji";

--- a/wBlock/pt-BR.lproj/Localizable.strings
+++ b/wBlock/pt-BR.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "Manter todos";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "Mantém os filtros atualizados quando o wBlock não está em execução. Desative para evitar um item de início persistente; as atualizações só serão executadas enquanto o wBlock estiver aberto.";
+"Keeps the app in portrait even if the device is rotated." = "Mantém o app na vertical mesmo se o dispositivo for girado.";
 "Languages: %@" = "Idiomas: %@";
 "Languages: \\(languageSummary)" = "Idiomas: \\(languageSummary)";
 "Large file - scrolling may be slow" = "Arquivo grande - a rolagem pode ficar lenta";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "Carregando metadados do script…";
 "Loading userscripts…" = "Carregando scripts de usuário…";
 "Local Import" = "Importação local";
+"Lock Portrait Orientation" = "Bloquear orientação retrato";
 "Logs" = "Registros";
 "Logs cleared" = "Registros limpos";
 "Logs will appear here as the app runs" = "Os logs aparecerão aqui enquanto o app é executado";

--- a/wBlock/ro.lproj/Localizable.strings
+++ b/wBlock/ro.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "Păstrează tot";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "Menține filtrele actualizate când wBlock nu rulează. Dezactivați pentru a evita un element de conectare persistent; actualizările vor rula atunci doar cât timp wBlock este deschis.";
+"Keeps the app in portrait even if the device is rotated." = "Păstrează aplicația în modul portret chiar dacă dispozitivul este rotit.";
 "Languages: %@" = "Limbi: %@";
 "Languages: \\(languageSummary)" = "Limbi: \\(languageSummary)";
 "Large file - scrolling may be slow" = "Fișier mare - derularea poate fi lentă";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "Se încarcă metadatele scriptului…";
 "Loading userscripts…" = "Se încarcă scripturile de utilizator…";
 "Local Import" = "Import local";
+"Lock Portrait Orientation" = "Blochează orientarea portret";
 "Logs" = "Jurnale";
 "Logs cleared" = "Jurnale șterse";
 "Logs will appear here as the app runs" = "Jurnalele vor apărea aici pe măsură ce aplicația rulează";

--- a/wBlock/ru.lproj/Localizable.strings
+++ b/wBlock/ru.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "Оставить все";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "Обновляет фильтры, даже когда wBlock не запущен. Отключите, чтобы не использовать постоянный объект входа; тогда обновления будут выполняться только пока wBlock открыт.";
+"Keeps the app in portrait even if the device is rotated." = "Оставляет приложение в портретной ориентации, даже если устройство повёрнуто.";
 "Languages: %@" = "Языки: %@";
 "Languages: \\(languageSummary)" = "Языки: \\(languageSummary)";
 "Large file - scrolling may be slow" = "Большой файл - прокрутка может быть медленной";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "Загрузка метаданных скрипта…";
 "Loading userscripts…" = "Загрузка пользовательских скриптов…";
 "Local Import" = "Локальный импорт";
+"Lock Portrait Orientation" = "Блокировать портретную ориентацию";
 "Logs" = "Журналы";
 "Logs cleared" = "Журналы очищены";
 "Logs will appear here as the app runs" = "Журналы будут появляться здесь во время работы приложения";

--- a/wBlock/tr.lproj/Localizable.strings
+++ b/wBlock/tr.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "Tümünü tut";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "wBlock çalışmadığında da filtrelerin güncellenmeye devam etmesini sağlar. Kalıcı bir başlangıç öğesi oluşmasını istemiyorsanız bu seçeneği kapatın; bu durumda güncellemeler yalnızca wBlock açıkken çalışır.";
+"Keeps the app in portrait even if the device is rotated." = "Cihaz döndürülse bile uygulamayı dikey tutar.";
 "Languages: %@" = "Dil: %@";
 "Languages: \\(languageSummary)" = "Dil: \\(languageSummary)";
 "Large file - scrolling may be slow" = "Büyük dosya - kaydırma işlemi yavaş olabilir";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "Betik meta verileri yükleniyor…";
 "Loading userscripts…" = "Kullanıcı betikleri güncelleniyor…";
 "Local Import" = "Yerel içe aktarma";
+"Lock Portrait Orientation" = "Dikey yönü kilitle";
 "Logs" = "Günlükler";
 "Logs cleared" = "Günlükler temizlendi";
 "Logs will appear here as the app runs" = "Uygulama çalıştıkça günlük kayıtları burada görünecektir";

--- a/wBlock/zh-Hans.lproj/Localizable.strings
+++ b/wBlock/zh-Hans.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "全部保留";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "在 wBlock 未运行时也保持过滤器更新。关闭可避免常驻登录项；此后更新仅在 wBlock 打开时运行。";
+"Keeps the app in portrait even if the device is rotated." = "即使旋转设备，也保持应用为竖屏。";
 "Languages: %@" = "语言：%@";
 "Languages: \\(languageSummary)" = "语言：\\(languageSummary)";
 "Large file - scrolling may be slow" = "文件较大，滚动可能较慢";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "正在加载脚本元数据…";
 "Loading userscripts…" = "正在加载用户脚本…";
 "Local Import" = "本地导入";
+"Lock Portrait Orientation" = "锁定竖屏方向";
 "Logs" = "日志";
 "Logs cleared" = "日志已清除";
 "Logs will appear here as the app runs" = "应用运行时日志将显示在这里";

--- a/wBlock/zh-Hant.lproj/Localizable.strings
+++ b/wBlock/zh-Hant.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "KAD - Anti-Scam" = "KAD - Anti-Scam";
 "Keep All" = "全部保留";
 "Keeps filters updating when wBlock isn't running. Turn off to avoid a persistent login item; updates will then only run while wBlock is open." = "在 wBlock 未執行時也保持過濾器更新。關閉可避免常駐登入項目；之後更新僅在 wBlock 開啟時執行。";
+"Keeps the app in portrait even if the device is rotated." = "即使旋轉裝置，也保持 App 為直向。";
 "Languages: %@" = "語言：%@";
 "Languages: \\(languageSummary)" = "語言：\\(languageSummary)";
 "Large file - scrolling may be slow" = "檔案較大，捲動可能較慢";
@@ -477,6 +478,7 @@
 "Loading script metadata…" = "正在載入腳本中繼資料…";
 "Loading userscripts…" = "正在載入使用者腳本…";
 "Local Import" = "本機匯入";
+"Lock Portrait Orientation" = "鎖定直向方向";
 "Logs" = "日誌";
 "Logs cleared" = "日誌已清除";
 "Logs will appear here as the app runs" = "應用程式執行時，日誌會顯示在這裡";


### PR DESCRIPTION
iOS Settings now has a Lock Portrait Orientation toggle, off by default, so the app still rotates unless you turn it on. It lives just under Pause Blocking and pins wBlock to portrait through the existing AppDelegate orientation mask.

swift scripts/test_portrait_orientation_lock.swift passed, and the iOS Simulator Debug build of scheme wBlock succeeded. Closes #558.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display preference with localized strings; no auth, sync, or filter pipeline changes.
> 
> **Overview**
> Adds an **optional portrait lock** for iOS (off by default, addresses #558). Users get a new **Display** section in Settings—placed under Pause Blocking—with a **Lock Portrait Orientation** toggle backed by `UserDefaults` via `@AppStorage`.
> 
> When enabled, **`PortraitOrientationLock`** pins the app to portrait; when disabled, unlocked masks stay aligned with **Info.plist** (`allButUpsideDown` on iPhone, `.all` on iPad). **`AppDelegate`** applies any stored preference at launch and returns the shared mask from `supportedInterfaceOrientationsFor`. Toggling calls **`apply()`**, which updates geometry on iOS 16+ and falls back to rotation on iOS 15.
> 
> Localized strings were added across supported locales, and **`scripts/test_portrait_orientation_lock.swift`** guards wiring and localization quality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07cbea4637fd2ea6a3705b728ba53f22993f7d5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->