### PR TITLE
refactor: consolidate duplicated wBlock workflows

### DIFF
--- a/scripts/run-ci-tests.sh
+++ b/scripts/run-ci-tests.sh
@@ -142,6 +142,7 @@ compile_core_test filter-list-site-exclusion scripts/test_filter_list_site_exclu
 compile_core_test userscript-pattern-budget scripts/test_userscript_pattern_budget.swift
 compile_core_test issue-645-compile-order scripts/test_issue_645_compile_order.swift
 compile_core_test compilation-provenance scripts/test_compilation_provenance.swift
+compile_core_test target-compilation scripts/test_target_compilation.swift
 compile_core_test issue-729-headless-rebuild-gate scripts/test_issue_729_headless_rebuild_gate.swift
 compile_core_test filter-catalog-remote scripts/test_filter_catalog_remote.swift
 compile_core_test filter-list-fetch-chain scripts/test_filter_list_fetch_chain.swift

--- a/scripts/test_target_compilation.swift
+++ b/scripts/test_target_compilation.swift
@@ -1,0 +1,47 @@
+import Foundation
+import wBlockCoreService
+
+@main
+struct TargetCompilationTests {
+    static func main() async {
+        let targets = ContentBlockerTargetManager.shared.allTargets(forPlatform: .macOS)
+        func requests(deadline: Date? = nil, cancelled: Bool) -> [SharedAutoUpdateManager.TargetCompilationRequest] {
+            targets.map {
+                SharedAutoUpdateManager.TargetCompilationRequest(
+                    target: $0, filters: [], allTargets: targets, disabledSites: [],
+                    affinitySnapshot: SafariContentBlockerAffinitySnapshot(contentsByFilterID: [:]),
+                    orderedFilters: [], extraRulesText: nil, deadline: deadline,
+                    minimumTime: 12, isCancelled: { cancelled }
+                )
+            }
+        }
+
+        var delivered: [ContentBlockerTargetInfo] = []
+        let cancelled = await SharedAutoUpdateManager.compileTargets(requests(cancelled: true)) {
+            delivered.append($0.target)
+        }
+        precondition(cancelled.count == targets.count)
+        precondition(Set(delivered) == Set(targets) && delivered.count == targets.count)
+        precondition(cancelled.allSatisfy {
+            $0.outcome == nil && $0.failureDescription == nil && $0.budgetExpired == nil
+        })
+
+        let expired = await SharedAutoUpdateManager.compileTargets(
+            requests(deadline: Date().addingTimeInterval(-1), cancelled: false)
+        )
+        precondition(expired.count == targets.count)
+        precondition(expired.allSatisfy { $0.budgetExpired == 0 && $0.outcome == nil })
+
+        let empty = await SharedAutoUpdateManager.compileTargets([]) { _ in
+            preconditionFailure("empty work must not deliver a result")
+        }
+        precondition(empty.isEmpty)
+        let work = requests(cancelled: false)
+        let stopped = await Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return await SharedAutoUpdateManager.compileTargets(work)
+        }.value
+        precondition(stopped.allSatisfy { $0.outcome == nil })
+        print("PASS: target compilation cancellation, budget, and result delivery")
+    }
+}

--- a/scripts/test_userscript_update_operation.swift
+++ b/scripts/test_userscript_update_operation.swift
@@ -69,6 +69,24 @@ struct UserScriptUpdateOperationRegression {
         precondition(!cancelled)
         precondition(!cancelledCommit)
 
+        var supersededDuringPreparation = false
+        var committedAfterPreparationSupersession = false
+        let preparationSuperseded = await UserScriptUpdateOperation.run(
+            downloadURL: resolvedURL,
+            fetch: { _ in "payload" },
+            isCurrent: { !supersededDuringPreparation },
+            prepare: { payload in
+                supersededDuringPreparation = true
+                return payload
+            },
+            commit: { _ in
+                committedAfterPreparationSupersession = true
+                return true
+            }
+        )
+        precondition(!preparationSuperseded)
+        precondition(!committedAfterPreparationSupersession)
+
         print("userscript update operation regression: PASS")
     }
 }

--- a/wBlock/AddContentShell.swift
+++ b/wBlock/AddContentShell.swift
@@ -208,6 +208,189 @@ struct ContentCategoryPicker: View {
     }
 }
 
+struct AddContentURLInput: View {
+    @Binding var text: String
+    @FocusState.Binding var isFocused: Bool
+    let isBulk: Bool
+    let singlePlaceholder: () -> Text
+    let bulkPlaceholder: () -> Text
+    let accessibilityLabel: LocalizedStringKey
+    let isDisabled: Bool
+    let onPaste: () -> Void
+    let pasteTitle: LocalizedStringKey
+    let pasteButtonUsesRow: Bool
+    var macPlaceholderPadding: CGFloat = 1
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if isBulk {
+                ZStack(alignment: .topLeading) {
+                    TextEditor(text: $text)
+                        .hideEditorBackgroundCompat()
+                        .font(.body)
+                        .autocorrectionDisabled()
+                        .focused($isFocused)
+                        #if os(iOS)
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(.URL)
+                        #endif
+                    if text.isEmpty {
+                        bulkPlaceholder()
+                            .font(.body)
+                            .foregroundStyle(.tertiary)
+                            #if os(macOS)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, macPlaceholderPadding)
+                            #else
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 8)
+                            #endif
+                            .allowsHitTesting(false)
+                    }
+                }
+                .frame(minHeight: 64, maxHeight: 96)
+                .background(Color.urlEditorBackground, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(.quaternary, lineWidth: 1)
+                )
+                .accessibilityLabel(accessibilityLabel)
+            } else {
+                TextField("", text: $text, prompt: singlePlaceholder())
+                    .textFieldStyle(.roundedBorder)
+                    .autocorrectionDisabled()
+                    .focused($isFocused)
+                    #if os(iOS)
+                    .textInputAutocapitalization(.never)
+                    .keyboardType(.URL)
+                    #endif
+                    .accessibilityLabel(accessibilityLabel)
+            }
+            if pasteButtonUsesRow {
+                HStack { pasteButton; Spacer() }
+            } else {
+                pasteButton
+            }
+        }
+    }
+
+    private var pasteButton: some View {
+        Button(action: onPaste) {
+            Label(pasteTitle, systemImage: "doc.on.clipboard")
+        }
+        .buttonStyle(.bordered)
+        .disabled(isDisabled)
+    }
+}
+
+struct AddContentFileSelectionButton: View {
+    let filename: String?
+    let isLoading: Bool
+    let isDisabled: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 10) {
+                Image(systemName: "doc")
+                if let filename {
+                    Text(filename)
+                } else {
+                    Text("Choose File")
+                }
+                if isLoading { ProgressView().controlSize(.small) }
+                Spacer()
+                if filename != nil { Text("Change File").foregroundStyle(.secondary) }
+            }
+            #if os(macOS)
+            .padding(.vertical, 10)
+            .padding(.horizontal, 12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.background, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(.quaternary, lineWidth: 1)
+            )
+            #endif
+        }
+        #if os(macOS)
+        .buttonStyle(.plain)
+        .noFocusRingCompat()
+        #endif
+        .disabled(isDisabled)
+    }
+}
+
+#if os(iOS)
+struct AddContentIOSSheet<Content: View>: View {
+    let title: LocalizedStringKey
+    let isLoading: Bool
+    let buttonTitle: () -> LocalizedStringKey
+    let isSubmitDisabled: Bool
+    let onDismiss: () -> Void
+    let onSubmit: () -> Void
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        CompatibleNavigationStack {
+            content()
+                .navigationTitle(title)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel", action: onDismiss)
+                            .disabled(isLoading)
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button(action: onSubmit) {
+                            if isLoading {
+                                ProgressView()
+                            } else {
+                                Text(buttonTitle())
+                            }
+                        }
+                        .disabled(isSubmitDisabled)
+                    }
+                }
+        }
+        .interactiveDismissDisabled(isLoading)
+        .largeSheetPresentationCompat()
+    }
+}
+
+#endif
+
+#if os(macOS)
+struct AddContentMacSheet<Content: View, Action: View>: View {
+    let title: String
+    let isLoading: Bool
+    let minHeight: CGFloat
+    let onDismiss: () -> Void
+    let isDismissDisabled: Bool
+    @ViewBuilder let content: () -> Content
+    @ViewBuilder let action: () -> Action
+
+    var body: some View {
+        SheetContainer {
+            SheetHeader(title: title, isLoading: isLoading) { onDismiss() }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) { content() }
+                    .padding(.horizontal, SheetDesign.contentHorizontalPadding)
+                    .padding(.top, 12)
+                    .padding(.bottom, 40)
+            }
+            SheetBottomToolbar {
+                Spacer()
+                action()
+            }
+        }
+        .interactiveDismissDisabled(isDismissDisabled)
+        .frame(minWidth: 560, minHeight: minHeight)
+    }
+}
+
+#endif
+
 extension Color {
     static var urlEditorBackground: Color {
         #if os(iOS)

--- a/wBlock/AppFilterManager+ApplyPipeline.swift
+++ b/wBlock/AppFilterManager+ApplyPipeline.swift
@@ -709,129 +709,69 @@ extension AppFilterManager {
             self.applyProgressViewModel.updatePhaseCompletion(reading: true, converting: false)
         }
 
-        let conversionWork = platformTargets.map { targetInfo in
-            TargetConversionWork(
-                targetInfo: targetInfo,
+        #if os(iOS)
+        let isConversionCancelled = { ApplyCancellation.isCancelled || Task.isCancelled }
+        #else
+        let isConversionCancelled = { Task.isCancelled }
+        #endif
+        let compilationRequests = platformTargets.map { targetInfo in
+            SharedAutoUpdateManager.TargetCompilationRequest(
+                target: targetInfo,
                 filters: filtersByTargetInfo[targetInfo] ?? [],
-                extraRulesText: targetInfo.slot == 5 ? generatedZapperRulesText : nil
+                allTargets: platformTargets,
+                disabledSites: disabledSites,
+                affinitySnapshot: affinitySnapshot,
+                orderedFilters: orderedSelectedFilters,
+                extraRulesText: targetInfo.slot == 5 ? generatedZapperRulesText : nil,
+                deadline: nil,
+                minimumTime: 0,
+                isCancelled: isConversionCancelled
             )
         }
-        let groupIdentifier = GroupIdentifier.shared.value
-        var conversionCompletions: [ContentBlockerTargetInfo: TargetConversionCompletion] = [:]
+        var conversionCompletions: [ContentBlockerTargetInfo: SharedAutoUpdateManager.TargetCompilationResult] = [:]
         var appliedSourceRuleCountsByFilterID: [UUID: Int] = [:]
 
-        await boundedConcurrentForEach(
-            conversionWork,
-            operation: { work in
-                let conversionStart = Date()
-                #if os(iOS)
-                if ApplyCancellation.isCancelled || Task.isCancelled {
-                    return TargetConversionCompletion(
-                        work: work,
-                        outcome: nil,
-                        failureDescription: LocalizedStrings.text(
-                            "Apply cancelled to release file locks before suspension",
-                            comment: "Apply pipeline suspension cancel"
-                        ),
-                        durationMs: Int(Date().timeIntervalSince(conversionStart) * 1000)
-                    )
-                }
-                #endif
-                #if os(iOS)
-                let isConversionCancelled = {
-                    ApplyCancellation.isCancelled || Task.isCancelled
-                }
-                #else
-                let isConversionCancelled = { Task.isCancelled }
-                #endif
-                do {
-                    let outcome = try ContentBlockerService.compileTargetRules(
-                        filters: work.filters,
-                        orderedSelectedFilters: orderedSelectedFilters,
-                        affinitySnapshot: affinitySnapshot,
-                        targetInfo: work.targetInfo,
-                        allTargets: platformTargets,
-                        disabledSites: disabledSites,
-                        extraRulesText: work.extraRulesText,
-                        groupIdentifier: groupIdentifier,
-                        isCancelled: isConversionCancelled
-                    )
-                    return TargetConversionCompletion(
-                        work: work,
-                        outcome: outcome,
-                        failureDescription: nil,
-                        durationMs: Int(Date().timeIntervalSince(conversionStart) * 1000)
-                    )
-                } catch is CancellationError {
-                    return TargetConversionCompletion(
-                        work: work,
-                        outcome: nil,
-                        failureDescription: nil,
-                        durationMs: Int(Date().timeIntervalSince(conversionStart) * 1000)
-                    )
-                } catch {
-                    return TargetConversionCompletion(
-                        work: work,
-                        outcome: nil,
-                        failureDescription: LogErrorDescriber.describe(error),
-                        durationMs: Int(Date().timeIntervalSince(conversionStart) * 1000)
-                    )
-                }
-            },
-            onResult: { completion in
-                conversionCompletions[completion.work.targetInfo] = completion
-                #if os(iOS)
-                if ApplyCancellation.isCancelled || Task.isCancelled {
-                    return
-                }
-                #endif
-                guard let conversionResult = completion.outcome else { return }
-                let targetInfo = completion.work.targetInfo
-                let blockerName = targetInfo.displayName
-                let ruleCountForThisTarget = conversionResult.safariRulesCount
-                let truncatedRuleCount = conversionResult.truncatedRuleCount
+        _ = await SharedAutoUpdateManager.compileTargets(compilationRequests) { completion in
+            conversionCompletions[completion.target] = completion
+            #if os(iOS)
+            if ApplyCancellation.isCancelled || Task.isCancelled { return }
+            #endif
+            guard let conversionResult = completion.outcome else { return }
+            let targetInfo = completion.target
+            let blockerName = targetInfo.displayName
+            let ruleCountForThisTarget = conversionResult.safariRulesCount
+            let truncatedRuleCount = conversionResult.truncatedRuleCount
 
-                await MainActor.run {
-                    self.applyProgressViewModel.updateStageDescription(
-                        LocalizedStrings.format(
-                            "Converting %@…",
-                            comment: "Apply pipeline converting stage",
-                            blockerName
-                        )
-                    )
-                    self.processedFiltersCount += 1
-                    self.progress = Float(self.processedFiltersCount) / Float(totalFiltersCount) * 0.7
-                    self.applyProgressViewModel.updateConvertingDone(self.processedFiltersCount)
-                    self.applyProgressViewModel.updateCurrentFilter(blockerName)
-                    self.ruleCountsByExtension[targetInfo.bundleIdentifier] = ruleCountForThisTarget
-
-                    if truncatedRuleCount > 0 {
-                        self.extensionsApproachingLimit.remove(targetInfo.bundleIdentifier)
-                        self.hasError = true
-                        self.statusDescription =
-                            "One or more content blockers exceeded Safari's \(ruleLimit.formatted()) rule limit. Disable some filter lists and try again."
-                    } else if ruleCountForThisTarget >= warningThreshold {
-                        self.extensionsApproachingLimit.insert(targetInfo.bundleIdentifier)
-                    } else {
-                        self.extensionsApproachingLimit.remove(targetInfo.bundleIdentifier)
-                    }
-                }
+            await MainActor.run {
+                self.applyProgressViewModel.updateStageDescription(
+                    LocalizedStrings.format("Converting %@…", comment: "Apply pipeline converting stage", blockerName)
+                )
+                self.processedFiltersCount += 1
+                self.progress = Float(self.processedFiltersCount) / Float(totalFiltersCount) * 0.7
+                self.applyProgressViewModel.updateConvertingDone(self.processedFiltersCount)
+                self.applyProgressViewModel.updateCurrentFilter(blockerName)
+                self.ruleCountsByExtension[targetInfo.bundleIdentifier] = ruleCountForThisTarget
 
                 if truncatedRuleCount > 0 {
-                    await ConcurrentLogManager.shared.error(
-                        .filterApply, LocalizedStrings.text("Rule limit exceeded for blocker"),
-                        metadata: [
-                            "blocker": blockerName,
-                            "bundleId": targetInfo.bundleIdentifier,
-                            "ruleCount": "\(ruleCountForThisTarget)",
-                            "truncatedRules": "\(truncatedRuleCount)",
-                            "ruleLimit": "\(ruleLimit)",
-                        ]
-                    )
+                    self.extensionsApproachingLimit.remove(targetInfo.bundleIdentifier)
+                    self.hasError = true
+                    self.statusDescription = "One or more content blockers exceeded Safari's \(ruleLimit.formatted()) rule limit. Disable some filter lists and try again."
+                } else if ruleCountForThisTarget >= warningThreshold {
+                    self.extensionsApproachingLimit.insert(targetInfo.bundleIdentifier)
+                } else {
+                    self.extensionsApproachingLimit.remove(targetInfo.bundleIdentifier)
                 }
             }
-        )
 
+            if truncatedRuleCount > 0 {
+                await ConcurrentLogManager.shared.error(
+                    .filterApply, LocalizedStrings.text("Rule limit exceeded for blocker"),
+                    metadata: ["blocker": blockerName, "bundleId": targetInfo.bundleIdentifier,
+                               "ruleCount": "\(ruleCountForThisTarget)", "truncatedRules": "\(truncatedRuleCount)",
+                               "ruleLimit": "\(ruleLimit)"]
+                )
+            }
+        }
         if let missingOutcomeTarget = platformTargets.first(where: { targetInfo in
             guard let completion = conversionCompletions[targetInfo] else { return true }
             return completion.outcome == nil && completion.failureDescription == nil
@@ -871,7 +811,7 @@ extension AppFilterManager {
                 )
                 return
             }
-            let filters = completion.work.filters
+            let filters = filtersByTargetInfo[completion.target] ?? []
             let blockerName = targetInfo.displayName
             let ruleCountForThisTarget = conversionResult.safariRulesCount
 
@@ -1427,20 +1367,6 @@ extension AppFilterManager {
     }
 
     // MARK: - Static helpers
-
-    /// Memory-efficient conversion that combines filter files using streaming I/O
-    private struct TargetConversionWork: Sendable {
-        let targetInfo: ContentBlockerTargetInfo
-        let filters: [FilterList]
-        let extraRulesText: String?
-    }
-
-    private struct TargetConversionCompletion: Sendable {
-        let work: TargetConversionWork
-        let outcome: ContentBlockerService.ContentBlockerTargetOutcome?
-        let failureDescription: String?
-        let durationMs: Int
-    }
 
     struct TargetConversionMetrics {
         let blockerName: String

--- a/wBlock/CloudSyncManager.swift
+++ b/wBlock/CloudSyncManager.swift
@@ -993,6 +993,36 @@ final class CloudSyncManager: ObservableObject {
         return merged
     }
 
+    @MainActor
+    private struct CloudSyncFilterStorageAdapter {
+        let filterManager: AppFilterManager?
+        let dataManager: ProtobufDataManager
+
+        var filterLists: [FilterList] {
+            filterManager?.filterLists ?? dataManager.getFilterLists()
+        }
+
+        var selectionMutationRevision: UInt64? {
+            filterManager?.selectionMutationRevision
+        }
+
+        func commit(
+            _ filterLists: [FilterList],
+            selectionChanged: Bool = false,
+            nonSelectionChanged: Bool = false
+        ) async {
+            if let filterManager {
+                filterManager.filterLists = filterLists
+                if nonSelectionChanged {
+                    filterManager.markNonSelectionChangesPending()
+                } else if selectionChanged {
+                    filterManager.refreshPendingSelectionChanges()
+                }
+            }
+            await dataManager.updateFilterLists(filterLists)
+        }
+    }
+
     private func applyRemoteFilters(
         _ filters: SyncPayload.Filters,
         baselineFilters: SyncPayload.Filters,
@@ -1012,8 +1042,6 @@ final class CloudSyncManager: ObservableObject {
             !Self.customFilterEqualForSync(currentCustomByURL[url], baselineCustomByURL[url])
         })
 
-        // Tombstones are a set-valued field: merge local and remote deltas instead of
-        // replacing one side wholesale.
         let currentDeleted = Set(currentFilters.deletedCustomURLs ?? [])
         var mergedDeleted = Set(Self.mergeStringSet(
             local: Array(currentDeleted),
@@ -1021,249 +1049,115 @@ final class CloudSyncManager: ObservableObject {
             remote: filters.deletedCustomURLs ?? []
         ))
         for url in locallyChangedCustomURLs where currentCustomByURL[url] != nil {
-            // A local add/edit wins a conflicting remote tombstone for that URL.
             mergedDeleted.remove(url)
         }
         clearDeletedCustomListURLs(currentDeleted.subtracting(mergedDeleted))
         mergeDeletedCustomListURLs(mergedDeleted.subtracting(currentDeleted))
-        let deletedCustomURLs = mergedDeleted
 
-        let desiredSelected = Set(
-            filters.selectedURLs.map(FilterListLoader.canonicalFilterURLString)
-        )
+        let desiredSelected = Set(filters.selectedURLs.map(FilterListLoader.canonicalFilterURLString))
         let knownURLs = Set(
             (filters.knownURLs ?? filters.selectedURLs).map(FilterListLoader.canonicalFilterURLString)
         )
-
-        if let filterManager {
-            var changed = false
-            var selectionChanged = false
-            var nonSelectionChanged = false
-            let mayApplyRemoteSelection =
-                filterManager.selectionMutationRevision == localSelectionRevisionAtStart
-
-            // Remove remotely deleted custom lists only when that URL was unchanged locally.
-            if !deletedCustomURLs.isEmpty {
-                let liveCustomURLs = Set(
-                    filterManager.filterLists.filter(\.isCustom).map(\.url.absoluteString)
-                )
-                let urlsToDelete = CloudSyncCustomFilterReconciler.tombstonedURLsToDelete(
-                    tombstonedURLs: deletedCustomURLs.subtracting(locallyChangedCustomURLs),
-                    snapshotCustomURLs: Set(currentCustomByURL.keys),
-                    liveCustomURLs: liveCustomURLs
-                )
-                let removed = filterManager.filterLists.filter { $0.isCustom && urlsToDelete.contains($0.url.absoluteString) }
-                if !removed.isEmpty {
-                    for list in removed {
-                        Self.deleteInlineUserListContentIfNeeded(urlString: list.url.absoluteString)
-                    }
-                    filterManager.filterLists.removeAll { $0.isCustom && urlsToDelete.contains($0.url.absoluteString) }
-                    changed = true
-                    nonSelectionChanged = true
-                }
-            }
-
-            // Update selection for all non-custom filters by URL
-            for index in filterManager.filterLists.indices {
-                guard !filterManager.filterLists[index].isCustom else { continue }
-                let urlString = FilterListLoader.canonicalFilterURLString(
-                    filterManager.filterLists[index].url.absoluteString
-                )
-                guard knownURLs.contains(urlString), mayApplyRemoteSelection else { continue }
-                let shouldSelect = desiredSelected.contains(urlString)
-                if filterManager.filterLists[index].isSelected != shouldSelect {
-                    filterManager.filterLists[index].isSelected = shouldSelect
-                    changed = true
-                    selectionChanged = true
-                }
-            }
-
-            // Upsert remote custom lists independently by URL.
-            for remoteCustom in filters.customLists {
-                if locallyChangedCustomURLs.contains(remoteCustom.url) {
-                    continue
-                }
-                if deletedCustomURLs.contains(remoteCustom.url) {
-                    continue
-                }
-                let remoteCategory = remoteCustom.resolvedCategory
-                if let inlineID = Self.inlineUserListID(from: remoteCustom.url) {
-                    guard let content = remoteCustom.content else { continue }
-                    Self.writeInlineUserListContent(id: inlineID, content: content)
-                }
-
-                if let existingIndex = filterManager.filterLists.firstIndex(where: {
-                    $0.isCustom && $0.url.absoluteString == remoteCustom.url
-                }) {
-                    var shouldTreatAsMissing = false
-                    if let inlineID = Self.inlineUserListID(from: remoteCustom.url),
-                       filterManager.filterLists[existingIndex].id != inlineID
-                    {
-                        // Replace mismatched legacy entry (ID-based filename mismatch breaks local storage).
-                        let existing = filterManager.filterLists[existingIndex]
-                        filterManager.filterLists.removeAll { $0.id == existing.id }
-                        changed = true
-                        nonSelectionChanged = true
-                        shouldTreatAsMissing = true
-                    }
-
-                    if !shouldTreatAsMissing {
-                        if filterManager.filterLists[existingIndex].name != remoteCustom.name {
-                            filterManager.filterLists[existingIndex].name = remoteCustom.name
-                            changed = true
-                            nonSelectionChanged = true
-                        }
-                        if filterManager.filterLists[existingIndex].hasUserProvidedName != remoteCustom.resolvedUserProvidedName {
-                            filterManager.filterLists[existingIndex].hasUserProvidedName = remoteCustom.resolvedUserProvidedName
-                            changed = true
-                            nonSelectionChanged = true
-                        }
-                        if let desc = remoteCustom.description,
-                           filterManager.filterLists[existingIndex].description != desc
-                        {
-                            filterManager.filterLists[existingIndex].description = desc
-                            changed = true
-                            nonSelectionChanged = true
-                        }
-                        if filterManager.filterLists[existingIndex].hasUserProvidedDescription != remoteCustom.resolvedUserProvidedDescription {
-                            filterManager.filterLists[existingIndex].hasUserProvidedDescription = remoteCustom.resolvedUserProvidedDescription
-                            changed = true
-                            nonSelectionChanged = true
-                        }
-                        if filterManager.filterLists[existingIndex].category != remoteCategory {
-                            filterManager.filterLists[existingIndex].category = remoteCategory
-                            changed = true
-                            nonSelectionChanged = true
-                        }
-                        if mayApplyRemoteSelection,
-                           filterManager.filterLists[existingIndex].isSelected != remoteCustom.isSelected
-                        {
-                            filterManager.filterLists[existingIndex].isSelected = remoteCustom.isSelected
-                            changed = true
-                            selectionChanged = true
-                        }
-                    } else {
-                        let newFilter = FilterList(
-                            id: Self.inlineUserListID(from: remoteCustom.url) ?? UUID(),
-                            name: remoteCustom.name,
-                            url: URL(string: remoteCustom.url) ?? URL(string: "https://example.com")!,
-                            category: remoteCategory,
-                            isCustom: true,
-                            isSelected: mayApplyRemoteSelection ? remoteCustom.isSelected : false,
-                            description: remoteCustom.description ?? "User-added filter list.",
-                            sourceRuleCount: nil,
-                            hasUserProvidedName: remoteCustom.resolvedUserProvidedName,
-                            hasUserProvidedDescription: remoteCustom.resolvedUserProvidedDescription
-                        )
-                        filterManager.filterLists.append(newFilter)
-                        changed = true
-                        nonSelectionChanged = true
-                    }
-                } else {
-                    let newFilter = FilterList(
-                        id: Self.inlineUserListID(from: remoteCustom.url) ?? UUID(),
-                        name: remoteCustom.name,
-                        url: URL(string: remoteCustom.url) ?? URL(string: "https://example.com")!,
-                        category: remoteCategory,
-                        isCustom: true,
-                        isSelected: mayApplyRemoteSelection ? remoteCustom.isSelected : false,
-                        description: remoteCustom.description ?? "User-added filter list.",
-                        sourceRuleCount: nil,
-                        hasUserProvidedName: remoteCustom.resolvedUserProvidedName,
-                        hasUserProvidedDescription: remoteCustom.resolvedUserProvidedDescription
-                    )
-                    filterManager.filterLists.append(newFilter)
-                    changed = true
-                    nonSelectionChanged = true
-                }
-            }
-
-            if changed {
-                if nonSelectionChanged {
-                    filterManager.markNonSelectionChangesPending()
-                } else if selectionChanged {
-                    filterManager.refreshPendingSelectionChanges()
-                }
-                await filterManager.saveFilterLists()
-            }
-            return
-        }
-
-        // Fallback: update persisted lists without touching the in-memory manager.
-        var storedLists = dataManager.getFilterLists()
-
-        if !deletedCustomURLs.isEmpty {
-            let urlsToDelete = deletedCustomURLs.subtracting(locallyChangedCustomURLs)
-            storedLists.removeAll { $0.isCustom && urlsToDelete.contains($0.url.absoluteString) }
-            for url in urlsToDelete {
-                Self.deleteInlineUserListContentIfNeeded(urlString: url)
-            }
-        }
-
+        let storage = CloudSyncFilterStorageAdapter(filterManager: filterManager, dataManager: dataManager)
+        var filterLists = storage.filterLists
         let mayApplyRemoteSelection =
-            filterManager == nil
-                || filterManager?.selectionMutationRevision == localSelectionRevisionAtStart
-        for index in storedLists.indices where !storedLists[index].isCustom {
-            let urlString = FilterListLoader.canonicalFilterURLString(
-                storedLists[index].url.absoluteString
-            )
-            guard knownURLs.contains(urlString), mayApplyRemoteSelection else { continue }
-            storedLists[index].isSelected = desiredSelected.contains(urlString)
+            storage.selectionMutationRevision.map { $0 == localSelectionRevisionAtStart } ?? true
+        var selectionChanged = false
+        var nonSelectionChanged = false
+
+        let liveCustomURLs = Set(filterLists.filter(\.isCustom).map { $0.url.absoluteString })
+        let urlsToDelete = CloudSyncCustomFilterReconciler.tombstonedURLsToDelete(
+            tombstonedURLs: mergedDeleted.subtracting(locallyChangedCustomURLs),
+            snapshotCustomURLs: Set(currentCustomByURL.keys),
+            liveCustomURLs: liveCustomURLs
+        )
+        let removed = filterLists.filter { $0.isCustom && urlsToDelete.contains($0.url.absoluteString) }
+        if !removed.isEmpty {
+            removed.forEach { Self.deleteInlineUserListContentIfNeeded(urlString: $0.url.absoluteString) }
+            filterLists.removeAll { $0.isCustom && urlsToDelete.contains($0.url.absoluteString) }
+            nonSelectionChanged = true
         }
 
-        // Upsert custom lists from remote without removing local-only customs.
-        let localCustomIndexByURL: [String: Int] = Dictionary(
-            uniqueKeysWithValues: storedLists.indices.compactMap { idx in
-                guard storedLists[idx].isCustom else { return nil }
-                return (storedLists[idx].url.absoluteString, idx)
+        for index in filterLists.indices where !filterLists[index].isCustom {
+            let url = FilterListLoader.canonicalFilterURLString(filterLists[index].url.absoluteString)
+            guard knownURLs.contains(url), mayApplyRemoteSelection else { continue }
+            let selected = desiredSelected.contains(url)
+            if filterLists[index].isSelected != selected {
+                filterLists[index].isSelected = selected
+                selectionChanged = true
             }
-        )
+        }
 
-        for remoteCustom in filters.customLists
-            where !deletedCustomURLs.contains(remoteCustom.url)
-                && !locallyChangedCustomURLs.contains(remoteCustom.url)
-        {
-            let remoteCategory = remoteCustom.resolvedCategory
+        for remoteCustom in filters.customLists {
+            guard !locallyChangedCustomURLs.contains(remoteCustom.url),
+                  !mergedDeleted.contains(remoteCustom.url) else { continue }
             if let inlineID = Self.inlineUserListID(from: remoteCustom.url) {
                 guard let content = remoteCustom.content else { continue }
                 Self.writeInlineUserListContent(id: inlineID, content: content)
             }
-
-            if let existingIndex = localCustomIndexByURL[remoteCustom.url] {
-                var updated = storedLists[existingIndex]
-                if updated.name != remoteCustom.name {
-                    updated.name = remoteCustom.name
+            let category = remoteCustom.resolvedCategory
+            if var index = filterLists.firstIndex(where: {
+                $0.isCustom && $0.url.absoluteString == remoteCustom.url
+            }) {
+                if let inlineID = Self.inlineUserListID(from: remoteCustom.url),
+                   filterLists[index].id != inlineID
+                {
+                    let oldID = filterLists[index].id
+                    filterLists.removeAll { $0.id == oldID }
+                    nonSelectionChanged = true
+                    index = filterLists.endIndex
                 }
-                updated.hasUserProvidedName = remoteCustom.resolvedUserProvidedName
-                if let desc = remoteCustom.description, updated.description != desc {
-                    updated.description = desc
+                if index < filterLists.endIndex {
+                    if filterLists[index].name != remoteCustom.name {
+                        filterLists[index].name = remoteCustom.name
+                        nonSelectionChanged = true
+                    }
+                    if filterLists[index].hasUserProvidedName != remoteCustom.resolvedUserProvidedName {
+                        filterLists[index].hasUserProvidedName = remoteCustom.resolvedUserProvidedName
+                        nonSelectionChanged = true
+                    }
+                    if let description = remoteCustom.description,
+                       filterLists[index].description != description
+                    {
+                        filterLists[index].description = description
+                        nonSelectionChanged = true
+                    }
+                    if filterLists[index].hasUserProvidedDescription != remoteCustom.resolvedUserProvidedDescription {
+                        filterLists[index].hasUserProvidedDescription = remoteCustom.resolvedUserProvidedDescription
+                        nonSelectionChanged = true
+                    }
+                    if filterLists[index].category != category {
+                        filterLists[index].category = category
+                        nonSelectionChanged = true
+                    }
+                    if mayApplyRemoteSelection, filterLists[index].isSelected != remoteCustom.isSelected {
+                        filterLists[index].isSelected = remoteCustom.isSelected
+                        selectionChanged = true
+                    }
+                    continue
                 }
-                updated.hasUserProvidedDescription = remoteCustom.resolvedUserProvidedDescription
-                if updated.category != remoteCategory {
-                    updated.category = remoteCategory
-                }
-                if mayApplyRemoteSelection {
-                    updated.isSelected = remoteCustom.isSelected
-                }
-                storedLists[existingIndex] = updated
-            } else {
-                let newFilter = FilterList(
-                    id: Self.inlineUserListID(from: remoteCustom.url) ?? UUID(),
-                    name: remoteCustom.name,
-                    url: URL(string: remoteCustom.url) ?? URL(string: "https://example.com")!,
-                    category: remoteCategory,
-                    isCustom: true,
-                    isSelected: mayApplyRemoteSelection ? remoteCustom.isSelected : false,
-                    description: remoteCustom.description ?? "User-added filter list.",
-                    sourceRuleCount: nil,
-                    hasUserProvidedName: remoteCustom.resolvedUserProvidedName,
-                    hasUserProvidedDescription: remoteCustom.resolvedUserProvidedDescription
-                )
-                storedLists.append(newFilter)
             }
+            filterLists.append(FilterList(
+                id: Self.inlineUserListID(from: remoteCustom.url) ?? UUID(),
+                name: remoteCustom.name,
+                url: URL(string: remoteCustom.url) ?? URL(string: "https://example.com")!,
+                category: category,
+                isCustom: true,
+                isSelected: mayApplyRemoteSelection ? remoteCustom.isSelected : false,
+                description: remoteCustom.description ?? "User-added filter list.",
+                sourceRuleCount: nil,
+                hasUserProvidedName: remoteCustom.resolvedUserProvidedName,
+                hasUserProvidedDescription: remoteCustom.resolvedUserProvidedDescription
+            ))
+            nonSelectionChanged = true
         }
 
-        await dataManager.updateFilterLists(storedLists)
+        guard selectionChanged || nonSelectionChanged else { return }
+        await storage.commit(
+            filterLists,
+            selectionChanged: selectionChanged,
+            nonSelectionChanged: nonSelectionChanged
+        )
     }
 
     private func applyRemoteUserScriptState(
@@ -1704,37 +1598,19 @@ final class CloudSyncManager: ObservableObject {
 
         let deletedCustomURLs = deletedCustomURLSet()
         if !deletedCustomURLs.isEmpty {
-            if let filterManager {
-                let urlsToDelete = CloudSyncCustomFilterReconciler.tombstonedURLsToDelete(
-                    tombstonedURLs: deletedCustomURLs,
-                    snapshotCustomURLs: localCustomURLs,
-                    liveCustomURLs: currentLocalCustomURLs()
-                )
-                let removed = filterManager.filterLists.filter { $0.isCustom && urlsToDelete.contains($0.url.absoluteString) }
-                if !removed.isEmpty {
-                    for list in removed {
-                        Self.deleteInlineUserListContentIfNeeded(urlString: list.url.absoluteString)
-                    }
-                    filterManager.filterLists.removeAll { $0.isCustom && urlsToDelete.contains($0.url.absoluteString) }
-                    filterManager.markNonSelectionChangesPending()
-                    await filterManager.saveFilterLists()
-                }
-            } else {
-                var storedLists = dataManager.getFilterLists()
-                let liveCustomURLs = Set(storedLists.filter(\.isCustom).map(\.url.absoluteString))
-                let urlsToDelete = CloudSyncCustomFilterReconciler.tombstonedURLsToDelete(
-                    tombstonedURLs: deletedCustomURLs,
-                    snapshotCustomURLs: localCustomURLs,
-                    liveCustomURLs: liveCustomURLs
-                )
-                let beforeCount = storedLists.count
-                storedLists.removeAll { $0.isCustom && urlsToDelete.contains($0.url.absoluteString) }
-                if storedLists.count != beforeCount {
-                    for url in urlsToDelete {
-                        Self.deleteInlineUserListContentIfNeeded(urlString: url)
-                    }
-                    await dataManager.updateFilterLists(storedLists)
-                }
+            let storage = CloudSyncFilterStorageAdapter(filterManager: filterManager, dataManager: dataManager)
+            var filterLists = storage.filterLists
+            let liveCustomURLs = Set(filterLists.filter(\.isCustom).map { $0.url.absoluteString })
+            let urlsToDelete = CloudSyncCustomFilterReconciler.tombstonedURLsToDelete(
+                tombstonedURLs: deletedCustomURLs,
+                snapshotCustomURLs: localCustomURLs,
+                liveCustomURLs: liveCustomURLs
+            )
+            let removed = filterLists.filter { $0.isCustom && urlsToDelete.contains($0.url.absoluteString) }
+            if !removed.isEmpty {
+                removed.forEach { Self.deleteInlineUserListContentIfNeeded(urlString: $0.url.absoluteString) }
+                filterLists.removeAll { $0.isCustom && urlsToDelete.contains($0.url.absoluteString) }
+                await storage.commit(filterLists, nonSelectionChanged: true)
             }
         }
 
@@ -1842,64 +1718,35 @@ final class CloudSyncManager: ObservableObject {
         defer { isApplyingRemoteChanges = false }
 
         if !missingCustoms.isEmpty {
+            let storage = CloudSyncFilterStorageAdapter(filterManager: filterManager, dataManager: dataManager)
+            var filterLists = storage.filterLists
             let mayApplyRemoteSelection =
-                (filterManager?.selectionMutationRevision ?? filterSelectionRevisionAtStart)
-                    == filterSelectionRevisionAtStart
-            if let filterManager {
-                var changed = false
-                for remoteCustom in missingCustoms {
-                    guard URL(string: remoteCustom.url) != nil else { continue }
-                    if filterManager.filterLists.contains(where: { $0.isCustom && $0.url.absoluteString == remoteCustom.url }) {
-                        continue
-                    }
-                    let remoteCategory = remoteCustom.resolvedCategory
-                    if let inlineID = Self.inlineUserListID(from: remoteCustom.url) {
-                        guard let content = remoteCustom.content else { continue }
-                        Self.writeInlineUserListContent(id: inlineID, content: content)
-                    }
-                    let newFilter = FilterList(
-                        id: Self.inlineUserListID(from: remoteCustom.url) ?? UUID(),
-                        name: remoteCustom.name,
-                        url: URL(string: remoteCustom.url) ?? URL(string: "https://example.com")!,
-                        category: remoteCategory,
-                        isCustom: true,
-                        isSelected: mayApplyRemoteSelection ? remoteCustom.isSelected : false,
-                        description: remoteCustom.description ?? "User-added filter list.",
-                        sourceRuleCount: nil,
-                        hasUserProvidedName: remoteCustom.resolvedUserProvidedName,
-                        hasUserProvidedDescription: remoteCustom.resolvedUserProvidedDescription
-                    )
-                    filterManager.filterLists.append(newFilter)
-                    changed = true
+                storage.selectionMutationRevision.map { $0 == filterSelectionRevisionAtStart } ?? true
+            var existingCustomURLs = Set(filterLists.filter(\.isCustom).map { $0.url.absoluteString })
+            var changed = false
+            for remoteCustom in missingCustoms where !existingCustomURLs.contains(remoteCustom.url) {
+                guard URL(string: remoteCustom.url) != nil else { continue }
+                if let inlineID = Self.inlineUserListID(from: remoteCustom.url) {
+                    guard let content = remoteCustom.content else { continue }
+                    Self.writeInlineUserListContent(id: inlineID, content: content)
                 }
-                if changed {
-                    filterManager.markNonSelectionChangesPending()
-                    await filterManager.saveFilterLists()
-                }
-            } else {
-                var storedLists = dataManager.getFilterLists()
-                let existingCustomURLs = Set(storedLists.filter(\.isCustom).map { $0.url.absoluteString })
-                for remoteCustom in missingCustoms where !existingCustomURLs.contains(remoteCustom.url) {
-                    let remoteCategory = remoteCustom.resolvedCategory
-                    if let inlineID = Self.inlineUserListID(from: remoteCustom.url) {
-                        guard let content = remoteCustom.content else { continue }
-                        Self.writeInlineUserListContent(id: inlineID, content: content)
-                    }
-                    let newFilter = FilterList(
-                        id: Self.inlineUserListID(from: remoteCustom.url) ?? UUID(),
-                        name: remoteCustom.name,
-                        url: URL(string: remoteCustom.url) ?? URL(string: "https://example.com")!,
-                        category: remoteCategory,
-                        isCustom: true,
-                        isSelected: mayApplyRemoteSelection ? remoteCustom.isSelected : false,
-                        description: remoteCustom.description ?? "User-added filter list.",
-                        sourceRuleCount: nil,
-                        hasUserProvidedName: remoteCustom.resolvedUserProvidedName,
-                        hasUserProvidedDescription: remoteCustom.resolvedUserProvidedDescription
-                    )
-                    storedLists.append(newFilter)
-                }
-                await dataManager.updateFilterLists(storedLists)
+                filterLists.append(FilterList(
+                    id: Self.inlineUserListID(from: remoteCustom.url) ?? UUID(),
+                    name: remoteCustom.name,
+                    url: URL(string: remoteCustom.url) ?? URL(string: "https://example.com")!,
+                    category: remoteCustom.resolvedCategory,
+                    isCustom: true,
+                    isSelected: mayApplyRemoteSelection ? remoteCustom.isSelected : false,
+                    description: remoteCustom.description ?? "User-added filter list.",
+                    sourceRuleCount: nil,
+                    hasUserProvidedName: remoteCustom.resolvedUserProvidedName,
+                    hasUserProvidedDescription: remoteCustom.resolvedUserProvidedDescription
+                ))
+                existingCustomURLs.insert(remoteCustom.url)
+                changed = true
+            }
+            if changed {
+                await storage.commit(filterLists, nonSelectionChanged: true)
             }
         }
 

--- a/wBlock/ContentView.swift
+++ b/wBlock/ContentView.swift
@@ -1411,30 +1411,17 @@ struct AddFilterListView: View {
 		var body: some View {
 		    Group {
 		        #if os(iOS)
-		            CompatibleNavigationStack {
-		                addTabs
-		                    .navigationTitle("Add Filter List")
-		                    .navigationBarTitleDisplayMode(.inline)
-		                    .toolbar {
-		                        ToolbarItem(placement: .cancellationAction) {
-		                            Button("Cancel") { dismiss() }
-		                                .disabled(isSaving)
-		                        }
-		                        ToolbarItem(placement: .confirmationAction) {
-		                            Button(action: submit) {
-		                                if isSaving {
-		                                    ProgressView()
-		                                } else {
-		                                    Text(LocalizedStringKey(addButtonTitle))
-		                                }
-		                            }
-		                            .disabled(!canSubmit || isSaving || (isReviewingURLs && isFetchingURLMetadata))
-		                        }
-		                    }
-		            }
-		            .interactiveDismissDisabled(isSaving)
-		            .largeSheetPresentationCompat()
-	        #elseif os(macOS)
+		            AddContentIOSSheet(
+                    title: "Add Filter List",
+                    isLoading: isSaving,
+                    buttonTitle: { LocalizedStringKey(addButtonTitle) },
+                    isSubmitDisabled: !canSubmit || isSaving || (isReviewingURLs && isFetchingURLMetadata),
+                    onDismiss: { dismiss() },
+                    onSubmit: submit
+                ) {
+                    addTabs
+                }
+                #elseif os(macOS)
 	            macosBody
 	        #endif
 	    }
@@ -1518,30 +1505,20 @@ struct AddFilterListView: View {
 	    }
 
 	    #if os(macOS)
-	        private var macosBody: some View {
-	            SheetContainer {
-	                SheetHeader(title: "Add Filter List", isLoading: isSaving) {
-	                    dismiss()
-	                }
-
-	                ScrollView {
-	                    VStack(alignment: .leading, spacing: 16) {
-	                        modePickerCard
-	                        macosModeContent
-	                    }
-	                    .padding(.horizontal, SheetDesign.contentHorizontalPadding)
-	                    .padding(.top, 12)
-	                    .padding(.bottom, 40)
-	                }
-
-	                SheetBottomToolbar {
-	                    Spacer()
-	                    macosAddButton
-	                }
-	            }
-	            .interactiveDismissDisabled(isSaving)
-	            .frame(minWidth: 560, minHeight: addMode == .paste ? 620 : 520)
-	        }
+        private var macosBody: some View {
+            AddContentMacSheet(
+                title: "Add Filter List",
+                isLoading: isSaving,
+                minHeight: addMode == .paste ? 620 : 520,
+                onDismiss: { dismiss() },
+                isDismissDisabled: isSaving
+            ) {
+                modePickerCard
+                macosModeContent
+            } action: {
+                macosAddButton
+            }
+        }
 
 	        private var macosAddButton: some View {
 	            Button(action: submit) {
@@ -1617,55 +1594,18 @@ struct AddFilterListView: View {
 	            }
 	        }
 
-        private var fileSelectionButton: some View {
-            Button {
-                showingFileImporter = true
-                importErrorMessage = nil
-            } label: {
-                HStack(spacing: 10) {
-                    Image(systemName: "doc")
-                    Text(stagedFile?.filename ?? "Choose File")
-                    if isStagingFile { ProgressView().controlSize(.small) }
-                    Spacer()
-                    if stagedFile != nil {
-                        Text("Change File")
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .padding(.vertical, 10)
-                .padding(.horizontal, 12)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(.background, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .stroke(.quaternary, lineWidth: 1)
-                )
-            }
-            .buttonStyle(.plain)
-            .noFocusRingCompat()
-            .disabled(isSaving)
-        }
-	    #endif
+    #endif
 
-        #if os(iOS)
         private var fileSelectionButton: some View {
-            Button {
+            AddContentFileSelectionButton(
+                filename: stagedFile?.filename,
+                isLoading: isStagingFile,
+                isDisabled: isSaving
+            ) {
                 showingFileImporter = true
                 importErrorMessage = nil
-            } label: {
-                HStack {
-                    Image(systemName: "doc")
-                    Text(stagedFile?.filename ?? "Choose File")
-                    if isStagingFile { ProgressView().controlSize(.small) }
-                    Spacer()
-                    if stagedFile != nil {
-                        Text("Change File").foregroundStyle(.secondary)
-                    }
-                }
             }
-            .disabled(isSaving)
         }
-        #endif
 
 	    private var addTabs: some View {
 	        TabView(selection: $addMode) {
@@ -1826,57 +1766,19 @@ struct AddFilterListView: View {
     }
 
 	    private var urlInputEditor: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            if urlEntryMode == .single {
-                TextField("https://example.com/filter.txt", text: $urlInput)
-                    .textFieldStyle(.roundedBorder)
-                    .autocorrectionDisabled()
-                    .focused($urlFieldIsFocused)
-                    #if os(iOS)
-                    .textInputAutocapitalization(.never)
-                    .keyboardType(.URL)
-                    #endif
-                    .accessibilityLabel("URL")
-            } else {
-                ZStack(alignment: .topLeading) {
-                    TextEditor(text: $urlInput)
-                        .hideEditorBackgroundCompat()
-                        .font(.body)
-                        .autocorrectionDisabled()
-                        .focused($urlFieldIsFocused)
-                        #if os(iOS)
-                        .textInputAutocapitalization(.never)
-                        .keyboardType(.URL)
-                        #endif
-
-                    if urlInput.isEmpty {
-                        Text("Paste one or more filter URLs, one per line.")
-                            .font(.body)
-                            .foregroundStyle(.tertiary)
-                            #if os(macOS)
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 0)
-                            #else
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 8)
-                            #endif
-                            .allowsHitTesting(false)
-                    }
-                }
-                .frame(minHeight: 64, maxHeight: 96)
-                .background(Color.urlEditorBackground, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .stroke(.quaternary, lineWidth: 1)
-                )
-                .accessibilityLabel("URLs")
-            }
-            Button(action: pasteURLsFromClipboard) {
-                Label(pasteURLButtonTitle, systemImage: "doc.on.clipboard")
-            }
-            .buttonStyle(.bordered)
-            .disabled(isSaving)
-        }
+        AddContentURLInput(
+            text: $urlInput,
+            isFocused: $urlFieldIsFocused,
+            isBulk: urlEntryMode == .bulk,
+            singlePlaceholder: { Text("https://example.com/filter.txt") },
+            bulkPlaceholder: { Text("Paste one or more filter URLs, one per line.") },
+            accessibilityLabel: urlEntryMode == .single ? "URL" : "URLs",
+            isDisabled: isSaving,
+            onPaste: pasteURLsFromClipboard,
+            pasteTitle: pasteURLButtonTitle,
+            pasteButtonUsesRow: false,
+            macPlaceholderPadding: 0
+        )
     }
 
     // MARK: - Footer
@@ -2598,23 +2500,6 @@ struct EditUserListView: View {
                         }
                     }
                 }
-                .interactiveDismissDisabled(isLoadingContent)
-                .onAppear {
-                    titleFieldIsFocused = true
-                    loadContent()
-                }
-                .alert(
-                    "Couldn’t Save",
-                    isPresented: Binding(
-                        get: { errorMessage != nil },
-                        set: { _ in errorMessage = nil }
-                    )
-                ) {
-                    Button("OK", role: .cancel) { errorMessage = nil }
-                } message: {
-                    Text(errorMessage ?? "")
-                }
-                .largeSheetPresentationCompat()
             #else
                 SheetContainer {
                     SheetHeader(title: "Edit User List", isLoading: isLoadingContent) {
@@ -2696,24 +2581,27 @@ struct EditUserListView: View {
                         saveButton
                     }
                 }
-                .interactiveDismissDisabled(isLoadingContent)
-                .onAppear {
-                    titleFieldIsFocused = true
-                    loadContent()
-                }
-                .alert(
-                    "Couldn’t Save",
-                    isPresented: Binding(
-                        get: { errorMessage != nil },
-                        set: { _ in errorMessage = nil }
-                    )
-                ) {
-                    Button("OK", role: .cancel) { errorMessage = nil }
-                } message: {
-                    Text(errorMessage ?? "")
-                }
             #endif
         }
+        .interactiveDismissDisabled(isLoadingContent)
+        .onAppear {
+            titleFieldIsFocused = true
+            loadContent()
+        }
+        .alert(
+            "Couldn’t Save",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { _ in errorMessage = nil }
+            )
+        ) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+        #if os(iOS)
+        .largeSheetPresentationCompat()
+        #endif
         .sheet(isPresented: $isShowingEditor) {
             CodeEditorSheet(
                 editorController: editorController,

--- a/wBlock/UserScriptManagerView.swift
+++ b/wBlock/UserScriptManagerView.swift
@@ -2054,29 +2054,18 @@ struct AddUserScriptView: View {
 
     #if os(iOS)
     private var iosBody: some View {
-        CompatibleNavigationStack {
+        AddContentIOSSheet(
+            title: "Add Userscript or Userstyle",
+            isLoading: isAdding,
+            buttonTitle: { LocalizedStringKey(addURLButtonTitle) },
+            isSubmitDisabled: !canSubmit || isAdding,
+            onDismiss: { dismiss() },
+            onSubmit: submit
+        ) {
             addTabs
-                .navigationTitle("Add Userscript or Userstyle")
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { dismiss() }
-                            .disabled(isAdding)
-                    }
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button(action: submit) {
-                            if isAdding {
-                                ProgressView()
-                            } else {
-                                Text(LocalizedStringKey(addURLButtonTitle))
-                            }
-                        }
-                        .disabled(!canSubmit || isAdding)
-                    }
-                }
         }
-        .largeSheetPresentationCompat()
     }
+    #endif
 
     private var addTabs: some View {
         TabView(selection: $addMode) {
@@ -2129,23 +2118,15 @@ struct AddUserScriptView: View {
     }
 
     private var fileSelectionButton: some View {
-        Button {
+        AddContentFileSelectionButton(
+            filename: stagedFile?.filename,
+            isLoading: isStagingFile,
+            isDisabled: isAdding
+        ) {
             showingFileImporter = true
             fileImportError = nil
-        } label: {
-            HStack {
-                Image(systemName: "doc")
-                Text(stagedFile?.filename ?? "Choose File")
-                if isStagingFile { ProgressView().controlSize(.small) }
-                Spacer()
-                if stagedFile != nil {
-                    Text("Change File").foregroundStyle(.secondary)
-                }
-            }
         }
-        .disabled(isAdding)
     }
-    #endif
 
     private var simpleTextContent: some View {
         AddContentSourceCard(title: "Script Content", isDisabled: isAdding,
@@ -2169,27 +2150,18 @@ struct AddUserScriptView: View {
 
     #if os(macOS)
     private var macosBody: some View {
-        SheetContainer {
-            SheetHeader(title: "Add Userscript or Userstyle", isLoading: isAdding) {
-                dismiss()
-            }
-
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    modePickerCard
-                    macosModeContent
-                }
-                .padding(.horizontal, SheetDesign.contentHorizontalPadding)
-                .padding(.top, 12)
-                .padding(.bottom, 40)
-            }
-
-            SheetBottomToolbar {
-                Spacer()
-                addButton
-            }
+        AddContentMacSheet(
+            title: "Add Userscript or Userstyle",
+            isLoading: isAdding,
+            minHeight: 500,
+            onDismiss: { dismiss() },
+            isDismissDisabled: isAdding
+        ) {
+            modePickerCard
+            macosModeContent
+        } action: {
+            addButton
         }
-        .frame(minWidth: 560, minHeight: 500)
     }
 
     private var modePickerCard: some View {
@@ -2259,33 +2231,6 @@ struct AddUserScriptView: View {
         }
     }
 
-    private var fileSelectionButton: some View {
-        Button {
-            showingFileImporter = true
-            fileImportError = nil
-        } label: {
-            HStack(spacing: 10) {
-                Image(systemName: "doc")
-                Text(stagedFile?.filename ?? "Choose File")
-                if isStagingFile { ProgressView().controlSize(.small) }
-                Spacer()
-                if stagedFile != nil {
-                    Text("Change File").foregroundStyle(.secondary)
-                }
-            }
-            .padding(.vertical, 10)
-            .padding(.horizontal, 12)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(.background, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .stroke(.quaternary, lineWidth: 1)
-            )
-        }
-        .buttonStyle(.plain)
-        .noFocusRingCompat()
-        .disabled(isAdding)
-    }
     #endif
 
     private var metadataRequirementText: LocalizedStringKey {
@@ -2402,65 +2347,21 @@ struct AddUserScriptView: View {
 
     private var urlInputEditor: some View {
         AddContentField(title: urlEntryMode == .single ? "URL" : "URLs") {
-            if urlEntryMode == .single {
-                TextField("https://example.com/script.user.js", text: $urlInput)
-                    .textFieldStyle(.roundedBorder)
-                    .autocorrectionDisabled()
-                    .focused($urlFieldFocused)
-                    #if os(iOS)
-                    .textInputAutocapitalization(.never)
-                    .keyboardType(.URL)
-                    #endif
-                    .accessibilityLabel("URL")
-            } else {
-            ZStack(alignment: .topLeading) {
-                TextEditor(text: $urlInput)
-                    .hideEditorBackgroundCompat()
-                    .font(.body)
-                    .autocorrectionDisabled()
-                    .focused($urlFieldFocused)
-                    #if os(iOS)
-                    .textInputAutocapitalization(.never)
-                    .keyboardType(.URL)
-                    #endif
-
-                if urlInput.isEmpty {
-                    Text(verbatim: "https://example.com/script.user.js")
-                        .font(.body)
-                        .foregroundStyle(.tertiary)
-                        #if os(macOS)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 1)
-                        #else
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 8)
-                        #endif
-                        .allowsHitTesting(false)
-                }
-            }
-            .frame(minHeight: 64, maxHeight: 96)
-            .background(Color.urlEditorBackground, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(.quaternary, lineWidth: 1)
+            AddContentURLInput(
+                text: $urlInput,
+                isFocused: $urlFieldFocused,
+                isBulk: urlEntryMode == .bulk,
+                singlePlaceholder: { Text(verbatim: "https://example.com/script.user.js") },
+                bulkPlaceholder: { Text(verbatim: "https://example.com/script.user.js") },
+                accessibilityLabel: urlEntryMode == .single ? "URL" : "URLs",
+                isDisabled: isAdding,
+                onPaste: pasteFromClipboard,
+                pasteTitle: urlEntryMode == .single ? "Paste URL" : "Paste URLs",
+                pasteButtonUsesRow: true
             )
-            .accessibilityLabel("URLs")
-            }
-
-            HStack {
-                compactPasteButton
-                Spacer()
-            }
         }
     }
 
-    private var compactPasteButton: some View {
-        Button(action: pasteFromClipboard) {
-            Label(urlEntryMode == .single ? "Paste URL" : "Paste URLs", systemImage: "doc.on.clipboard")
-        }
-        .buttonStyle(.bordered)
-        .disabled(isAdding)
-    }
 
     private var urlValidationFeedback: ValidationState {
         if let urlImportError { return .invalid(urlImportError) }

--- a/wBlockCoreService/SharedAutoUpdateManager.swift
+++ b/wBlockCoreService/SharedAutoUpdateManager.swift
@@ -1913,111 +1913,100 @@ public actor SharedAutoUpdateManager {
         }
     }
 
-    // MARK: - Conversion & Reload
-    private struct ConversionTargetWork: Sendable {
-        let target: ContentBlockerTargetInfo
-        let filters: [FilterList]
-        let allTargets: [ContentBlockerTargetInfo]
-        let containerURL: URL
-        let disabledSites: [String]
-        let affinitySnapshot: SafariContentBlockerAffinitySnapshot
-        let orderedFilters: [FilterList]
-        let extraRulesText: String?
-        let isBackground: Bool
-        let deadline: Date?
-        let minimumTimeForConversionTarget: TimeInterval
+    public struct TargetCompilationRequest: Sendable {
+        public let target: ContentBlockerTargetInfo
+        public let filters: [FilterList]
+        public let allTargets: [ContentBlockerTargetInfo]
+        public let disabledSites: [String]
+        public let affinitySnapshot: SafariContentBlockerAffinitySnapshot
+        public let orderedFilters: [FilterList]
+        public let extraRulesText: String?
+        public let deadline: Date?
+        public let minimumTime: TimeInterval
+        public let isCancelled: @Sendable () -> Bool
+
+        public init(
+            target: ContentBlockerTargetInfo,
+            filters: [FilterList],
+            allTargets: [ContentBlockerTargetInfo],
+            disabledSites: [String],
+            affinitySnapshot: SafariContentBlockerAffinitySnapshot,
+            orderedFilters: [FilterList],
+            extraRulesText: String?,
+            deadline: Date?,
+            minimumTime: TimeInterval,
+            isCancelled: @escaping @Sendable () -> Bool
+        ) {
+            self.target = target
+            self.filters = filters
+            self.allTargets = allTargets
+            self.disabledSites = disabledSites
+            self.affinitySnapshot = affinitySnapshot
+            self.orderedFilters = orderedFilters
+            self.extraRulesText = extraRulesText
+            self.deadline = deadline
+            self.minimumTime = minimumTime
+            self.isCancelled = isCancelled
+        }
     }
 
-    private enum ConversionTargetFailure: Sendable {
-        case cancelled
-        case budgetExpired(remainingSeconds: Int)
-        case failed(description: String)
+    public struct TargetCompilationResult: Sendable {
+        public let target: ContentBlockerTargetInfo
+        public let outcome: ContentBlockerService.ContentBlockerTargetOutcome?
+        public let failureDescription: String?
+        public let budgetExpired: Int?
+        public let durationMs: Int
     }
 
-    private struct ConversionTargetResult: Sendable {
-        let target: ContentBlockerTargetInfo
-        let conversion: (safariRulesCount: Int, truncatedRuleCount: Int, advancedRulesText: String?)?
-        let usedCache: Bool
-        let admittedSourceRuleCountsByFilterID: [UUID: Int]
-        let inputWriteMs: Int
-        let inputBytes: Int64
-        let conversionMs: Int
-        let failure: ConversionTargetFailure?
-    }
-
-    private nonisolated static func convertTarget(_ work: ConversionTargetWork) -> ConversionTargetResult {
-        let target = work.target
-        let start = Date()
-
-        if work.isBackground, let deadline = work.deadline,
-           deadline.timeIntervalSinceNow < work.minimumTimeForConversionTarget {
-            return ConversionTargetResult(
-                target: target,
-                conversion: nil,
-                usedCache: false,
-                admittedSourceRuleCountsByFilterID: [:],
-                inputWriteMs: 0,
-                inputBytes: 0,
-                conversionMs: 0,
-                failure: .budgetExpired(
-                    remainingSeconds: max(0, Int(deadline.timeIntervalSinceNow.rounded(.down)))
+    /// Compiles independent targets with bounded concurrency and serial result delivery.
+    public nonisolated static func compileTargets(
+        _ requests: [TargetCompilationRequest],
+        onResult: ((TargetCompilationResult) async -> Void)? = nil
+    ) async -> [TargetCompilationResult] {
+        var results: [TargetCompilationResult] = []
+        await boundedConcurrentForEach(requests, operation: { request in
+            let started = Date()
+            func result(
+                outcome: ContentBlockerService.ContentBlockerTargetOutcome? = nil,
+                failureDescription: String? = nil,
+                budgetExpired: Int? = nil
+            ) -> TargetCompilationResult {
+                TargetCompilationResult(
+                    target: request.target, outcome: outcome,
+                    failureDescription: failureDescription, budgetExpired: budgetExpired,
+                    durationMs: Int(Date().timeIntervalSince(started) * 1000)
                 )
-            )
-        }
-
-        do {
-            let outcome = try ContentBlockerService.compileTargetRules(
-                filters: work.filters,
-                orderedSelectedFilters: work.orderedFilters,
-                affinitySnapshot: work.affinitySnapshot,
-                targetInfo: target,
-                allTargets: work.allTargets,
-                disabledSites: work.disabledSites,
-                extraRulesText: work.extraRulesText,
-                groupIdentifier: GroupIdentifier.shared.value,
-                isCancelled: { Task.isCancelled }
-            )
-
-            let conversion = (
-                safariRulesCount: outcome.safariRulesCount,
-                truncatedRuleCount: outcome.truncatedRuleCount,
-                advancedRulesText: outcome.advancedRulesText
-            )
-            return ConversionTargetResult(
-                target: target,
-                conversion: conversion,
-                usedCache: outcome.reusedCachedBase,
-                admittedSourceRuleCountsByFilterID: outcome.admittedSourceRuleCountsByFilterID,
-                inputWriteMs: 0,
-                inputBytes: 0,
-                conversionMs: Int(Date().timeIntervalSince(start) * 1000),
-                failure: nil
-            )
-        } catch is CancellationError {
-            return ConversionTargetResult(
-                target: target,
-                conversion: nil,
-                usedCache: false,
-                admittedSourceRuleCountsByFilterID: [:],
-                inputWriteMs: 0,
-                inputBytes: 0,
-                conversionMs: Int(Date().timeIntervalSince(start) * 1000),
-                failure: .cancelled
-            )
-        } catch {
-            return ConversionTargetResult(
-                target: target,
-                conversion: nil,
-                usedCache: false,
-                admittedSourceRuleCountsByFilterID: [:],
-                inputWriteMs: 0,
-                inputBytes: 0,
-                conversionMs: Int(Date().timeIntervalSince(start) * 1000),
-                failure: .failed(description: error.localizedDescription)
-            )
-        }
+            }
+            if let deadline = request.deadline, deadline.timeIntervalSinceNow < request.minimumTime {
+                return result(budgetExpired: max(0, Int(deadline.timeIntervalSinceNow.rounded(.down))))
+            }
+            if request.isCancelled() || Task.isCancelled { return result() }
+            do {
+                let outcome = try ContentBlockerService.compileTargetRules(
+                    filters: request.filters,
+                    orderedSelectedFilters: request.orderedFilters,
+                    affinitySnapshot: request.affinitySnapshot,
+                    targetInfo: request.target,
+                    allTargets: request.allTargets,
+                    disabledSites: request.disabledSites,
+                    extraRulesText: request.extraRulesText,
+                    groupIdentifier: GroupIdentifier.shared.value,
+                    isCancelled: { request.isCancelled() || Task.isCancelled }
+                )
+                return result(outcome: outcome)
+            } catch is CancellationError {
+                return result()
+            } catch {
+                return result(failureDescription: LogErrorDescriber.describe(error))
+            }
+        }, onResult: { result in
+            results.append(result)
+            await onResult?(result)
+        })
+        return results
     }
 
+    // MARK: - Conversion & Reload
     private func rebuildAndReload(
         selectedFilters: [FilterList],
         policy: AutoUpdateExecutionPolicy,
@@ -2048,76 +2037,43 @@ public actor SharedAutoUpdateManager {
                     from: ProtobufDataManager.shared.getActiveZapperRulesByHost()
                 )
         }
-        var results: [String: ConversionTargetResult] = [:]
-        let works = targets.map { target in
-            ConversionTargetWork(
+        let requests = targets.map { target in
+            TargetCompilationRequest(
                 target: target,
                 filters: byTarget[target] ?? [],
                 allTargets: targets,
-                containerURL: containerURL,
                 disabledSites: disabledSites,
                 affinitySnapshot: affinitySnapshot,
                 orderedFilters: ordered,
                 extraRulesText: target.slot == 5 ? zapper : nil,
-                isBackground: policy.isBackground,
-                deadline: policy.deadline,
-                minimumTimeForConversionTarget: policy.minimumTimeForConversionTarget
+                deadline: policy.isBackground ? policy.deadline : nil,
+                minimumTime: policy.minimumTimeForConversionTarget,
+                isCancelled: { Task.isCancelled }
             )
         }
-        await boundedConcurrentForEach(
-            works,
-            operation: { Self.convertTarget($0) },
-            onResult: { result in
-                results[result.target.bundleIdentifier] = result
-            }
-        )
+        let compiled = await Self.compileTargets(requests)
+        let results = Dictionary(uniqueKeysWithValues: compiled.map { ($0.target.bundleIdentifier, $0) })
 
         for target in targets {
-            guard let result = results[target.bundleIdentifier] else {
-                throw CancellationError()
+            guard let result = results[target.bundleIdentifier] else { throw CancellationError() }
+            if let remaining = result.budgetExpired {
+                throw AutoUpdateError.backgroundBudgetExpired(phase: AutoUpdateBudgetPhase.conversionTarget, remainingSeconds: remaining)
             }
-            switch result.failure {
-            case .cancelled:
-                throw CancellationError()
-            case let .budgetExpired(remainingSeconds):
-                throw AutoUpdateError.backgroundBudgetExpired(
-                    phase: AutoUpdateBudgetPhase.conversionTarget,
-                    remainingSeconds: remainingSeconds
-                )
-            case let .failed(description):
-                throw NSError(
-                    domain: "SharedAutoUpdateManager.Conversion",
-                    code: 1,
-                    userInfo: [NSLocalizedDescriptionKey: description]
-                )
-            case nil:
-                guard result.conversion != nil else { throw CancellationError() }
+            if let description = result.failureDescription {
+                throw NSError(domain: "SharedAutoUpdateManager.Conversion", code: 1, userInfo: [NSLocalizedDescriptionKey: description])
             }
+            guard result.outcome != nil else { throw CancellationError() }
         }
 
         for target in targets {
-            guard let conversion = results[target.bundleIdentifier]?.conversion else {
-                throw CancellationError()
-            }
+            guard let conversion = results[target.bundleIdentifier]?.outcome else { throw CancellationError() }
             if conversion.truncatedRuleCount > 0 {
-                throw NSError(
-                    domain: "SharedAutoUpdateManager.RuleLimit",
-                    code: 1,
-                    userInfo: [
-                        NSLocalizedDescriptionKey:
-                            String.localizedStringWithFormat(
-                                NSLocalizedString("%@ dropped %d rules at Safari's per-extension limit.", comment: "Truncated Safari rule count"),
-                                target.displayName,
-                                conversion.truncatedRuleCount
-                            )
-                    ]
-                )
+                throw NSError(domain: "SharedAutoUpdateManager.RuleLimit", code: 1, userInfo: [NSLocalizedDescriptionKey: String.localizedStringWithFormat(NSLocalizedString("%@ dropped %d rules at Safari's per-extension limit.", comment: "Truncated Safari rule count"), target.displayName, conversion.truncatedRuleCount)])
             }
         }
-
         var reloadResults: [String: ContentBlockerService.ReloadAttemptResult] = [:]
         if reloadContentBlockers {
-            let counts = results.mapValues { $0.conversion?.safariRulesCount ?? 0 }
+            let counts = results.mapValues { $0.outcome?.safariRulesCount ?? 0 }
             for target in ContentBlockerReloadPolicy.orderedTargets(targets, ruleCounts: counts) {
                 try Task.checkCancellation()
                 try checkBudget(
@@ -2141,7 +2097,7 @@ public actor SharedAutoUpdateManager {
         for target in targets {
             try Task.checkCancellation()
             guard let result = results[target.bundleIdentifier],
-                  let conversion = result.conversion else {
+                  let conversion = result.outcome else {
                 throw CancellationError()
             }
             let cached = ContentBlockerIncrementalCache.loadCachedAdvancedRules(
@@ -2163,16 +2119,16 @@ public actor SharedAutoUpdateManager {
                     failedNames.append(target.displayName)
                 }
             }
-            for (filterID, count) in result.admittedSourceRuleCountsByFilterID {
+            for (filterID, count) in conversion.admittedSourceRuleCountsByFilterID {
                 appliedSourceRuleCountsByFilterID[filterID, default: 0] += count
             }
             metrics.append(
                 RebuildTargetMetrics(
                     targetName: target.displayName,
-                    cacheHit: result.usedCache,
-                    inputWriteMs: result.inputWriteMs,
-                    inputBytes: result.inputBytes,
-                    conversionMs: result.conversionMs,
+                    cacheHit: conversion.reusedCachedBase,
+                    inputWriteMs: 0,
+                    inputBytes: 0,
+                    conversionMs: result.durationMs,
                     reloadMs: reloadMs,
                     reloadAttempts: reloadAttempts,
                     safariRules: conversion.safariRulesCount

--- a/wBlockCoreService/UserScriptManager.swift
+++ b/wBlockCoreService/UserScriptManager.swift
@@ -2324,57 +2324,59 @@ public class UserScriptManager: ObservableObject {
               userScripts.indices.contains(index)
         else { return }
         let scriptName = userScripts[index].name
+        let expectedURL = userScripts[index].url
         let mutationRevision = scriptMutationRevision(scriptID)
 
         logger.info("📥 Downloading userscript from: \(url)")
 
         do {
-            let content = try await downloadUserScriptContent(from: url)
+            _ = try await UserScriptUpdateOperation.run(
+                downloadURL: url,
+                fetch: { url in try await self.downloadUserScriptContent(from: url) },
+                isCurrent: {
+                    guard let current = self.userScript(withId: scriptID) else { return false }
+                    return mutationRevision == self.scriptMutationRevision(scriptID)
+                        && current.url == expectedURL
+                },
+                prepare: { content in
+                    guard let current = self.userScript(withId: scriptID) else {
+                        throw CancellationError()
+                    }
+                    return try await self.preparedDownloadedUserScript(content, replacing: current)
+                },
+                commit: { prepared in
+                    guard let index = self.indexOfUserScript(withId: scriptID),
+                          mutationRevision == self.scriptMutationRevision(scriptID)
+                    else { return false }
 
-            guard mutationRevision == scriptMutationRevision(scriptID),
-                  let currentIndex = indexOfUserScript(withId: scriptID),
-                  userScripts.indices.contains(currentIndex)
-            else { return }
-
-            let downloaded = try await validatedDownloadedUserScriptContent(
-                content,
-                replacing: userScripts[currentIndex]
+                    var updated = self.updatedUserScript(
+                        self.userScripts[index],
+                        from: prepared.parsed,
+                        content: prepared.content,
+                        resources: prepared.resources,
+                        preserveDisplayMetadata: false
+                    )
+                    if updated.description.isEmpty
+                        || updated.description == "Default userscript - downloading..."
+                    {
+                        updated.description = updated.description.isEmpty
+                            ? "Ready to enable" : updated.description
+                    }
+                    if updated.version == "Downloading..." {
+                        updated.version = updated.version.isEmpty ? "Downloaded" : updated.version
+                    }
+                    guard self.writeUserScriptFiles(updated) else {
+                        throw CocoaError(.fileWriteUnknown)
+                    }
+                    self.userScripts[index] = updated
+                    if origin == .local { self.recordScriptMutation(scriptID) }
+                    let saved = try await self.persistDownloadedUserScript(scriptID)
+                    if saved { self.logger.info("✅ Downloaded and saved: \(updated.name)") }
+                    return saved
+                }
             )
-            userScripts[currentIndex] = downloaded
-            userScripts[currentIndex].lastUpdated = Date()
-
-            // Update description and version from metadata, but keep disabled
-            if userScripts[currentIndex].description.isEmpty
-                || userScripts[currentIndex].description == "Default userscript - downloading..."
-            {
-                userScripts[currentIndex].description =
-                    userScripts[currentIndex].description.isEmpty
-                    ? "Ready to enable" : userScripts[currentIndex].description
-            }
-
-            if userScripts[currentIndex].version == "Downloading..." {
-                userScripts[currentIndex].version =
-                    userScripts[currentIndex].version.isEmpty
-                    ? "Downloaded" : userScripts[currentIndex].version
-            }
-
-            // Process @require directives after metadata is parsed
-            let scriptForDirectives = userScripts[currentIndex]
-            let dependencies = await processedDependencies(for: scriptForDirectives)
-            let processedContent = dependencies.content
-            let resourceContents = dependencies.resources
-
-            guard mutationRevision == scriptMutationRevision(scriptID),
-                  let finalIndex = indexOfUserScript(withId: scriptID),
-                  userScripts.indices.contains(finalIndex)
-            else { return }
-
-            userScripts[finalIndex].content = processedContent
-            userScripts[finalIndex].resourceContents = resourceContents
-            _ = writeUserScriptFiles(userScripts[finalIndex])
-            if origin == .local { recordScriptMutation(scriptID) }
-            await persistUserScriptsNow()
-            logger.info("✅ Downloaded and saved: \(self.userScripts[finalIndex].name)")
+        } catch is CancellationError {
+            return
         } catch {
             if mutationRevision == scriptMutationRevision(scriptID),
                let failedIndex = indexOfUserScript(withId: scriptID),
@@ -2573,16 +2575,40 @@ public class UserScriptManager: ObservableObject {
         return downloaded
     }
 
+    private func persistDownloadedUserScript(_ id: UUID) async throws -> Bool {
+        let revision = scriptMutationRevision(id)
+        guard await persistUserScriptsNow() else {
+            userScriptsPendingPersistence.insert(id)
+            throw CocoaError(.fileWriteUnknown)
+        }
+        guard !Task.isCancelled, revision == scriptMutationRevision(id),
+              indexOfUserScript(withId: id) != nil else { return false }
+        userScriptsPendingPersistence.remove(id)
+        return true
+    }
+
+    private func preparedDownloadedUserScript(
+        _ content: String,
+        replacing existing: UserScript
+    ) async throws -> (parsed: UserScript, content: String, resources: [String: String]) {
+        let parsed = try await validatedDownloadedUserScriptContent(content, replacing: existing)
+        let dependencies = await processedDependencies(for: parsed)
+        return (parsed, dependencies.content, dependencies.resources)
+    }
+
     private func updatedUserScript(
         _ existing: UserScript,
         from parsed: UserScript,
         content: String,
-        resources: [String: String]
+        resources: [String: String],
+        preserveDisplayMetadata: Bool = true
     ) -> UserScript {
         var updated = parsed
-        updated.name = existing.name
-        if !isDefaultUserScript(existing) {
-            updated.description = existing.description
+        if preserveDisplayMetadata {
+            updated.name = existing.name
+            if !isDefaultUserScript(existing) {
+                updated.description = existing.description
+            }
         }
         updated.url = existing.url
         updated.isEnabled = existing.isEnabled
@@ -2921,29 +2947,22 @@ public class UserScriptManager: ObservableObject {
         }.value
     }
 
-    public func addUserScript(
-        fromStagedImport staged: UserScript,
-        nameOverride: String,
-        descriptionOverride: String,
-        category: FilterListCategory,
-        origin: UserScriptMutationOrigin = .local
+    private func performLocalImport(
+        status: String,
+        securityScopedURL: URL? = nil,
+        operation: () async throws -> UserScript
     ) async -> Error? {
         isLoading = true
-        statusDescription = staged.isUserStyle ? "Importing userstyle..." : "Importing userscript..."
+        statusDescription = status
         hasError = false
 
+        let accessed = securityScopedURL?.startAccessingSecurityScopedResource() ?? false
+        defer {
+            if accessed { securityScopedURL?.stopAccessingSecurityScopedResource() }
+        }
+
         do {
-            _ = try await importLocalUserScript(
-                content: staged.content,
-                fallbackName: staged.name,
-                importedStatusVerb: "Imported",
-                replacedStatusVerb: "Replaced",
-                nameOverride: nameOverride,
-                descriptionOverride: descriptionOverride,
-                categoryOverride: category,
-                localImportIdentity: staged.localImportIdentity,
-                origin: origin
-            )
+            _ = try await operation()
             isLoading = false
             return nil
         } catch {
@@ -2956,28 +2975,16 @@ public class UserScriptManager: ObservableObject {
     }
 
     public func addUserScript(
-        fromLocalFile fileURL: URL,
-        nameOverride: String? = nil,
-        descriptionOverride: String? = nil,
-        category: FilterListCategory? = nil,
+        fromStagedImport staged: UserScript,
+        nameOverride: String,
+        descriptionOverride: String,
+        category: FilterListCategory,
         origin: UserScriptMutationOrigin = .local
     ) async -> Error? {
-        isLoading = true
-        statusDescription = UserStyleSupport.isUserStylePath(fileURL.lastPathComponent)
-            ? "Importing userstyle..." : "Importing userscript..."
-        hasError = false
-
-        let accessed = fileURL.startAccessingSecurityScopedResource()
-        defer {
-            if accessed {
-                fileURL.stopAccessingSecurityScopedResource()
-            }
-        }
-
-        do {
-            let staged = try await stageUserScriptImport(fromLocalFile: fileURL)
-
-            _ = try await importLocalUserScript(
+        await performLocalImport(
+            status: staged.isUserStyle ? "Importing userstyle..." : "Importing userscript..."
+        ) {
+            try await self.importLocalUserScript(
                 content: staged.content,
                 fallbackName: staged.name,
                 importedStatusVerb: "Imported",
@@ -2988,15 +2995,33 @@ public class UserScriptManager: ObservableObject {
                 localImportIdentity: staged.localImportIdentity,
                 origin: origin
             )
+        }
+    }
 
-            isLoading = false
-            return nil
-        } catch {
-            hasError = true
-            errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-            statusDescription = "Import failed"
-            isLoading = false
-            return error
+    public func addUserScript(
+        fromLocalFile fileURL: URL,
+        nameOverride: String? = nil,
+        descriptionOverride: String? = nil,
+        category: FilterListCategory? = nil,
+        origin: UserScriptMutationOrigin = .local
+    ) async -> Error? {
+        await performLocalImport(
+            status: UserStyleSupport.isUserStylePath(fileURL.lastPathComponent)
+                ? "Importing userstyle..." : "Importing userscript...",
+            securityScopedURL: fileURL
+        ) {
+            let staged = try await self.stageUserScriptImport(fromLocalFile: fileURL)
+            return try await self.importLocalUserScript(
+                content: staged.content,
+                fallbackName: staged.name,
+                importedStatusVerb: "Imported",
+                replacedStatusVerb: "Replaced",
+                nameOverride: nameOverride,
+                descriptionOverride: descriptionOverride,
+                categoryOverride: category,
+                localImportIdentity: staged.localImportIdentity,
+                origin: origin
+            )
         }
     }
 
@@ -3010,12 +3035,8 @@ public class UserScriptManager: ObservableObject {
         origin: UserScriptMutationOrigin = .local
     ) async -> Error? {
         let startingLocalMutationRevision = origin == .remoteSync ? localMutationRevision : nil
-        isLoading = true
-        statusDescription = "Adding userscript..."
-        hasError = false
-
-        do {
-            _ = try await importLocalUserScript(
+        return await performLocalImport(status: "Adding userscript...") {
+            try await self.importLocalUserScript(
                 content: content,
                 fallbackName: "Pasted Userscript",
                 importedStatusVerb: "Added",
@@ -3028,15 +3049,6 @@ public class UserScriptManager: ObservableObject {
                 origin: origin,
                 startingLocalMutationRevision: startingLocalMutationRevision
             )
-
-            isLoading = false
-            return nil
-        } catch {
-            hasError = true
-            errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-            statusDescription = "Import failed"
-            isLoading = false
-            return error
         }
     }
 
@@ -3887,12 +3899,7 @@ public class UserScriptManager: ObservableObject {
                 guard let current = self.userScripts.first(where: { $0.id == candidate.id }) else {
                     throw CancellationError()
                 }
-                let parsed = try await self.validatedDownloadedUserScriptContent(
-                    rawContent,
-                    replacing: current
-                )
-                let dependencies = await self.processedDependencies(for: parsed)
-                return (parsed, dependencies.content, dependencies.resources)
+                return try await self.preparedDownloadedUserScript(rawContent, replacing: current)
             },
             commit: { parsed, processedContent, resourceContents in
                 guard let index = self.userScripts.firstIndex(where: { $0.id == candidate.id }) else {
@@ -3902,16 +3909,7 @@ public class UserScriptManager: ObservableObject {
                 if self.userScripts[index].content == processedContent,
                    self.userScripts[index].resourceContents == resourceContents {
                     if persistChanges || needsPersistenceRetry {
-                        guard await self.persistUserScriptsNow() else {
-                            self.userScriptsPendingPersistence.insert(candidate.id)
-                            throw CocoaError(.fileWriteUnknown)
-                        }
-                        guard !Task.isCancelled,
-                              mutationRevision == self.scriptMutationRevision(candidate.id),
-                              self.userScripts.contains(where: { $0.id == candidate.id })
-                        else { return false }
-                        self.userScriptsPendingPersistence.remove(candidate.id)
-                        return true
+                        return try await self.persistDownloadedUserScript(candidate.id)
                     }
                     return false
                 }
@@ -3930,16 +3928,7 @@ public class UserScriptManager: ObservableObject {
                     self.recordScriptMutation(candidate.id)
                 }
                 if persistChanges {
-                    let persistenceRevision = self.scriptMutationRevision(candidate.id)
-                    guard await self.persistUserScriptsNow() else {
-                        self.userScriptsPendingPersistence.insert(candidate.id)
-                        throw CocoaError(.fileWriteUnknown)
-                    }
-                    guard !Task.isCancelled,
-                          persistenceRevision == self.scriptMutationRevision(candidate.id),
-                          self.userScripts.contains(where: { $0.id == candidate.id })
-                    else { return false }
-                    self.userScriptsPendingPersistence.remove(candidate.id)
+                    return try await self.persistDownloadedUserScript(candidate.id)
                 }
                 return true
             }

--- a/wBlockCoreService/UserScriptManager.swift
+++ b/wBlockCoreService/UserScriptManager.swift
@@ -2370,7 +2370,9 @@ public class UserScriptManager: ObservableObject {
                     }
                     self.userScripts[index] = updated
                     if origin == .local { self.recordScriptMutation(scriptID) }
-                    let saved = try await self.persistDownloadedUserScript(scriptID)
+                    // A deferred or failed metadata save does not undo the completed download.
+                    // The persistence helper keeps it pending for retry.
+                    let saved = (try? await self.persistDownloadedUserScript(scriptID)) ?? false
                     if saved { self.logger.info("✅ Downloaded and saved: \(updated.name)") }
                     return saved
                 }


### PR DESCRIPTION
## Why

Several workflows repeated the same plumbing in the app, background updater, and import sheets. This consolidates that plumbing without trying to make their different policies interchangeable.

The initial reduction estimate was too optimistic. The measured result is 310 fewer production Swift lines, or 244 fewer lines overall after regression coverage. Bundled libraries, generated code, and catalog data are untouched; moving them would not simplify the application.

## Incremental commits

- `9bd9875e`: one cloud-filter reconciliation path for in-memory and persisted storage, retaining tombstones and local-selection guards.
- `4f43c13f`: shared bounded target compilation, cancellation, deadline checks, and serial result delivery. Foreground progress and background publication/reload policy stay separate.
- `afde51c8`: shared userscript preparation, durable-save/retry checks, and import bookkeeping. Background downloads revalidate their identity before committing; first-download metadata remains distinct from update overrides.
- `c67bbe0a`: shared URL/file controls and platform-specific import-sheet shells, retaining focus bindings, accessibility labels, and localized text.

## Verification

- macOS Debug build passed in the existing signed Xcode derived-data directory.
- iOS Simulator Debug build passed.
- All CI-harness cases passed on the final sources. The final run timed out at removeparam; that case passed in isolation, and the harness was resumed after it rather than rerunning the earlier passing cases.
- Added coverage for target cancellation/deadlines/result delivery and userscript supersession during preparation.
- `git diff --check` passed.

Manual sheet interaction and screenshots are not verified: Cua could capture the app window but could not resolve its accessibility surface, and refused background input. I did not escalate to foreground control. No visual redesign is intended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filter apply conversion, iCloud filter reconciliation, and userscript download/commit paths—core data flows—with new regression tests but no intended behavior change.
> 
> **Overview**
> Consolidates duplicated plumbing across filter apply, auto-update rebuild, cloud sync, userscript downloads, and “add content” sheets without merging their separate policies.
> 
> **Target compilation:** Introduces public `SharedAutoUpdateManager.compileTargets` with `TargetCompilationRequest` / `TargetCompilationResult` (bounded concurrency, cancellation, deadline/budget, serial callbacks). The manual apply pipeline now routes conversion through this API instead of inline `ContentBlockerService.compileTargetRules` work items; background rebuild uses the same helper.
> 
> **Cloud sync:** Adds `CloudSyncFilterStorageAdapter` so remote filter reconciliation (tombstones, selection guards, custom list upserts/deletes) follows one path whether state lives in `AppFilterManager` or `ProtobufDataManager`.
> 
> **Userscripts:** Background downloads and update flows share `UserScriptUpdateOperation` plus `preparedDownloadedUserScript` / `persistDownloadedUserScript`; local imports use a shared `performLocalImport` wrapper. Supersession during preparation is covered by an extended regression test.
> 
> **UI:** Extracts reusable `AddContentURLInput`, `AddContentFileSelectionButton`, and iOS/macOS sheet shells; filter-list and userscript add flows adopt them.
> 
> CI adds `target-compilation` harness coverage for cancellation, expired budgets, empty work, and task cancel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ca921b90788aaaadd1a17251a66f029ebe13a65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->